### PR TITLE
Use issue number for branch creation when planning from issue

### DIFF
--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -268,9 +268,23 @@ Tool parameters:
    - If output is empty → `worktreeNeedsBranch = true`
    - If output is non-empty → `worktreeNeedsBranch = false`
 
-### If (`github-issue` OR `plain description`) AND (on `main` branch OR `worktreeNeedsBranch` is true)
+### If on `main` branch OR `worktreeNeedsBranch` is true
 
-Add `## Pre-Implementation` as the FIRST section of the plan file (before `## Summary`):
+Add `## Pre-Implementation` as the FIRST section of the plan file (before `## Summary`). The block content depends on input type from Phase 0.
+
+#### Input type is `github-issue` (bare number, `#`-prefixed number, or GitHub issue URL)
+
+Use this body for the `## Pre-Implementation` section:
+
+```
+## Pre-Implementation
+
+Invoke `Skill(autopilot:branch-create)` with the resolved issue number (e.g., `42` for `#42`). The branch-create skill fetches the issue, generates an `issue-<number>-<slug>` branch name, and prompts the user to confirm before creation. Do NOT present a Hotfix/Trivial/Maintenance prefix prompt — issue inputs always use the `issue-<number>-<slug>` convention so the PR can link back via `Closes #<number>`.
+```
+
+#### Input type is `plain description`
+
+Use this body for the `## Pre-Implementation` section:
 
 ```
 ## Pre-Implementation
@@ -287,7 +301,7 @@ Tool parameters:
   ]
 - `multiSelect`: false
 
-Then invoke `/autopilot:branch-create --<chosen-prefix> "<description>"` using the Skill tool, where `<description>` is a short summary derived from the task context (issue title or user description). The branch name MUST be approved by the user via AskUserQuestion before creation — do not skip approval or create the branch directly with git commands.
+Then invoke `/autopilot:branch-create --<chosen-prefix> "<description>"` using the Skill tool, where `<description>` is a short summary derived from the user description. The branch name MUST be approved by the user via AskUserQuestion before creation — do not skip approval or create the branch directly with git commands.
 ```
 
 ### Otherwise (not on `main` AND (`isWorktree` is false OR `worktreeNeedsBranch` is false))

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -249,9 +249,23 @@ Check conditions:
    - If output is empty → `worktreeNeedsBranch = true`
    - If output is non-empty → `worktreeNeedsBranch = false`
 
-#### If (`github-issue` OR `plain description`) AND (on `main` branch OR `worktreeNeedsBranch` is true)
+#### If on `main` branch OR `worktreeNeedsBranch` is true
 
-Add `## Pre-Implementation` as the FIRST section of the plan file (before `## Summary`):
+Add `## Pre-Implementation` as the FIRST section of the plan file (before `## Summary`). The block content depends on input type from Phase 0.
+
+##### Input type is `github-issue` (bare number, `#`-prefixed number, or GitHub issue URL)
+
+Use this body for the `## Pre-Implementation` section:
+
+```
+## Pre-Implementation
+
+Invoke `Skill(autopilot:branch-create)` with the resolved issue number (e.g., `42` for `#42`). The branch-create skill fetches the issue, generates an `issue-<number>-<slug>` branch name, and prompts the user to confirm before creation. Do NOT present a Hotfix/Trivial/Maintenance prefix prompt — issue inputs always use the `issue-<number>-<slug>` convention so the PR can link back via `Closes #<number>`.
+```
+
+##### Input type is `plain description`
+
+Use this body for the `## Pre-Implementation` section:
 
 ```
 ## Pre-Implementation
@@ -268,7 +282,7 @@ Tool parameters:
   ]
 - `multiSelect`: false
 
-Then invoke `/autopilot:branch-create --<chosen-prefix> "<description>"` using the Skill tool, where `<description>` is a short summary derived from the task context (issue title or user description). The branch name MUST be approved by the user via AskUserQuestion before creation — do not skip approval or create the branch directly with git commands.
+Then invoke `/autopilot:branch-create --<chosen-prefix> "<description>"` using the Skill tool, where `<description>` is a short summary derived from the user description. The branch name MUST be approved by the user via AskUserQuestion before creation — do not skip approval or create the branch directly with git commands.
 ```
 
 #### Otherwise (not on `main` AND (`isWorktree` is false OR `worktreeNeedsBranch` is false))


### PR DESCRIPTION
The plan and run skills now use the provided GitHub issue number to drive branch creation, instead of presenting a Hotfix/Trivial/Maintenance prefix prompt when an issue is supplied.

- Split the embedded `## Pre-Implementation` block in `plan/SKILL.md` and `run/SKILL.md` by input type
- `github-issue` inputs now invoke `Skill(autopilot:branch-create)` with the resolved issue number directly, producing `issue-<number>-<slug>` branches that link back to the issue
- The Hotfix/Trivial/Maintenance prefix prompt is kept only for `plain description` inputs

---

**Issues:**

Closes #4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements #4 by using the GitHub issue number to create branches when planning or running from an issue, generating `issue-<number>-<slug>` names that link back automatically. The Hotfix/Trivial/Maintenance prefix prompt now only shows for `plain description` inputs.

- **Refactors**
  - Split the `## Pre-Implementation` block by input type in `plan/SKILL.md` and `run/SKILL.md`.
  - For `github-issue` inputs, call `Skill(autopilot:branch-create)` with the resolved issue number and skip the prefix prompt.
  - For `plain description`, keep the prefix prompt and require branch name approval via AskUserQuestion.

<sup>Written for commit 42bdaf65e889755cc4a552223736cc3e8d0bb39e. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/6?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

