### PR TITLE
Recommend ASCII Schemas skill in plan mode for visual changes

### DIFF
--- a/claude-plugins/autopilot/skills/plan-bun/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-bun/SKILL.md
@@ -16,6 +16,7 @@ allowed-tools:
   - MCP(perplexity:*)
   - MCP(repomix:*)
   - AskUserQuestion
+  - Skill(autopilot:ascii-schemas)
 ---
 
 Continue implementation planning using Bun/NodeJS-specific configuration. Phase 0 context (issue data, branch info, TODO matches) is available from the conversation history.
@@ -134,6 +135,10 @@ After all expert reviews complete, call TaskUpdate to set task 5 ("Review with e
 ## Summary
 [1-2 sentences: what and why]
 Score: [X]/100
+
+<!-- Include the ## Diagrams section only if the change is architectural/visual/UI/flow-related. Generate diagrams via Skill(autopilot:ascii-schemas) per the plan skill's "Visualize with ASCII Schemas" guidance. -->
+## Diagrams
+[ASCII diagram(s) generated via Skill(autopilot:ascii-schemas) — architecture, data flow, sequence, topology, UI layout, or component interaction. Omit this section entirely for pure logic/refactor changes.]
 
 ## Implementation Steps
 1. [ ] [Action] in `path/to/file.ts`

--- a/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
@@ -16,6 +16,7 @@ allowed-tools:
   - MCP(perplexity:*)
   - MCP(repomix:*)
   - AskUserQuestion
+  - Skill(autopilot:ascii-schemas)
 ---
 
 Continue implementation planning using NodeJS+React-specific configuration. Phase 0 context (issue data, branch info, TODO matches) is available from the conversation history.
@@ -139,6 +140,10 @@ After all expert reviews complete, call TaskUpdate to set task 5 ("Review with e
 ## Summary
 [1-2 sentences: what and why]
 Score: [X]/100
+
+<!-- Include the ## Diagrams section only if the change is architectural/visual/UI/flow-related. Generate diagrams via Skill(autopilot:ascii-schemas) per the plan skill's "Visualize with ASCII Schemas" guidance. -->
+## Diagrams
+[ASCII diagram(s) generated via Skill(autopilot:ascii-schemas) — architecture, data flow, sequence, topology, UI layout, or component interaction. Omit this section entirely for pure logic/refactor changes.]
 
 ## Implementation Steps
 1. [ ] [Action] in `path/to/file.ts`

--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -18,6 +18,7 @@ allowed-tools:
   - Skill(autopilot:plan-bun)
   - Skill(autopilot:plan-nodejs-react)
   - Skill(autopilot:branch-create)
+  - Skill(autopilot:ascii-schemas)
 ---
 
 Perform deep analysis of the codebase, recent changes, and the requested task. Create a validated, expert-reviewed implementation plan.
@@ -197,6 +198,28 @@ Use all available documentation sources. If a source is unavailable or returns n
 ### CLAUDE.md Compliance
 
 Map each planned change to project rules defined in CLAUDE.md.
+
+### Visualize with ASCII Schemas
+
+When the planned change is structural or visual, invoke `Skill(autopilot:ascii-schemas)` to generate diagrams and embed them in the plan's `## Diagrams` section (see the stack skill's Phase 5 output template).
+
+**Trigger** — invoke the skill when the change touches any of:
+
+- Architecture or module boundaries
+- Data flow, request/response paths, event pipelines
+- Sequence or timing interactions between components
+- Deployment topology or infrastructure layout
+- UI layout, screen mockups, or component hierarchy
+- Component interactions (parent/child, pub/sub, dependencies)
+
+**Skip** — do NOT invoke for:
+
+- Pure refactors with no structural change
+- Formatting, lint fixes, dependency bumps
+- Internal logic edits inside a single function
+- Documentation-only changes with no diagrams requested
+
+Always reuse `Skill(autopilot:ascii-schemas)` output verbatim — do not hand-draw diagrams.
 
 ## Phase 1: Detect Stack and Delegate
 


### PR DESCRIPTION
Plan mode now recommends invoking Skill(autopilot:ascii-schemas) when a planned change touches architecture, data flow, UI, layout, or component interactions, so resulting plans embed ASCII diagrams that make structural changes easier to understand.

- Added Visualize with ASCII Schemas subsection to plan/SKILL.md Common Instructions with trigger and skip lists
- Added optional ## Diagrams section to plan-bun and plan-nodejs-react Phase 5 output templates
- Added Skill(autopilot:ascii-schemas) to allowed-tools in plan, plan-bun, and plan-nodejs-react frontmatters

---

**Issues:**

Closes #2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plan mode now recommends using `Skill(autopilot:ascii-schemas)` for structural/visual changes and adds an optional Diagrams section to planning templates to embed ASCII diagrams for clarity.

- **New Features**
  - Added “Visualize with ASCII Schemas” guidance with trigger/skip lists in `plan/SKILL.md`.
  - Added optional “## Diagrams” section to Phase 5 output in `plan-bun` and `plan-nodejs-react`.
  - Allowed `Skill(autopilot:ascii-schemas)` in `plan`, `plan-bun`, and `plan-nodejs-react` frontmatters.

<sup>Written for commit 9f9b6b2802fcaf3b3d2df298a7d560ce52f1b169. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/5?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

