### PR TITLE
Add files-sync GitHub Action to keep files in sync across repos

### DIFF
--- a/.github/actions/files-sync/README.md
+++ b/.github/actions/files-sync/README.md
@@ -24,13 +24,13 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: awinogradov/autopilot/.github/actions/files-sync@v1
+      - uses: awinogradov/code-assistants/.github/actions/files-sync@v1
         with:
           files: |
-            - repo: awinogradov/autopilot
+            - repo: awinogradov/code-assistants
               source: CONTRIBUTING.md
               dest: CONTRIBUTING.md
-            - repo: awinogradov/autopilot
+            - repo: awinogradov/code-assistants
               source: rules/Bun.md
               dest: CLAUDE.md
 ```
@@ -84,5 +84,5 @@ For private source repositories or cross-org reads, provide a token with `conten
 Reference the action by tag of the autopilot repo, e.g.:
 
 ```yaml
-uses: awinogradov/autopilot/.github/actions/files-sync@v1
+uses: awinogradov/code-assistants/.github/actions/files-sync@v1
 ```

--- a/.github/actions/files-sync/README.md
+++ b/.github/actions/files-sync/README.md
@@ -1,0 +1,88 @@
+# Files sync
+
+Composite GitHub Action that syncs declared files from one or more source repositories into
+the current repository and opens a single pull request with the differences.
+
+The action works purely against the GitHub REST + Git Data APIs — it does not require
+`actions/checkout` and never touches the local working tree of the runner.
+
+## Usage
+
+```yaml
+name: Sync files
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: awinogradov/autopilot/.github/actions/files-sync@v1
+        with:
+          files: |
+            - repo: awinogradov/autopilot
+              source: CONTRIBUTING.md
+              dest: CONTRIBUTING.md
+            - repo: awinogradov/autopilot
+              source: rules/Bun.md
+              dest: CLAUDE.md
+```
+
+## Inputs
+
+| Input            | Required | Default                                           | Description                                                                               |
+| ---------------- | -------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `files`          | yes      | —                                                 | YAML list of entries. Each item: `repo` (`owner/name`), `source`, `dest`, optional `ref`. |
+| `token`          | no       | `${{ github.token }}`                             | Token used for source reads and PR creation. Override for private cross-repo sources.     |
+| `base`           | no       | `${{ github.event.repository.default_branch }}`   | Base branch the PR targets.                                                               |
+| `branch`         | no       | `chore/sync-files`                                | Head branch the PR uses. Force-updated on subsequent runs.                                |
+| `title`          | no       | `MAINTENANCE: Sync files from upstream`           | PR title. Uses the `MAINTENANCE:` prefix per CONTRIBUTING.md.                             |
+| `body`           | no       | `Automated file sync from upstream repositories.` | PR body intro. The action auto-appends a `**Updated files:**` bullet list.                |
+| `commit-message` | no       | `chore: sync files from upstream`                 | Conventional commit message for the sync commit.                                          |
+
+### Entry fields
+
+- `repo` — source repository in `owner/name` form.
+- `source` — path in the source repository (relative to the repo root).
+- `dest` — destination path in the current repository.
+- `ref` _(optional)_ — branch, tag, or SHA to read the source from. Defaults to the source repo's default branch.
+
+## Outputs
+
+| Output          | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `changed-files` | Newline-separated list of destination paths that were updated.       |
+| `pr-number`     | Number of the opened or reused PR. Empty when no changes detected.   |
+| `pr-url`        | HTML URL of the opened or reused PR. Empty when no changes detected. |
+
+## Permissions
+
+The token (default `${{ github.token }}`) needs:
+
+- `contents: write` — to create the branch, blobs, tree, and commit on the destination repo.
+- `pull-requests: write` — to open or reuse the PR.
+
+For private source repositories or cross-org reads, provide a token with `contents: read` scope on the source repos.
+
+## Behavior
+
+- A single PR with all changed files is created (or reused if `branch` already has an open PR).
+- The head `branch` is force-updated on every run.
+- If no files differ between source and destination, no PR is created and the action exits cleanly.
+- A missing source path fails the run with `Source not found at <repo>:<path>`.
+- The destination path may not exist yet — it will be created in the PR.
+
+## Versioning
+
+Reference the action by tag of the autopilot repo, e.g.:
+
+```yaml
+uses: awinogradov/autopilot/.github/actions/files-sync@v1
+```

--- a/.github/actions/files-sync/action.yml
+++ b/.github/actions/files-sync/action.yml
@@ -45,7 +45,7 @@ runs:
   using: composite
   steps:
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
         bun-version: 1.x
 

--- a/.github/actions/files-sync/action.yml
+++ b/.github/actions/files-sync/action.yml
@@ -52,7 +52,7 @@ runs:
     - name: Install workspace dependencies
       shell: bash
       working-directory: ${{ github.action_path }}/../../..
-      run: bun install --frozen-lockfile --filter @autopilot/files-sync-action
+      run: bun install --frozen-lockfile --filter @code-assistants/files-sync-action
 
     - name: Run files-sync
       id: sync

--- a/.github/actions/files-sync/action.yml
+++ b/.github/actions/files-sync/action.yml
@@ -1,0 +1,68 @@
+name: Files sync
+description: Sync declared files from source repositories into the current repository and open a single PR with the differences.
+
+inputs:
+  files:
+    description: YAML list of sync entries. Each item must define `repo` (owner/name), `source`, `dest`, and optionally `ref`.
+    required: true
+  token:
+    description: GitHub token used to read source files and create the PR in the current repository. Defaults to the workflow token.
+    required: false
+    default: ${{ github.token }}
+  base:
+    description: Base branch the PR targets.
+    required: false
+    default: ${{ github.event.repository.default_branch }}
+  branch:
+    description: Head branch the PR uses. Force-updated on subsequent runs.
+    required: false
+    default: chore/sync-files
+  title:
+    description: PR title. Defaults to the MAINTENANCE prefix per CONTRIBUTING.md.
+    required: false
+    default: "MAINTENANCE: Sync files from upstream"
+  body:
+    description: PR body intro. The action automatically appends a `**Updated files:**` bullet list with the synced paths.
+    required: false
+    default: Automated file sync from upstream repositories.
+  commit-message:
+    description: Commit message for the sync commit. Must follow Conventional Commits.
+    required: false
+    default: "chore: sync files from upstream"
+
+outputs:
+  changed-files:
+    description: Newline-separated list of destination paths that were updated.
+    value: ${{ steps.sync.outputs.changed-files }}
+  pr-number:
+    description: Number of the opened or reused PR. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.pr-number }}
+  pr-url:
+    description: HTML URL of the opened or reused PR. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.pr-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: 1.x
+
+    - name: Install workspace dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      run: bun install --frozen-lockfile --filter @autopilot/files-sync-action
+
+    - name: Run files-sync
+      id: sync
+      shell: bash
+      env:
+        FILES_INPUT: ${{ inputs.files }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+        INPUT_BASE: ${{ inputs.base }}
+        INPUT_BRANCH: ${{ inputs.branch }}
+        INPUT_TITLE: ${{ inputs.title }}
+        INPUT_BODY: ${{ inputs.body }}
+        INPUT_COMMIT_MESSAGE: ${{ inputs.commit-message }}
+      run: bun "${{ github.action_path }}/files-sync.ts"

--- a/.github/actions/files-sync/files-sync.ts
+++ b/.github/actions/files-sync/files-sync.ts
@@ -1,0 +1,126 @@
+/**
+ * Entry point for the files-sync composite action.
+ *
+ * Reads action inputs from environment variables, fetches declared source files,
+ * compares them against the current repository, and — when differences exist —
+ * commits a single tree via the Git Data API and opens one PR.
+ *
+ * @example
+ *   FILES_INPUT='- repo: owner/name
+ *     source: README.md
+ *     dest: README.md' \
+ *   GITHUB_TOKEN=... GITHUB_REPOSITORY=me/dest \
+ *   INPUT_BASE=main INPUT_BRANCH=chore/sync-files \
+ *   INPUT_TITLE="MAINTENANCE: Sync" INPUT_BODY="Automated sync." \
+ *   INPUT_COMMIT_MESSAGE="chore: sync files from upstream" \
+ *   bun files-sync.ts
+ */
+
+import * as core from '@actions/core';
+import { Octokit } from '@octokit/rest';
+
+import { computeChanges } from './src/changeDetector.ts';
+import { createSyncPullRequest } from './src/createSyncPullRequest.ts';
+import { parseFilesInput, parseRepoSlug } from './src/parseInputs.ts';
+
+interface Env {
+  filesInput: string;
+  token: string;
+  destRepo: { owner: string; name: string };
+  base: string;
+  branch: string;
+  title: string;
+  body: string;
+  commitMessage: string;
+}
+
+function readEnv(): Env {
+  const token = required('GITHUB_TOKEN');
+  const filesInput = required('FILES_INPUT');
+  const repository = required('GITHUB_REPOSITORY');
+  const base = required('INPUT_BASE');
+  const branch = required('INPUT_BRANCH');
+  const title = required('INPUT_TITLE');
+  const body = required('INPUT_BODY');
+  const commitMessage = required('INPUT_COMMIT_MESSAGE');
+
+  const { owner, name } = parseRepoSlug(repository);
+
+  return {
+    filesInput,
+    token,
+    destRepo: { owner, name },
+    base,
+    branch,
+    title,
+    body,
+    commitMessage,
+  };
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+
+  if (value === undefined || value === '') {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function composeBody(intro: string, paths: string[]): string {
+  const lines = paths.map((path) => `- \`${path}\``).join('\n');
+  return `${intro}\n\n**Updated files:**\n\n${lines}\n`;
+}
+
+async function main(): Promise<void> {
+  const env = readEnv();
+  const entries = parseFilesInput(env.filesInput);
+
+  core.info(`Resolved ${entries.length} sync entr${entries.length === 1 ? 'y' : 'ies'}.`);
+
+  const octokit = new Octokit({ auth: env.token });
+
+  const changes = await computeChanges({
+    octokit,
+    entries,
+    destRepo: env.destRepo,
+    baseRef: env.base,
+  });
+
+  if (changes.length === 0) {
+    core.info('No file differences detected. Skipping PR creation.');
+    core.setOutput('changed-files', '');
+    core.setOutput('pr-number', '');
+    core.setOutput('pr-url', '');
+    return;
+  }
+
+  core.info(`Detected ${changes.length} changed file(s):`);
+  changes.forEach((change) => core.info(`  - ${change.path}`));
+
+  const body = composeBody(env.body, changes.map((change) => change.path));
+
+  const pr = await createSyncPullRequest({
+    octokit,
+    destRepo: env.destRepo,
+    base: env.base,
+    branch: env.branch,
+    title: env.title,
+    body,
+    commitMessage: env.commitMessage,
+    changes,
+  });
+
+  core.setOutput('changed-files', changes.map((change) => change.path).join('\n'));
+  core.setOutput('pr-number', String(pr.number));
+  core.setOutput('pr-url', pr.htmlUrl);
+
+  core.info(`Pull request ready: ${pr.htmlUrl}`);
+}
+
+await main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  core.setFailed(message);
+  process.exit(1);
+});

--- a/.github/actions/files-sync/package.json
+++ b/.github/actions/files-sync/package.json
@@ -17,7 +17,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "1.3.14",
     "typescript": "6.0.3"
   }
 }

--- a/.github/actions/files-sync/package.json
+++ b/.github/actions/files-sync/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@autopilot/files-sync-action",
+  "version": "0.0.0",
+  "description": "Composite GitHub Action that syncs declared files from upstream repositories.",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf node_modules .turbo"
+  },
+  "dependencies": {
+    "@actions/core": "3.0.1",
+    "@octokit/request-error": "7.1.0",
+    "@octokit/rest": "22.0.1",
+    "yaml": "2.9.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "6.0.3"
+  }
+}

--- a/.github/actions/files-sync/package.json
+++ b/.github/actions/files-sync/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@autopilot/files-sync-action",
+  "name": "@code-assistants/files-sync-action",
   "version": "0.0.0",
   "description": "Composite GitHub Action that syncs declared files from upstream repositories.",
   "private": true,

--- a/.github/actions/files-sync/src/changeDetector.ts
+++ b/.github/actions/files-sync/src/changeDetector.ts
@@ -2,7 +2,9 @@
  * Source/destination comparison for the files-sync action.
  *
  * Fetches raw file contents from GitHub via the REST API (no working tree required) and
- * returns the subset of entries that differ between source and destination.
+ * returns the subset of entries that differ between source and destination. Preserves
+ * the source file mode (e.g. `100755` for executables) so the sync commit does not
+ * strip execute bits.
  *
  * @example
  *   const changes = await computeChanges(octokit, entries, { owner, name }, 'main');
@@ -13,9 +15,12 @@ import type { RequestError } from '@octokit/request-error';
 
 import { parseRepoSlug, type SyncEntry } from './parseInputs.ts';
 
+const defaultMode = '100644';
+
 export interface FileChange {
   path: string;
   content: string;
+  mode: string;
 }
 
 interface FetchArgs {
@@ -45,9 +50,13 @@ export async function fetchRawContent({
       },
     );
 
-    return typeof response.data === 'string'
-      ? response.data
-      : Buffer.from(JSON.stringify(response.data)).toString('utf-8');
+    if (typeof response.data !== 'string') {
+      throw new Error(
+        `Expected raw string content from ${owner}/${repo}:${path}${ref ? `@${ref}` : ''}, got ${typeof response.data}`,
+      );
+    }
+
+    return response.data;
   } catch (error) {
     const requestError = error as RequestError;
 
@@ -74,8 +83,11 @@ export async function computeChanges({
   destRepo,
   baseRef,
 }: ComputeArgs): Promise<FileChange[]> {
+  const modeCache = new Map<string, Promise<Map<string, string>>>();
   const results = await Promise.all(
-    entries.map((entry) => detectChange({ octokit, entry, destRepo, baseRef })),
+    entries.map((entry) =>
+      detectChange({ octokit, entry, destRepo, baseRef, modeCache }),
+    ),
   );
 
   return results.filter((change): change is FileChange => change !== null);
@@ -86,6 +98,7 @@ interface DetectArgs {
   entry: SyncEntry;
   destRepo: { owner: string; name: string };
   baseRef: string;
+  modeCache: Map<string, Promise<Map<string, string>>>;
 }
 
 async function detectChange({
@@ -93,6 +106,7 @@ async function detectChange({
   entry,
   destRepo,
   baseRef,
+  modeCache,
 }: DetectArgs): Promise<FileChange | null> {
   const source = parseRepoSlug(entry.repo);
 
@@ -120,5 +134,75 @@ async function detectChange({
     return null;
   }
 
-  return { path: entry.dest, content: sourceContent };
+  const mode = await resolveSourceMode({
+    octokit,
+    owner: source.owner,
+    repo: source.name,
+    ref: entry.ref,
+    path: entry.source,
+    modeCache,
+  });
+
+  return { path: entry.dest, content: sourceContent, mode };
+}
+
+interface ResolveModeArgs {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  ref?: string;
+  path: string;
+  modeCache: Map<string, Promise<Map<string, string>>>;
+}
+
+async function resolveSourceMode({
+  octokit,
+  owner,
+  repo,
+  ref,
+  path,
+  modeCache,
+}: ResolveModeArgs): Promise<string> {
+  const cacheKey = `${owner}/${repo}@${ref ?? ''}`;
+  let modesPromise = modeCache.get(cacheKey);
+
+  if (modesPromise === undefined) {
+    modesPromise = fetchSourceTreeModes({ octokit, owner, repo, ref });
+    modeCache.set(cacheKey, modesPromise);
+  }
+
+  const modes = await modesPromise;
+  return modes.get(path) ?? defaultMode;
+}
+
+interface FetchModesArgs {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  ref?: string;
+}
+
+async function fetchSourceTreeModes({
+  octokit,
+  owner,
+  repo,
+  ref,
+}: FetchModesArgs): Promise<Map<string, string>> {
+  const targetRef = ref ?? (await octokit.rest.repos.get({ owner, repo })).data.default_branch;
+  const commit = await octokit.rest.repos.getCommit({ owner, repo, ref: targetRef });
+  const tree = await octokit.rest.git.getTree({
+    owner,
+    repo,
+    tree_sha: commit.data.commit.tree.sha,
+    recursive: 'true',
+  });
+
+  const modes = new Map<string, string>();
+  for (const entry of tree.data.tree) {
+    if (entry.path !== undefined && entry.mode !== undefined) {
+      modes.set(entry.path, entry.mode);
+    }
+  }
+
+  return modes;
 }

--- a/.github/actions/files-sync/src/changeDetector.ts
+++ b/.github/actions/files-sync/src/changeDetector.ts
@@ -197,6 +197,12 @@ async function fetchSourceTreeModes({
     recursive: 'true',
   });
 
+  if (tree.data.truncated) {
+    throw new Error(
+      `Source tree is truncated for ${owner}/${repo}${ref ? `@${ref}` : ''}; cannot reliably resolve file modes`,
+    );
+  }
+
   const modes = new Map<string, string>();
   for (const entry of tree.data.tree) {
     if (entry.path !== undefined && entry.mode !== undefined) {

--- a/.github/actions/files-sync/src/changeDetector.ts
+++ b/.github/actions/files-sync/src/changeDetector.ts
@@ -1,0 +1,124 @@
+/**
+ * Source/destination comparison for the files-sync action.
+ *
+ * Fetches raw file contents from GitHub via the REST API (no working tree required) and
+ * returns the subset of entries that differ between source and destination.
+ *
+ * @example
+ *   const changes = await computeChanges(octokit, entries, { owner, name }, 'main');
+ */
+
+import type { Octokit } from '@octokit/rest';
+import type { RequestError } from '@octokit/request-error';
+
+import { parseRepoSlug, type SyncEntry } from './parseInputs.ts';
+
+export interface FileChange {
+  path: string;
+  content: string;
+}
+
+interface FetchArgs {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  path: string;
+  ref?: string;
+}
+
+export async function fetchRawContent({
+  octokit,
+  owner,
+  repo,
+  path,
+  ref,
+}: FetchArgs): Promise<string | null> {
+  try {
+    const response = await octokit.request(
+      'GET /repos/{owner}/{repo}/contents/{path}',
+      {
+        owner,
+        repo,
+        path,
+        ref,
+        headers: { accept: 'application/vnd.github.raw' },
+      },
+    );
+
+    return typeof response.data === 'string'
+      ? response.data
+      : Buffer.from(JSON.stringify(response.data)).toString('utf-8');
+  } catch (error) {
+    const requestError = error as RequestError;
+
+    if (requestError.status === 404) {
+      return null;
+    }
+
+    throw new Error(
+      `Failed to fetch ${owner}/${repo}:${path}${ref ? `@${ref}` : ''}: ${requestError.message}`,
+    );
+  }
+}
+
+interface ComputeArgs {
+  octokit: Octokit;
+  entries: SyncEntry[];
+  destRepo: { owner: string; name: string };
+  baseRef: string;
+}
+
+export async function computeChanges({
+  octokit,
+  entries,
+  destRepo,
+  baseRef,
+}: ComputeArgs): Promise<FileChange[]> {
+  const results = await Promise.all(
+    entries.map((entry) => detectChange({ octokit, entry, destRepo, baseRef })),
+  );
+
+  return results.filter((change): change is FileChange => change !== null);
+}
+
+interface DetectArgs {
+  octokit: Octokit;
+  entry: SyncEntry;
+  destRepo: { owner: string; name: string };
+  baseRef: string;
+}
+
+async function detectChange({
+  octokit,
+  entry,
+  destRepo,
+  baseRef,
+}: DetectArgs): Promise<FileChange | null> {
+  const source = parseRepoSlug(entry.repo);
+
+  const sourceContent = await fetchRawContent({
+    octokit,
+    owner: source.owner,
+    repo: source.name,
+    path: entry.source,
+    ref: entry.ref,
+  });
+
+  if (sourceContent === null) {
+    throw new Error(`Source not found at ${entry.repo}:${entry.source}`);
+  }
+
+  const destContent = await fetchRawContent({
+    octokit,
+    owner: destRepo.owner,
+    repo: destRepo.name,
+    path: entry.dest,
+    ref: baseRef,
+  });
+
+  if (destContent === sourceContent) {
+    return null;
+  }
+
+  return { path: entry.dest, content: sourceContent };
+}

--- a/.github/actions/files-sync/src/createSyncPullRequest.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.ts
@@ -72,7 +72,7 @@ export async function createSyncPullRequest({
     base_tree: baseTreeSha,
     tree: changes.map((change, index) => ({
       path: change.path,
-      mode: '100644',
+      mode: change.mode as '100644' | '100755' | '040000' | '160000' | '120000',
       type: 'blob',
       sha: blobs[index]!.data.sha,
     })),
@@ -162,6 +162,7 @@ async function upsertPullRequest({
     repo,
     state: 'open',
     head: `${owner}:${branch}`,
+    base,
   });
 
   const open = existing.data[0];

--- a/.github/actions/files-sync/src/createSyncPullRequest.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.ts
@@ -1,0 +1,183 @@
+/**
+ * Pull request creation for the files-sync action.
+ *
+ * Builds a single commit through the GitHub Git Data API (`blob` → `tree` → `commit` → `ref`)
+ * and opens or reuses one PR with all changed files. Never touches the local working tree.
+ *
+ * @example
+ *   const pr = await createSyncPullRequest(octokit, { destRepo, base, branch, ...meta, changes });
+ */
+
+import type { Octokit } from '@octokit/rest';
+import type { RequestError } from '@octokit/request-error';
+
+import type { FileChange } from './changeDetector.ts';
+
+interface CreateArgs {
+  octokit: Octokit;
+  destRepo: { owner: string; name: string };
+  base: string;
+  branch: string;
+  title: string;
+  body: string;
+  commitMessage: string;
+  changes: FileChange[];
+}
+
+export interface SyncPullRequest {
+  number: number;
+  htmlUrl: string;
+}
+
+export async function createSyncPullRequest({
+  octokit,
+  destRepo,
+  base,
+  branch,
+  title,
+  body,
+  commitMessage,
+  changes,
+}: CreateArgs): Promise<SyncPullRequest> {
+  const { owner, name: repo } = destRepo;
+
+  const baseRef = await octokit.rest.git.getRef({
+    owner,
+    repo,
+    ref: `heads/${base}`,
+  });
+  const baseCommitSha = baseRef.data.object.sha;
+
+  const baseCommit = await octokit.rest.git.getCommit({
+    owner,
+    repo,
+    commit_sha: baseCommitSha,
+  });
+  const baseTreeSha = baseCommit.data.tree.sha;
+
+  const blobs = await Promise.all(
+    changes.map((change) =>
+      octokit.rest.git.createBlob({
+        owner,
+        repo,
+        content: change.content,
+        encoding: 'utf-8',
+      }),
+    ),
+  );
+
+  const newTree = await octokit.rest.git.createTree({
+    owner,
+    repo,
+    base_tree: baseTreeSha,
+    tree: changes.map((change, index) => ({
+      path: change.path,
+      mode: '100644',
+      type: 'blob',
+      sha: blobs[index]!.data.sha,
+    })),
+  });
+
+  const newCommit = await octokit.rest.git.createCommit({
+    owner,
+    repo,
+    message: commitMessage,
+    tree: newTree.data.sha,
+    parents: [baseCommitSha],
+  });
+
+  await upsertBranch({ octokit, owner, repo, branch, sha: newCommit.data.sha });
+
+  return upsertPullRequest({
+    octokit,
+    owner,
+    repo,
+    base,
+    branch,
+    title,
+    body,
+  });
+}
+
+interface UpsertBranchArgs {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  branch: string;
+  sha: string;
+}
+
+async function upsertBranch({
+  octokit,
+  owner,
+  repo,
+  branch,
+  sha,
+}: UpsertBranchArgs): Promise<void> {
+  try {
+    await octokit.rest.git.createRef({
+      owner,
+      repo,
+      ref: `refs/heads/${branch}`,
+      sha,
+    });
+  } catch (error) {
+    const requestError = error as RequestError;
+
+    if (requestError.status !== 422) {
+      throw error;
+    }
+
+    await octokit.rest.git.updateRef({
+      owner,
+      repo,
+      ref: `heads/${branch}`,
+      sha,
+      force: true,
+    });
+  }
+}
+
+interface UpsertPrArgs {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  base: string;
+  branch: string;
+  title: string;
+  body: string;
+}
+
+async function upsertPullRequest({
+  octokit,
+  owner,
+  repo,
+  base,
+  branch,
+  title,
+  body,
+}: UpsertPrArgs): Promise<SyncPullRequest> {
+  const existing = await octokit.rest.pulls.list({
+    owner,
+    repo,
+    state: 'open',
+    head: `${owner}:${branch}`,
+  });
+
+  const open = existing.data[0];
+
+  if (open !== undefined) {
+    return { number: open.number, htmlUrl: open.html_url };
+  }
+
+  const created = await octokit.rest.pulls.create({
+    owner,
+    repo,
+    base,
+    head: branch,
+    title,
+    body,
+  });
+
+  return { number: created.data.number, htmlUrl: created.data.html_url };
+}

--- a/.github/actions/files-sync/src/parseInputs.ts
+++ b/.github/actions/files-sync/src/parseInputs.ts
@@ -1,0 +1,57 @@
+/**
+ * Input parsing for the files-sync action.
+ *
+ * Parses the `files` action input — a YAML list of sync entries — and validates it with Zod.
+ *
+ * @example
+ *   const entries = parseFilesInput(process.env.FILES_INPUT ?? '');
+ */
+
+import { parse as parseYaml } from 'yaml';
+import { z } from 'zod';
+
+const repoPattern = /^[^/]+\/[^/]+$/;
+
+export const syncEntrySchema = z.object({
+  repo: z
+    .string()
+    .regex(repoPattern, 'repo must be in `owner/name` form'),
+  source: z.string().min(1, 'source path is required'),
+  dest: z.string().min(1, 'dest path is required'),
+  ref: z.string().min(1).optional(),
+});
+
+export const filesInputSchema = z
+  .array(syncEntrySchema)
+  .min(1, 'at least one file entry is required');
+
+export type SyncEntry = z.infer<typeof syncEntrySchema>;
+
+export function parseFilesInput(raw: string): SyncEntry[] {
+  const trimmed = raw.trim();
+
+  if (trimmed === '') {
+    throw new Error('FILES_INPUT is empty');
+  }
+
+  const parsed = parseYaml(trimmed) as unknown;
+  const result = filesInputSchema.safeParse(parsed);
+
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    throw new Error(`Invalid files input at ${path}: ${issue.message}`);
+  }
+
+  return result.data;
+}
+
+export function parseRepoSlug(repo: string): { owner: string; name: string } {
+  const [owner, name] = repo.split('/');
+
+  if (owner === undefined || name === undefined) {
+    throw new Error(`Invalid repo slug: ${repo}`);
+  }
+
+  return { owner, name };
+}

--- a/.github/actions/files-sync/tsconfig.json
+++ b/.github/actions/files-sync/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["*.ts", "src/**/*.ts"]
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ See the [plugin README](./claude-plugins/autopilot/README.md#installation) for s
 - [`agents` field spec](./docs/agents-field.md) — how skills detect a repository's tech stack from `package.json`
 - [Stack rule sets](./rules/) — `Bun`, `Bun+React+Tailwind`, `NodeJS+React`, `NodeJS+React+Tailwind`
 
+## GitHub Actions
+
+- [`files-sync`](./.github/actions/files-sync/README.md) — sync declared files from upstream repos and open one PR with the differences
+
 ## Contributing
 
 - [Contributing guide](./CONTRIBUTING.md)

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
       },
     },
     ".github/actions/files-sync": {
-      "name": "@autopilot/files-sync-action",
+      "name": "@code-assistants/files-sync-action",
       "version": "0.0.0",
       "dependencies": {
         "@actions/core": "3.0.1",
@@ -42,11 +42,11 @@
 
     "@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
 
-    "@autopilot/files-sync-action": ["@autopilot/files-sync-action@workspace:.github/actions/files-sync"],
-
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@code-assistants/files-sync-action": ["@code-assistants/files-sync-action@workspace:.github/actions/files-sync"],
 
     "@commitlint/cli": ["@commitlint/cli@21.0.1", "", { "dependencies": { "@commitlint/format": "^21.0.1", "@commitlint/lint": "^21.0.1", "@commitlint/load": "^21.0.1", "@commitlint/read": "^21.0.1", "@commitlint/types": "^21.0.1", "tinyexec": "^1.0.0", "yargs": "^18.0.0" }, "bin": { "commitlint": "cli.js" } }, "sha512-8vq10krmbJwBkvzXKhbs4o4JQEVscd3pqOlWuDUaDBwbeL694/P33UC29tZQFTAgPU9fVJ2+f2m3zw16yKWxHg=="],
 
@@ -308,7 +308,7 @@
 
     "zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
 
-    "@autopilot/files-sync-action/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+    "@code-assistants/files-sync-action/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "cli-truncate/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@commitlint/cli": "21.0.1",
         "@commitlint/config-conventional": "21.0.1",
         "@commitlint/types": "21.0.1",
-        "@types/bun": "latest",
+        "@types/bun": "1.3.14",
         "gray-matter": "4.0.3",
         "husky": "9.1.7",
         "lint-staged": "17.0.5",
@@ -28,7 +28,7 @@
         "zod": "4.4.3",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "1.3.14",
         "typescript": "6.0.3",
       },
     },

--- a/bun.lock
+++ b/bun.lock
@@ -13,11 +13,37 @@
         "husky": "9.1.7",
         "lint-staged": "17.0.5",
         "prettier": "3.8.3",
+        "turbo": "2.9.14",
         "zod": "3.23.8",
+      },
+    },
+    ".github/actions/files-sync": {
+      "name": "@autopilot/files-sync-action",
+      "version": "0.0.0",
+      "dependencies": {
+        "@actions/core": "3.0.1",
+        "@octokit/request-error": "7.1.0",
+        "@octokit/rest": "22.0.1",
+        "yaml": "2.9.0",
+        "zod": "4.4.3",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "6.0.3",
       },
     },
   },
   "packages": {
+    "@actions/core": ["@actions/core@3.0.1", "", { "dependencies": { "@actions/exec": "^3.0.0", "@actions/http-client": "^4.0.0" } }, "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA=="],
+
+    "@actions/exec": ["@actions/exec@3.0.0", "", { "dependencies": { "@actions/io": "^3.0.2" } }, "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw=="],
+
+    "@actions/http-client": ["@actions/http-client@4.0.1", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^6.23.0" } }, "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg=="],
+
+    "@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
+
+    "@autopilot/files-sync-action": ["@autopilot/files-sync-action@workspace:.github/actions/files-sync"],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -58,9 +84,45 @@
 
     "@conventional-changelog/git-client": ["@conventional-changelog/git-client@2.7.0", "", { "dependencies": { "@simple-libs/child-process-utils": "^1.0.0", "@simple-libs/stream-utils": "^1.2.0", "semver": "^7.5.2" }, "peerDependencies": { "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.4.0" }, "optionalPeers": ["conventional-commits-filter", "conventional-commits-parser"] }, "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw=="],
 
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.9", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
 
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.14", "", { "os": "linux", "cpu": "x64" }, "sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.14", "", { "os": "win32", "cpu": "x64" }, "sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -78,6 +140,8 @@
 
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
@@ -89,6 +153,8 @@
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
+
+    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "conventional-changelog-angular": ["conventional-changelog-angular@8.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg=="],
 
@@ -119,6 +185,8 @@
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
+    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -159,6 +227,8 @@
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
@@ -214,9 +284,17 @@
 
     "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 
+    "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
+
+    "turbo": ["turbo@2.9.14", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.14", "@turbo/darwin-arm64": "2.9.14", "@turbo/linux-64": "2.9.14", "@turbo/linux-arm64": "2.9.14", "@turbo/windows-64": "2.9.14", "@turbo/windows-arm64": "2.9.14" }, "bin": { "turbo": "bin/turbo" } }, "sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw=="],
+
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
+    "undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
+
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
@@ -229,6 +307,8 @@
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
+
+    "@autopilot/files-sync-action/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "cli-truncate/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@commitlint/cli": "21.0.1",
     "@commitlint/config-conventional": "21.0.1",
     "@commitlint/types": "21.0.1",
-    "@types/bun": "latest",
+    "@types/bun": "1.3.14",
     "gray-matter": "4.0.3",
     "husky": "9.1.7",
     "lint-staged": "17.0.5",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "rules": "Bun",
     "language": "typescript"
   },
+  "workspaces": [".github/actions/files-sync"],
   "scripts": {
     "prepare": "husky",
     "format": "prettier --write \"**/*.{md,json}\"",
     "format:check": "prettier --check \"**/*.{md,json}\"",
     "validate": "bun scripts/validate-plugins.ts",
-    "lint": "bun run format:check && bun run validate"
+    "typecheck": "turbo run typecheck",
+    "lint": "bun run format:check && bun run validate && turbo run typecheck"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.1",
@@ -31,6 +33,7 @@
     "husky": "9.1.7",
     "lint-staged": "17.0.5",
     "prettier": "3.8.3",
+    "turbo": "2.9.14",
     "zod": "3.23.8"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "ui": "stream",
+  "globalDependencies": [".prettierignore", "bun.lock"],
+  "globalPassThroughEnv": ["CI", "GITHUB_*", "RUNNER_*", "TURBO_*", "PATH", "HOME", "TMPDIR"],
+  "tasks": {
+    "typecheck": {
+      "inputs": ["action.yml", "*.ts", "src/**/*.ts", "tsconfig.json", "package.json"],
+      "outputs": []
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
The code-assistants repo distributes shared assets (CLAUDE.md rule sets, CONTRIBUTING.md, plugin skills) that drift across consumer repos when copied by hand. The new files-sync composite action lets any consumer repo declare which files to pull from upstream and automatically opens a single PR when differences are detected.

- New `.github/actions/files-sync` composite action with action.yml manifest, files-sync.ts entry, and src/ helpers for parsing inputs, detecting changes, and building the PR
- Fetches sources via @octokit/rest and builds a single commit through the Git Data API — no actions/checkout or local working tree needed
- Default token is \${{ github.token }}; PR title defaults to the MAINTENANCE: prefix per CONTRIBUTING.md; commit message defaults to a Conventional Commits chore: message; PR body auto-appends an **Updated files:** bullet list
- Converts the repo to a Bun workspaces + Turborepo monorepo so additional actions can be added as workspaces and orchestrated via \`turbo run typecheck\`

---

**Release notes:**

- Added the \`files-sync\` GitHub Action — sync declared files from upstream repositories into the current repository via one PR
- Added Bun workspaces + Turborepo at the repo root to manage multiple actions as a monorepo

---

**Issues:**

Closes #9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `files-sync` composite GitHub Action to sync declared files across repos and open one PR with changes. Converts the repo to Bun workspaces + Turborepo for action management and type checking; closes #9.

- **New Features**
  - New `.github/actions/files-sync` action that reads a YAML `files` list and uses `@octokit/rest` + Git Data API (no `actions/checkout`).
  - Creates or reuses a single PR and force-updates the head branch; PR body includes an “Updated files” list.
  - Defaults: token `${{ github.token }}`, title with `MAINTENANCE:` prefix, commit message `chore: …`.
  - Outputs: `changed-files`, `pr-number`, `pr-url`; no PR when no diffs.

- **Bug Fixes**
  - Preserve source file modes (e.g., `100755`) and throw when the source tree is truncated to avoid losing execute bits.
  - Harden raw content fetch: throw on non-string responses.
  - Pin `oven-sh/setup-bun` to a v2 commit SHA.
  - Reuse an existing PR only when both head and base match (adds base filter).

<sup>Written for commit 6f676dfa5b12d0d41ce93495b094b4e43fafc59f. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/10?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

