### PR TITLE
MAINTENANCE: Strengthen autopilot skill enforcement in stack rules

### DIFF
--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -316,6 +316,9 @@ Before making any changes:
 - 👤 No useEffect for state sync
 - 👤 No inline functions in loops
 - 👤 No incomplete configurations
+- 👤 No raw `git commit` — use `Skill(autopilot:commits:create)`
+- 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch:create)`
+- 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 
 ## 16. AI Assistant Workflow
 
@@ -327,9 +330,9 @@ Before making any changes:
 - 👤 Gather context before editing
 - 👤 Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - 👤 Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- 👤 Always use `Skill(autopilot:commits:create)` to commit — never run raw `git commit`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 Always use `Skill(autopilot:branch:create)` to create branches — never run raw `git checkout -b` or `git branch`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 Always use `Skill(autopilot:pr:create)` to create PRs — never run raw `gh pr create`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Commit only via `Skill(autopilot:commits:create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch:create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr:create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -201,6 +201,9 @@ Before making any changes:
 - 👤 No useEffect for state sync
 - 👤 No inline functions in loops
 - 👤 No incomplete configurations
+- 👤 No raw `git commit` — use `Skill(autopilot:commits:create)`
+- 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch:create)`
+- 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 
 ## 16. AI Assistant Workflow
 
@@ -211,9 +214,9 @@ Before making any changes:
 - 👤 Parallel tool execution when possible
 - 👤 Gather context before editing
 - 👤 Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- 👤 Always use `Skill(autopilot:commits:create)` to commit — never run raw `git commit`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 Always use `Skill(autopilot:branch:create)` to create branches — never run raw `git checkout -b` or `git branch`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 Always use `Skill(autopilot:pr:create)` to create PRs — never run raw `gh pr create`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Commit only via `Skill(autopilot:commits:create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch:create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr:create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -319,6 +319,9 @@ Before making any changes:
 - 👤 No useEffect for state sync
 - 👤 No inline functions in loops
 - 👤 No incomplete configurations
+- 👤 No raw `git commit` — use `Skill(autopilot:commits:create)`
+- 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch:create)`
+- 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 
 ## 16. AI Assistant Workflow
 
@@ -330,9 +333,9 @@ Before making any changes:
 - 👤 Gather context before editing
 - 👤 Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - 👤 Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- 👤 Always use `Skill(autopilot:commits:create)` to commit — never run raw `git commit`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 Always use `Skill(autopilot:branch:create)` to create branches — never run raw `git checkout -b` or `git branch`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 Always use `Skill(autopilot:pr:create)` to create PRs — never run raw `gh pr create`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Commit only via `Skill(autopilot:commits:create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch:create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr:create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -315,6 +315,9 @@ Before making any changes:
 - 👤 No useEffect for state sync
 - 👤 No inline functions in loops
 - 👤 No incomplete configurations
+- 👤 No raw `git commit` — use `Skill(autopilot:commits:create)`
+- 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch:create)`
+- 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 
 ## 16. AI Assistant Workflow
 
@@ -326,9 +329,9 @@ Before making any changes:
 - 👤 Gather context before editing
 - 👤 Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - 👤 Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- 👤 Always use `Skill(autopilot:commits:create)` to commit — never run raw `git commit`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 Always use `Skill(autopilot:branch:create)` to create branches — never run raw `git checkout -b` or `git branch`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 Always use `Skill(autopilot:pr:create)` to create PRs — never run raw `gh pr create`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Commit only via `Skill(autopilot:commits:create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch:create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr:create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 


### PR DESCRIPTION
Each of the four stack-specific rule files (Bun, Bun+React+Tailwind, NodeJS+React, NodeJS+React+Tailwind) already mentioned the three autopilot skills, but the bullets were buried in section 16.1 and easy to miss. This PR makes the rules harder to overlook and harder to violate without removing the CONTRIBUTING.md fallback.

- Added three anti-pattern bullets to section 14 forbidding raw `git commit`, `git checkout -b` / `git branch`, and `gh pr create`
- Rewrote the section 16.1 skill-usage bullets with **MANDATORY** markers and explicit prohibitions on `-m`, `--amend`, `git switch -c`, and web-UI PR creation
- CONTRIBUTING.md fallback clause preserved for forks that don't install the autopilot plugin

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens enforcement of autopilot skills in all stack rule docs to prevent raw Git/PR commands and reduce violations. Makes the guidance prominent and mandatory while keeping the CONTRIBUTING.md fallback for forks without the plugin.

Added anti-pattern bullets in section 14 and marked section 16.1 as MANDATORY, explicitly banning raw `git commit`, `git commit -m`, `--amend`, `git checkout -b`/`git branch`/`git switch -c`, and `gh pr create` or web-UI PR creation.

<sup>Written for commit f4df237e6e697f59f43be02c09af6273adaf24a7. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/3?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

