### PR TITLE
Allow filesystem storage in Bun+React+Tailwind rules

### DIFF
--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -45,10 +45,11 @@ Before making any changes:
 - React Router for routing
 - React Query for data fetching
 - Vitest for testing
-- Prisma (migrations) + Kysely (application ORM)
-- PostgreSQL database
+- Storage (choose one):
+  - Prisma (migrations) + Kysely (application ORM) + PostgreSQL
+  - Filesystem only (local-first apps; no database)
 - oRPC or tRPC for API, Zod for validation
-- BetterAuth for authentication
+- Authentication (only when using a database): BetterAuth
 - ESLint for linting
 - Prettier for formatting
 
@@ -194,13 +195,24 @@ Before making any changes:
 - 👤 Await promises before returning for complete stack traces
 - 👤 Subscribe to 'error' events on EventEmitters and streams
 
-### 8.2 Database (Prisma/Kysely)
+### 8.2 Storage
+
+Choose ONE backend based on the project's needs. Do not mix.
+
+**Option A — Relational database (Prisma + Kysely + PostgreSQL)**
 
 - 👤 Prisma: migrations and type generation ONLY
 - 👤 Kysely: ALL application queries
 - 👤 Never use Prisma Client in application code
 - 👤 Use explicit junction tables
 - 👤 Use `/// @kyselyType()` in schema.prisma for typed Json fields (never edit kysely.ts directly)
+
+**Option B — Filesystem (local-first, single-user apps; no database)**
+
+- 👤 Persist user-visible state to the filesystem under a per-app directory (e.g. `~/.<app>/`)
+- 👤 Use atomic writes (write-to-tmp + rename) for any user-visible state file
+- 👤 Validate file contents on read with Zod schemas — never trust on-disk shape
+- 👤 Handle ENOENT/EACCES explicitly; never swallow filesystem errors
 
 ### 8.3 File Operations
 


### PR DESCRIPTION
Lets local-first apps (e.g. symbiot) honestly declare `agents.rules: "Bun+React+Tailwind"` by making the storage backend a choose-one decision instead of mandating Prisma+Kysely+PostgreSQL.

- Replaced Section 8.2 "Database (Prisma/Kysely)" with Section 8.2 "Storage" listing two mutually-exclusive options: relational DB (Prisma+Kysely+PostgreSQL) and filesystem-only
- Added filesystem rules: atomic writes, Zod validation on read, explicit ENOENT/EACCES handling
- Updated the Technology Stack list to mark storage as choose-one and qualify BetterAuth as "only when using a database"

---

**Issues:**

Closes #7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add filesystem-only storage as a first-class option in the Bun+React+Tailwind rules, making storage a choose-one decision instead of requiring a relational DB. Closes #7 and clarifies that `BetterAuth` applies only to DB-backed apps.

- **New Features**
  - Replace Section 8.2 with “Storage” and require picking one backend; update the stack to mark storage as choose-one and `BetterAuth` as DB-only.
  - Option A: relational DB — `Prisma` for migrations/types, `Kysely` for all app queries, no `Prisma Client`, explicit junction tables, use `/// @kyselyType()` for typed JSON.
  - Option B: filesystem only — persist under a per-app dir (e.g., `~/.<app>/`), atomic writes (tmp + rename), validate on read with `Zod`, handle `ENOENT`/`EACCES` explicitly.

<sup>Written for commit afc41ed86e5882c584bcb4e208c21a2d5cd42c61. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/8?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

