### PR TITLE
Sync stack-appropriate agent rules into CLAUDE.md

### DIFF
--- a/.github/actions/agents-rules-sync/README.md
+++ b/.github/actions/agents-rules-sync/README.md
@@ -1,0 +1,100 @@
+# Agents rules sync
+
+Composite GitHub Action that syncs the stack-appropriate agent rules file from an upstream
+repository into the current repository's `CLAUDE.md` and opens a single pull request with
+the difference.
+
+The action reads the consumer's `agents.rules` field (see
+[docs/agents-field.md](../../../docs/agents-field.md)), builds the corresponding source path
+(`rules/<value>.md`), and delegates the diff and PR mechanics to the
+[`files-sync`](../files-sync/README.md) action. It does not require `actions/checkout` and
+never touches the runner's working tree.
+
+## Usage
+
+```yaml
+name: Sync agent rules
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: awinogradov/code-assistants/.github/actions/agents-rules-sync@v1
+```
+
+The consumer repository must declare an `agents.rules` field in its root `package.json`:
+
+```json
+{
+  "name": "my-app",
+  "agents": {
+    "rules": "Bun"
+  }
+}
+```
+
+Accepted values: `Bun`, `Bun+React+Tailwind`, `NodeJS+React`, `NodeJS+React+Tailwind`.
+
+## Inputs
+
+| Input         | Required | Default                       | Description                                                                                       |
+| ------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------- |
+| `token`       | no       | `${{ github.token }}`         | Token used to read `package.json`, fetch the source rules file, and create the PR.                |
+| `source-repo` | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.                   |
+| `source-ref`  | no       | _(empty)_                     | Branch, tag, or SHA to read the source rules file from. Empty → source repository default branch. |
+
+PR-shaping inputs (branch, title, body, commit message) are fixed by design — see
+[Behavior](#behavior).
+
+## Outputs
+
+| Output          | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `changed-files` | Newline-separated list of destination paths that were updated.       |
+| `pr-number`     | Number of the opened or reused PR. Empty when no changes detected.   |
+| `pr-url`        | HTML URL of the opened or reused PR. Empty when no changes detected. |
+
+## Permissions
+
+The token (default `${{ github.token }}`) needs:
+
+- `contents: write` — to create the branch, blobs, tree, and commit on the consumer repo.
+- `pull-requests: write` — to open or reuse the PR.
+
+For private source repositories or cross-org reads, provide a token with `contents: read`
+scope on the source repository.
+
+## Behavior
+
+- Resolves the consumer's `agents.rules` value from its root `package.json` on the default
+  branch.
+- Delegates to `files-sync` with a single entry: `repo: <source-repo>`,
+  `source: rules/<value>.md`, `dest: CLAUDE.md`.
+- The PR is opened on the fixed branch `chore/sync-agents-rules` with the title
+  `MAINTENANCE: Sync agent rules from upstream` and the commit message
+  `chore: sync agent rules from upstream`. These values are not configurable so the action
+  cannot collide with `files-sync`'s default branch and so every consumer gets the same
+  one-line setup.
+- The head branch is force-updated on every run (inherited from `files-sync`); local edits
+  to `CLAUDE.md` will be overwritten when the upstream rules file changes.
+- If `CLAUDE.md` already matches `rules/<value>.md`, no PR is created.
+- If `package.json` is missing, malformed, or lacks `agents.rules` (or its value is
+  unrecognized), the action fails with a link to `docs/agents-field.md` and the list of
+  accepted values.
+
+## Versioning
+
+Reference the action by tag of the autopilot repo, e.g.:
+
+```yaml
+uses: awinogradov/code-assistants/.github/actions/agents-rules-sync@v1
+```

--- a/.github/actions/agents-rules-sync/action.yml
+++ b/.github/actions/agents-rules-sync/action.yml
@@ -1,0 +1,62 @@
+name: Agents rules sync
+description: Sync the stack-appropriate agent rules file from an upstream repository into the current repository's CLAUDE.md.
+
+inputs:
+  token:
+    description: GitHub token used to read the source rules file and create the PR in the current repository. Defaults to the workflow token.
+    required: false
+    default: ${{ github.token }}
+  source-repo:
+    description: Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.
+    required: false
+    default: awinogradov/code-assistants
+  source-ref:
+    description: Branch, tag, or SHA to read the source rules file from. Defaults to the source repository's default branch.
+    required: false
+    default: ""
+
+outputs:
+  changed-files:
+    description: Newline-separated list of destination paths that were updated. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.changed-files }}
+  pr-number:
+    description: Number of the opened or reused PR. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.pr-number }}
+  pr-url:
+    description: HTML URL of the opened or reused PR. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.pr-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      with:
+        bun-version: 1.x
+
+    - name: Install workspace dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      run: bun install --frozen-lockfile --filter @code-assistants/agents-rules-sync-action
+
+    - name: Resolve files list from agents.rules
+      id: resolve
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        DEST_REPO: ${{ github.repository }}
+        INPUT_SOURCE_REPO: ${{ inputs.source-repo }}
+        INPUT_SOURCE_REF: ${{ inputs.source-ref }}
+        INPUT_BASE: ${{ github.event.repository.default_branch }}
+      run: bun "${{ github.action_path }}/agents-rules-sync.ts"
+
+    - name: Sync via files-sync
+      id: sync
+      uses: awinogradov/code-assistants/.github/actions/files-sync@main
+      with:
+        files: ${{ steps.resolve.outputs.files }}
+        token: ${{ inputs.token }}
+        branch: chore/sync-agents-rules
+        title: "MAINTENANCE: Sync agent rules from upstream"
+        body: Automated agent rules sync from upstream.
+        commit-message: "chore: sync agent rules from upstream"

--- a/.github/actions/agents-rules-sync/agents-rules-sync.ts
+++ b/.github/actions/agents-rules-sync/agents-rules-sync.ts
@@ -1,0 +1,98 @@
+/**
+ * Entry point for the agents-rules-sync composite action.
+ *
+ * Reads the current repository's `package.json` via the GitHub contents API,
+ * validates the `agents.rules` field, and emits a single-entry YAML `files`
+ * list as a step output that the downstream `files-sync` step consumes.
+ */
+
+import * as core from '@actions/core';
+import { Octokit } from '@octokit/rest';
+import { stringify as stringifyYaml } from 'yaml';
+
+import { fetchRawContent } from '@code-assistants/actions-lib/fetchRawContent';
+
+import { resolvePackageAgentsRules } from './src/resolvePackageAgentsRules.ts';
+
+interface Env {
+  token: string;
+  destRepo: { owner: string; name: string };
+  sourceRepo: string;
+  sourceRef: string;
+  base: string;
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+
+  if (value === undefined || value === '') {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function readEnv(): Env {
+  const token = required('GITHUB_TOKEN');
+  const destRepoRaw = required('DEST_REPO');
+  const sourceRepo = required('INPUT_SOURCE_REPO');
+  const base = required('INPUT_BASE');
+  const sourceRef = process.env.INPUT_SOURCE_REF ?? '';
+
+  const [owner, name] = destRepoRaw.split('/');
+
+  if (owner === undefined || name === undefined || owner === '' || name === '') {
+    throw new Error(`Invalid DEST_REPO slug: ${destRepoRaw}`);
+  }
+
+  return {
+    token,
+    destRepo: { owner, name },
+    sourceRepo,
+    sourceRef,
+    base,
+  };
+}
+
+async function main(): Promise<void> {
+  const env = readEnv();
+  const octokit = new Octokit({ auth: env.token });
+
+  const raw = await fetchRawContent({
+    octokit,
+    owner: env.destRepo.owner,
+    repo: env.destRepo.name,
+    path: 'package.json',
+    ref: env.base,
+  });
+
+  if (raw === null) {
+    throw new Error(
+      `package.json not found at ${env.destRepo.owner}/${env.destRepo.name}@${env.base}. ` +
+        `Add a package.json with an \`agents.rules\` field — see https://github.com/awinogradov/code-assistants/blob/main/docs/agents-field.md`,
+    );
+  }
+
+  const rules = resolvePackageAgentsRules(raw);
+
+  const entry: Record<string, string> = {
+    repo: env.sourceRepo,
+    source: `rules/${rules}.md`,
+    dest: 'CLAUDE.md',
+  };
+
+  if (env.sourceRef !== '') {
+    entry.ref = env.sourceRef;
+  }
+
+  const filesYaml = stringifyYaml([entry]);
+
+  core.info(`Resolved agents.rules=${rules}; syncing rules/${rules}.md → CLAUDE.md from ${env.sourceRepo}`);
+  core.setOutput('files', filesYaml);
+}
+
+await main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  core.setFailed(message);
+  process.exit(1);
+});

--- a/.github/actions/agents-rules-sync/package.json
+++ b/.github/actions/agents-rules-sync/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "@code-assistants/files-sync-action",
+  "name": "@code-assistants/agents-rules-sync-action",
   "version": "0.0.0",
-  "description": "Composite GitHub Action that syncs declared files from upstream repositories.",
+  "description": "Composite GitHub Action that syncs the stack-appropriate agent rules file into CLAUDE.md.",
   "private": true,
   "type": "module",
   "license": "MIT",
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "bun test",
     "clean": "rm -rf node_modules .turbo"
   },
   "dependencies": {

--- a/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.test.ts
+++ b/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.test.ts
@@ -11,8 +11,12 @@ describe('resolvePackageAgentsRules', () => {
     expect(() => resolvePackageAgentsRules('')).toThrow(/agents-field\.md/);
   });
 
-  test('rejects non-JSON input', () => {
+  test('rejects non-JSON input with docs link and allowed values', () => {
     expect(() => resolvePackageAgentsRules('not json')).toThrow(/not valid JSON/);
+    expect(() => resolvePackageAgentsRules('not json')).toThrow(agentsFieldDocsUrl);
+    for (const value of agentsRulesValues) {
+      expect(() => resolvePackageAgentsRules('not json')).toThrow(new RegExp(`"${value.replace(/\+/g, '\\+')}"`));
+    }
   });
 
   test('rejects package.json without `agents`', () => {

--- a/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.test.ts
+++ b/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  agentsFieldDocsUrl,
+  agentsRulesValues,
+  resolvePackageAgentsRules,
+} from './resolvePackageAgentsRules.ts';
+
+describe('resolvePackageAgentsRules', () => {
+  test('rejects empty input with docs link', () => {
+    expect(() => resolvePackageAgentsRules('')).toThrow(/agents-field\.md/);
+  });
+
+  test('rejects non-JSON input', () => {
+    expect(() => resolvePackageAgentsRules('not json')).toThrow(/not valid JSON/);
+  });
+
+  test('rejects package.json without `agents`', () => {
+    const raw = JSON.stringify({ name: 'demo' });
+    expect(() => resolvePackageAgentsRules(raw)).toThrow(/Missing `agents.rules`/);
+    expect(() => resolvePackageAgentsRules(raw)).toThrow(agentsFieldDocsUrl);
+  });
+
+  test('rejects package.json without `agents.rules`', () => {
+    const raw = JSON.stringify({ name: 'demo', agents: { language: 'typescript' } });
+    expect(() => resolvePackageAgentsRules(raw)).toThrow(/Missing `agents.rules`/);
+    expect(() => resolvePackageAgentsRules(raw)).toThrow(agentsFieldDocsUrl);
+  });
+
+  test('rejects unrecognized `agents.rules` value and lists allowed values', () => {
+    const raw = JSON.stringify({ agents: { rules: 'Deno' } });
+    expect(() => resolvePackageAgentsRules(raw)).toThrow(/Invalid `agents.rules`/);
+    for (const value of agentsRulesValues) {
+      expect(() => resolvePackageAgentsRules(raw)).toThrow(new RegExp(`"${value.replace(/\+/g, '\\+')}"`));
+    }
+  });
+
+  for (const value of agentsRulesValues) {
+    test(`resolves valid value "${value}"`, () => {
+      const raw = JSON.stringify({ name: 'demo', agents: { rules: value } });
+      expect(resolvePackageAgentsRules(raw)).toBe(value);
+    });
+  }
+
+  test('ignores extra fields on `agents` and root', () => {
+    const raw = JSON.stringify({
+      name: 'demo',
+      version: '1.0.0',
+      agents: { rules: 'Bun', language: 'typescript' },
+    });
+    expect(resolvePackageAgentsRules(raw)).toBe('Bun');
+  });
+});

--- a/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.ts
+++ b/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.ts
@@ -75,7 +75,7 @@ function parseJsonOrThrow(raw: string): unknown {
     return JSON.parse(trimmed);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`package.json is not valid JSON: ${message}`);
+    throw new Error(`package.json is not valid JSON: ${message}. ${addInstructions()}`);
   }
 }
 

--- a/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.ts
+++ b/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.ts
@@ -1,0 +1,94 @@
+/**
+ * Validates a `package.json` body and extracts the `agents.rules` value.
+ *
+ * Throws with a helpful, link-decorated error message when the file is malformed,
+ * the `agents` object is missing, or `agents.rules` is unset or invalid.
+ *
+ * @example
+ *   const rules = resolvePackageAgentsRules(await readPackageJson());
+ *   // rules: 'Bun' | 'Bun+React+Tailwind' | 'NodeJS+React' | 'NodeJS+React+Tailwind'
+ *
+ * @see https://github.com/awinogradov/code-assistants/blob/main/docs/agents-field.md
+ */
+
+import { z } from 'zod';
+
+export const agentsRulesValues = [
+  'Bun',
+  'Bun+React+Tailwind',
+  'NodeJS+React',
+  'NodeJS+React+Tailwind',
+] as const;
+
+export type AgentsRules = (typeof agentsRulesValues)[number];
+
+export const agentsFieldDocsUrl =
+  'https://github.com/awinogradov/code-assistants/blob/main/docs/agents-field.md';
+
+const packageJsonSchema = z
+  .object({
+    agents: z
+      .object({ rules: z.unknown().optional() })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export function resolvePackageAgentsRules(raw: string): AgentsRules {
+  const parsed = parseJsonOrThrow(raw);
+  const result = packageJsonSchema.safeParse(parsed);
+
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    throw new Error(`Invalid package.json at ${path}: ${issue.message}. ${addInstructions()}`);
+  }
+
+  const rules = result.data.agents?.rules;
+
+  if (rules === undefined) {
+    throw new Error(missingFieldMessage());
+  }
+
+  if (!isAgentsRules(rules)) {
+    throw new Error(invalidValueMessage());
+  }
+
+  return rules;
+}
+
+function isAgentsRules(value: unknown): value is AgentsRules {
+  return (
+    typeof value === 'string' &&
+    (agentsRulesValues as readonly string[]).includes(value)
+  );
+}
+
+function parseJsonOrThrow(raw: string): unknown {
+  const trimmed = raw.trim();
+
+  if (trimmed === '') {
+    throw new Error(`package.json is empty. ${addInstructions()}`);
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`package.json is not valid JSON: ${message}`);
+  }
+}
+
+function missingFieldMessage(): string {
+  return `Missing \`agents.rules\` in package.json. ${addInstructions()}`;
+}
+
+function invalidValueMessage(): string {
+  const allowed = agentsRulesValues.map((value) => `"${value}"`).join(', ');
+  return `Invalid \`agents.rules\` in package.json. Allowed values: ${allowed}. See ${agentsFieldDocsUrl}`;
+}
+
+function addInstructions(): string {
+  const allowed = agentsRulesValues.map((value) => `"${value}"`).join(', ');
+  return `Add an \`agents.rules\` field to package.json with one of: ${allowed}. See ${agentsFieldDocsUrl}`;
+}

--- a/.github/actions/agents-rules-sync/tsconfig.json
+++ b/.github/actions/agents-rules-sync/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["*.ts", "src/**/*.ts"]
+}

--- a/.github/actions/files-sync/src/changeDetector.ts
+++ b/.github/actions/files-sync/src/changeDetector.ts
@@ -11,7 +11,8 @@
  */
 
 import type { Octokit } from '@octokit/rest';
-import type { RequestError } from '@octokit/request-error';
+
+import { fetchRawContent } from '@code-assistants/actions-lib/fetchRawContent';
 
 import { parseRepoSlug, type SyncEntry } from './parseInputs.ts';
 
@@ -21,53 +22,6 @@ export interface FileChange {
   path: string;
   content: string;
   mode: string;
-}
-
-interface FetchArgs {
-  octokit: Octokit;
-  owner: string;
-  repo: string;
-  path: string;
-  ref?: string;
-}
-
-export async function fetchRawContent({
-  octokit,
-  owner,
-  repo,
-  path,
-  ref,
-}: FetchArgs): Promise<string | null> {
-  try {
-    const response = await octokit.request(
-      'GET /repos/{owner}/{repo}/contents/{path}',
-      {
-        owner,
-        repo,
-        path,
-        ref,
-        headers: { accept: 'application/vnd.github.raw' },
-      },
-    );
-
-    if (typeof response.data !== 'string') {
-      throw new Error(
-        `Expected raw string content from ${owner}/${repo}:${path}${ref ? `@${ref}` : ''}, got ${typeof response.data}`,
-      );
-    }
-
-    return response.data;
-  } catch (error) {
-    const requestError = error as RequestError;
-
-    if (requestError.status === 404) {
-      return null;
-    }
-
-    throw new Error(
-      `Failed to fetch ${owner}/${repo}:${path}${ref ? `@${ref}` : ''}: ${requestError.message}`,
-    );
-  }
 }
 
 interface ComputeArgs {

--- a/.github/actions/lib/package.json
+++ b/.github/actions/lib/package.json
@@ -1,21 +1,20 @@
 {
-  "name": "@code-assistants/files-sync-action",
+  "name": "@code-assistants/actions-lib",
   "version": "0.0.0",
-  "description": "Composite GitHub Action that syncs declared files from upstream repositories.",
+  "description": "Shared helpers for GitHub Actions in this repository.",
   "private": true,
   "type": "module",
   "license": "MIT",
+  "exports": {
+    "./fetchRawContent": "./src/fetchRawContent.ts"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf node_modules .turbo"
   },
   "dependencies": {
-    "@actions/core": "3.0.1",
-    "@code-assistants/actions-lib": "workspace:*",
     "@octokit/request-error": "7.1.0",
-    "@octokit/rest": "22.0.1",
-    "yaml": "2.9.0",
-    "zod": "4.4.3"
+    "@octokit/rest": "22.0.1"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/.github/actions/lib/src/fetchRawContent.ts
+++ b/.github/actions/lib/src/fetchRawContent.ts
@@ -1,0 +1,64 @@
+/**
+ * Fetch raw file content from a GitHub repository via the contents API.
+ *
+ * Returns `null` when the file is not found (HTTP 404). All other HTTP errors
+ * are re-thrown with a descriptive message that includes the resource path.
+ *
+ * @example
+ *   const raw = await fetchRawContent({
+ *     octokit,
+ *     owner: 'awinogradov',
+ *     repo: 'code-assistants',
+ *     path: 'rules/Bun.md',
+ *   });
+ */
+
+import type { Octokit } from '@octokit/rest';
+import type { RequestError } from '@octokit/request-error';
+
+interface FetchRawContentArgs {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  path: string;
+  ref?: string;
+}
+
+export async function fetchRawContent({
+  octokit,
+  owner,
+  repo,
+  path,
+  ref,
+}: FetchRawContentArgs): Promise<string | null> {
+  try {
+    const response = await octokit.request(
+      'GET /repos/{owner}/{repo}/contents/{path}',
+      {
+        owner,
+        repo,
+        path,
+        ref,
+        headers: { accept: 'application/vnd.github.raw' },
+      },
+    );
+
+    if (typeof response.data !== 'string') {
+      throw new Error(
+        `Expected raw string content from ${owner}/${repo}:${path}${ref ? `@${ref}` : ''}, got ${typeof response.data}`,
+      );
+    }
+
+    return response.data;
+  } catch (error) {
+    const requestError = error as RequestError;
+
+    if (requestError.status === 404) {
+      return null;
+    }
+
+    throw new Error(
+      `Failed to fetch ${owner}/${repo}:${path}${ref ? `@${ref}` : ''}: ${requestError.message}`,
+    );
+  }
+}

--- a/.github/actions/lib/tsconfig.json
+++ b/.github/actions/lib/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See the [plugin README](./claude-plugins/autopilot/README.md#installation) for s
 ## GitHub Actions
 
 - [`files-sync`](./.github/actions/files-sync/README.md) — sync declared files from upstream repos and open one PR with the differences
+- [`agents-rules-sync`](./.github/actions/agents-rules-sync/README.md) — sync the stack-appropriate `rules/<stack>.md` into `CLAUDE.md` based on `package.json` `agents.rules`
 
 ## Contributing
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,24 @@
         "lint-staged": "17.0.5",
         "prettier": "3.8.3",
         "turbo": "2.9.14",
+        "typescript": "6.0.3",
         "zod": "3.23.8",
+      },
+    },
+    ".github/actions/agents-rules-sync": {
+      "name": "@code-assistants/agents-rules-sync-action",
+      "version": "0.0.0",
+      "dependencies": {
+        "@actions/core": "3.0.1",
+        "@code-assistants/actions-lib": "workspace:*",
+        "@octokit/request-error": "7.1.0",
+        "@octokit/rest": "22.0.1",
+        "yaml": "2.9.0",
+        "zod": "4.4.3",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+        "typescript": "6.0.3",
       },
     },
     ".github/actions/files-sync": {
@@ -22,10 +39,23 @@
       "version": "0.0.0",
       "dependencies": {
         "@actions/core": "3.0.1",
+        "@code-assistants/actions-lib": "workspace:*",
         "@octokit/request-error": "7.1.0",
         "@octokit/rest": "22.0.1",
         "yaml": "2.9.0",
         "zod": "4.4.3",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+        "typescript": "6.0.3",
+      },
+    },
+    ".github/actions/lib": {
+      "name": "@code-assistants/actions-lib",
+      "version": "0.0.0",
+      "dependencies": {
+        "@octokit/request-error": "7.1.0",
+        "@octokit/rest": "22.0.1",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
@@ -45,6 +75,10 @@
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@code-assistants/actions-lib": ["@code-assistants/actions-lib@workspace:.github/actions/lib"],
+
+    "@code-assistants/agents-rules-sync-action": ["@code-assistants/agents-rules-sync-action@workspace:.github/actions/agents-rules-sync"],
 
     "@code-assistants/files-sync-action": ["@code-assistants/files-sync-action@workspace:.github/actions/files-sync"],
 
@@ -307,6 +341,8 @@
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
+
+    "@code-assistants/agents-rules-sync-action/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@code-assistants/files-sync-action/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 

--- a/package.json
+++ b/package.json
@@ -15,13 +15,18 @@
     "rules": "Bun",
     "language": "typescript"
   },
-  "workspaces": [".github/actions/files-sync"],
+  "workspaces": [
+    ".github/actions/lib",
+    ".github/actions/files-sync",
+    ".github/actions/agents-rules-sync"
+  ],
   "scripts": {
     "prepare": "husky",
     "format": "prettier --write \"**/*.{md,json}\"",
     "format:check": "prettier --check \"**/*.{md,json}\"",
     "validate": "bun scripts/validate-plugins.ts",
     "typecheck": "turbo run typecheck",
+    "test": "turbo run test",
     "lint": "bun run format:check && bun run validate && turbo run typecheck"
   },
   "devDependencies": {
@@ -34,6 +39,7 @@
     "lint-staged": "17.0.5",
     "prettier": "3.8.3",
     "turbo": "2.9.14",
+    "typescript": "6.0.3",
     "zod": "3.23.8"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,10 @@
       "inputs": ["action.yml", "*.ts", "src/**/*.ts", "tsconfig.json", "package.json"],
       "outputs": []
     },
+    "test": {
+      "inputs": ["*.ts", "src/**/*.ts", "tsconfig.json", "package.json"],
+      "outputs": []
+    },
     "clean": {
       "cache": false
     }


### PR DESCRIPTION
Adds a one-line GitHub Action that keeps a consumer repository's CLAUDE.md in sync with the stack rules file declared via the package.json agents.rules field. Removes the need for each consumer to hand-write a files-sync YAML payload and to update it whenever the stack changes.

- New composite action .github/actions/agents-rules-sync resolves agents.rules from the consumer's package.json (via the contents API, no checkout required) and delegates to files-sync@main with a single-entry files list mapping rules/<stack>.md to CLAUDE.md
- PR-shaping inputs (branch chore/sync-agents-rules, MAINTENANCE title, conventional commit message) are fixed by design so the new action never collides with files-sync's default branch
- Extracts fetchRawContent from files-sync into a new .github/actions/lib workspace shared by both actions
- Fails with a link to docs/agents-field.md and the list of accepted values when agents.rules is missing or invalid
- 10 Bun unit tests cover missing, empty, non-JSON, and invalid input cases plus each of the four valid stack values

---

**Issues:**

Closes #11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a composite GitHub Action to auto-sync the stack-appropriate `rules/<stack>.md` into `CLAUDE.md` based on `package.json` `agents.rules`, removing custom `files-sync` YAML in consumers. Closes #11.

- **New Features**
  - New action `.github/actions/agents-rules-sync` reads `agents.rules` via the Contents API (no checkout) and feeds `rules/<stack>.md → CLAUDE.md` to `files-sync`.
  - Fixed PR shape: branch `chore/sync-agents-rules`, preset title/body/commit message; opens/reuses PR only when changes exist.
  - Inputs: `token`, `source-repo`, `source-ref`. Outputs: `changed-files`, `pr-number`, `pr-url`.
  - Validation now always includes a docs link and allowed values, including malformed JSON; 10 Bun tests cover valid stacks and error cases.

- **Refactors**
  - Extracted `fetchRawContent` to `@code-assistants/actions-lib` and updated `files-sync` to use it.
  - Added workspaces for `lib` and `agents-rules-sync`, a `turbo` `test` task, root `test` script, `typescript` dev dep, and linked the new action from the README.

<sup>Written for commit beece90bb0bfc85a6757ec52b9a912602f38f2e0. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/12?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

