### PR TITLE
HOTFIX: Require explicit token input on sync actions

### DIFF
--- a/.github/actions/agents-rules-sync/README.md
+++ b/.github/actions/agents-rules-sync/README.md
@@ -73,7 +73,7 @@ Pass one of the following:
 
 - A **classic Personal Access Token** with the `repo` scope.
 - A **fine-grained Personal Access Token** scoped to this repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on the source repo.
-- A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. If the org enforces the policy above, App tokens also require it to be enabled.
+- A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
 
 Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
 

--- a/.github/actions/agents-rules-sync/README.md
+++ b/.github/actions/agents-rules-sync/README.md
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: awinogradov/code-assistants/.github/actions/agents-rules-sync@v1
+        with:
+          token: ${{ secrets.SYNC_PAT }}
 ```
 
 The consumer repository must declare an `agents.rules` field in its root `package.json`:
@@ -46,11 +48,11 @@ Accepted values: `Bun`, `Bun+React+Tailwind`, `NodeJS+React`, `NodeJS+React+Tail
 
 ## Inputs
 
-| Input         | Required | Default                       | Description                                                                                       |
-| ------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------- |
-| `token`       | no       | `${{ github.token }}`         | Token used to read `package.json`, fetch the source rules file, and create the PR.                |
-| `source-repo` | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.                   |
-| `source-ref`  | no       | _(empty)_                     | Branch, tag, or SHA to read the source rules file from. Empty → source repository default branch. |
+| Input         | Required | Default                       | Description                                                                                                                                                                                      |
+| ------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `token`       | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
+| `source-repo` | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.                                                                                                                  |
+| `source-ref`  | no       | _(empty)_                     | Branch, tag, or SHA to read the source rules file from. Empty → source repository default branch.                                                                                                |
 
 PR-shaping inputs (branch, title, body, commit message) are fixed by design — see
 [Behavior](#behavior).
@@ -65,13 +67,17 @@ PR-shaping inputs (branch, title, body, commit message) are fixed by design — 
 
 ## Permissions
 
-The token (default `${{ github.token }}`) needs:
+The `token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever this repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
 
-- `contents: write` — to create the branch, blobs, tree, and commit on the consumer repo.
-- `pull-requests: write` — to open or reuse the PR.
+Pass one of the following:
 
-For private source repositories or cross-org reads, provide a token with `contents: read`
-scope on the source repository.
+- A **classic Personal Access Token** with the `repo` scope.
+- A **fine-grained Personal Access Token** scoped to this repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on the source repo.
+- A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. If the org enforces the policy above, App tokens also require it to be enabled.
+
+Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
+
+See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and [GitHub App installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
 
 ## Behavior
 

--- a/.github/actions/agents-rules-sync/action.yml
+++ b/.github/actions/agents-rules-sync/action.yml
@@ -3,9 +3,9 @@ description: Sync the stack-appropriate agent rules file from an upstream reposi
 
 inputs:
   token:
-    description: GitHub token used to read the source rules file and create the PR in the current repository. Defaults to the workflow token.
-    required: false
-    default: ${{ github.token }}
+    description: |
+      PAT (classic with `repo`, or fine-grained with `contents: write` + `pull-requests: write` on this repo) or GitHub App installation token. The workflow's default `GITHUB_TOKEN` is not supported — it cannot create pull requests when the repo/org has "Allow GitHub Actions to create and approve pull requests" disabled, and the resulting 403 is opaque. See README for setup.
+    required: true
   source-repo:
     description: Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.
     required: false

--- a/.github/actions/agents-rules-sync/agents-rules-sync.ts
+++ b/.github/actions/agents-rules-sync/agents-rules-sync.ts
@@ -32,8 +32,23 @@ function required(name: string): string {
   return value;
 }
 
+function requiredToken(): string {
+  const value = process.env.GITHUB_TOKEN;
+
+  if (value === undefined || value === '') {
+    throw new Error(
+      'GITHUB_TOKEN is empty. Pass an explicit PAT or GitHub App installation token via the action\'s `token` input — ' +
+        'the workflow\'s default `GITHUB_TOKEN` is not supported because it cannot create pull requests when the repo/org ' +
+        'disables "Allow GitHub Actions to create and approve pull requests". ' +
+        'See https://github.com/awinogradov/code-assistants/blob/main/.github/actions/agents-rules-sync/README.md#permissions',
+    );
+  }
+
+  return value;
+}
+
 function readEnv(): Env {
-  const token = required('GITHUB_TOKEN');
+  const token = requiredToken();
   const destRepoRaw = required('DEST_REPO');
   const sourceRepo = required('INPUT_SOURCE_REPO');
   const base = required('INPUT_BASE');

--- a/.github/actions/files-sync/README.md
+++ b/.github/actions/files-sync/README.md
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: awinogradov/code-assistants/.github/actions/files-sync@v1
         with:
+          token: ${{ secrets.SYNC_PAT }}
           files: |
             - repo: awinogradov/code-assistants
               source: CONTRIBUTING.md
@@ -37,15 +38,15 @@ jobs:
 
 ## Inputs
 
-| Input            | Required | Default                                           | Description                                                                               |
-| ---------------- | -------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `files`          | yes      | —                                                 | YAML list of entries. Each item: `repo` (`owner/name`), `source`, `dest`, optional `ref`. |
-| `token`          | no       | `${{ github.token }}`                             | Token used for source reads and PR creation. Override for private cross-repo sources.     |
-| `base`           | no       | `${{ github.event.repository.default_branch }}`   | Base branch the PR targets.                                                               |
-| `branch`         | no       | `chore/sync-files`                                | Head branch the PR uses. Force-updated on subsequent runs.                                |
-| `title`          | no       | `MAINTENANCE: Sync files from upstream`           | PR title. Uses the `MAINTENANCE:` prefix per CONTRIBUTING.md.                             |
-| `body`           | no       | `Automated file sync from upstream repositories.` | PR body intro. The action auto-appends a `**Updated files:**` bullet list.                |
-| `commit-message` | no       | `chore: sync files from upstream`                 | Conventional commit message for the sync commit.                                          |
+| Input            | Required | Default                                           | Description                                                                                                                                                                                                 |
+| ---------------- | -------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `files`          | yes      | —                                                 | YAML list of entries. Each item: `repo` (`owner/name`), `source`, `dest`, optional `ref`.                                                                                                                   |
+| `token`          | yes      | —                                                 | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on the destination repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
+| `base`           | no       | `${{ github.event.repository.default_branch }}`   | Base branch the PR targets.                                                                                                                                                                                 |
+| `branch`         | no       | `chore/sync-files`                                | Head branch the PR uses. Force-updated on subsequent runs.                                                                                                                                                  |
+| `title`          | no       | `MAINTENANCE: Sync files from upstream`           | PR title. Uses the `MAINTENANCE:` prefix per CONTRIBUTING.md.                                                                                                                                               |
+| `body`           | no       | `Automated file sync from upstream repositories.` | PR body intro. The action auto-appends a `**Updated files:**` bullet list.                                                                                                                                  |
+| `commit-message` | no       | `chore: sync files from upstream`                 | Conventional commit message for the sync commit.                                                                                                                                                            |
 
 ### Entry fields
 
@@ -64,12 +65,17 @@ jobs:
 
 ## Permissions
 
-The token (default `${{ github.token }}`) needs:
+The `token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever the destination repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
 
-- `contents: write` — to create the branch, blobs, tree, and commit on the destination repo.
-- `pull-requests: write` — to open or reuse the PR.
+Pass one of the following:
 
-For private source repositories or cross-org reads, provide a token with `contents: read` scope on the source repos.
+- A **classic Personal Access Token** with the `repo` scope.
+- A **fine-grained Personal Access Token** scoped to the destination repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on each source repo.
+- A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. If the destination org enforces the policy above, App tokens also require it to be enabled.
+
+Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
+
+See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and [GitHub App installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
 
 ## Behavior
 

--- a/.github/actions/files-sync/README.md
+++ b/.github/actions/files-sync/README.md
@@ -71,7 +71,7 @@ Pass one of the following:
 
 - A **classic Personal Access Token** with the `repo` scope.
 - A **fine-grained Personal Access Token** scoped to the destination repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on each source repo.
-- A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. If the destination org enforces the policy above, App tokens also require it to be enabled.
+- A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
 
 Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
 

--- a/.github/actions/files-sync/action.yml
+++ b/.github/actions/files-sync/action.yml
@@ -6,9 +6,9 @@ inputs:
     description: YAML list of sync entries. Each item must define `repo` (owner/name), `source`, `dest`, and optionally `ref`.
     required: true
   token:
-    description: GitHub token used to read source files and create the PR in the current repository. Defaults to the workflow token.
-    required: false
-    default: ${{ github.token }}
+    description: |
+      PAT (classic with `repo`, or fine-grained with `contents: write` + `pull-requests: write` on the destination repo) or GitHub App installation token. The workflow's default `GITHUB_TOKEN` is not supported — it cannot create pull requests when the destination repo/org has "Allow GitHub Actions to create and approve pull requests" disabled, and the resulting 403 is opaque. See README for setup.
+    required: true
   base:
     description: Base branch the PR targets.
     required: false

--- a/.github/actions/files-sync/files-sync.ts
+++ b/.github/actions/files-sync/files-sync.ts
@@ -35,7 +35,7 @@ interface Env {
 }
 
 function readEnv(): Env {
-  const token = required('GITHUB_TOKEN');
+  const token = requiredToken();
   const filesInput = required('FILES_INPUT');
   const repository = required('GITHUB_REPOSITORY');
   const base = required('INPUT_BASE');
@@ -63,6 +63,21 @@ function required(name: string): string {
 
   if (value === undefined || value === '') {
     throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function requiredToken(): string {
+  const value = process.env.GITHUB_TOKEN;
+
+  if (value === undefined || value === '') {
+    throw new Error(
+      'GITHUB_TOKEN is empty. Pass an explicit PAT or GitHub App installation token via the action\'s `token` input — ' +
+        'the workflow\'s default `GITHUB_TOKEN` is not supported because it cannot create pull requests when the destination ' +
+        'repo/org disables "Allow GitHub Actions to create and approve pull requests". ' +
+        'See https://github.com/awinogradov/code-assistants/blob/main/.github/actions/files-sync/README.md#permissions',
+    );
   }
 
   return value;

--- a/.github/actions/files-sync/package.json
+++ b/.github/actions/files-sync/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "bun test",
     "clean": "rm -rf node_modules .turbo"
   },
   "dependencies": {

--- a/.github/actions/files-sync/src/createSyncPullRequest.test.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Octokit } from '@octokit/rest';
+
+import type { FileChange } from './changeDetector.ts';
+import { createSyncPullRequest } from './createSyncPullRequest.ts';
+
+interface MockOverrides {
+  listOpenPrs?: () => Promise<{ data: Array<{ number: number; html_url: string }> }>;
+  createPr?: () => Promise<{ data: { number: number; html_url: string } }>;
+}
+
+function makeOctokit(overrides: MockOverrides = {}): Octokit {
+  const listOpenPrs = overrides.listOpenPrs ?? (async () => ({ data: [] }));
+  const createPr =
+    overrides.createPr ??
+    (async () => ({ data: { number: 42, html_url: 'https://github.com/owner/repo/pull/42' } }));
+
+  return {
+    rest: {
+      git: {
+        getRef: async () => ({ data: { object: { sha: 'base-sha' } } }),
+        getCommit: async () => ({ data: { tree: { sha: 'base-tree-sha' } } }),
+        createBlob: async () => ({ data: { sha: 'blob-sha' } }),
+        createTree: async () => ({ data: { sha: 'new-tree-sha' } }),
+        createCommit: async () => ({ data: { sha: 'new-commit-sha' } }),
+        createRef: async () => ({ data: {} }),
+        updateRef: async () => ({ data: {} }),
+      },
+      pulls: {
+        list: listOpenPrs,
+        create: createPr,
+      },
+    },
+  } as unknown as Octokit;
+}
+
+const baseArgs = {
+  destRepo: { owner: 'owner', name: 'repo' },
+  base: 'main',
+  branch: 'chore/sync',
+  title: 'Sync',
+  body: 'body',
+  commitMessage: 'chore: sync',
+  changes: [{ path: 'CLAUDE.md', content: 'hello', mode: '100644' }] satisfies FileChange[],
+};
+
+describe('createSyncPullRequest', () => {
+  test('returns PR shape on happy path', async () => {
+    const octokit = makeOctokit();
+
+    const pr = await createSyncPullRequest({ octokit, ...baseArgs });
+
+    expect(pr).toEqual({ number: 42, htmlUrl: 'https://github.com/owner/repo/pull/42' });
+  });
+
+  test('rethrows 403 from pulls.create with PAT / GitHub App guidance and README link', async () => {
+    const octokit = makeOctokit({
+      createPr: async () => {
+        const error = new Error('GitHub Actions is not permitted to create or approve pull requests');
+        Object.assign(error, { status: 403 });
+        throw error;
+      },
+    });
+
+    const promise = createSyncPullRequest({ octokit, ...baseArgs });
+
+    await expect(promise).rejects.toThrow(/PAT or GitHub App/);
+    await expect(promise).rejects.toThrow(/owner\/repo/);
+    await expect(promise).rejects.toThrow(/files-sync\/README\.md#permissions/);
+  });
+
+  test('rethrows non-403 errors unchanged', async () => {
+    const octokit = makeOctokit({
+      createPr: async () => {
+        const error = new Error('boom');
+        Object.assign(error, { status: 500 });
+        throw error;
+      },
+    });
+
+    await expect(createSyncPullRequest({ octokit, ...baseArgs })).rejects.toThrow(/^boom$/);
+  });
+});

--- a/.github/actions/files-sync/src/createSyncPullRequest.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.ts
@@ -189,8 +189,7 @@ async function upsertPullRequest({
       throw new Error(
         `Refused to create pull request in ${owner}/${repo}: ${requestError.message}. ` +
           'Confirm the `token` input is a PAT or GitHub App installation token with `contents: write` + `pull-requests: write` ' +
-          `on ${owner}/${repo} (not the workflow's default \`GITHUB_TOKEN\`), and that the repo/org has ` +
-          '"Allow GitHub Actions to create and approve pull requests" enabled when using a GitHub App token. ' +
+          `on ${owner}/${repo} (not the workflow's default \`GITHUB_TOKEN\`). ` +
           'See https://github.com/awinogradov/code-assistants/blob/main/.github/actions/files-sync/README.md#permissions',
         { cause: error },
       );

--- a/.github/actions/files-sync/src/createSyncPullRequest.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.ts
@@ -171,14 +171,31 @@ async function upsertPullRequest({
     return { number: open.number, htmlUrl: open.html_url };
   }
 
-  const created = await octokit.rest.pulls.create({
-    owner,
-    repo,
-    base,
-    head: branch,
-    title,
-    body,
-  });
+  try {
+    const created = await octokit.rest.pulls.create({
+      owner,
+      repo,
+      base,
+      head: branch,
+      title,
+      body,
+    });
 
-  return { number: created.data.number, htmlUrl: created.data.html_url };
+    return { number: created.data.number, htmlUrl: created.data.html_url };
+  } catch (error) {
+    const requestError = error as RequestError;
+
+    if (requestError.status === 403) {
+      throw new Error(
+        `Refused to create pull request in ${owner}/${repo}: ${requestError.message}. ` +
+          'Confirm the `token` input is a PAT or GitHub App installation token with `contents: write` + `pull-requests: write` ' +
+          `on ${owner}/${repo} (not the workflow's default \`GITHUB_TOKEN\`), and that the repo/org has ` +
+          '"Allow GitHub Actions to create and approve pull requests" enabled when using a GitHub App token. ' +
+          'See https://github.com/awinogradov/code-assistants/blob/main/.github/actions/files-sync/README.md#permissions',
+        { cause: error },
+      );
+    }
+
+    throw error;
+  }
 }


### PR DESCRIPTION
The files-sync and agents-rules-sync actions defaulted the `token` input to `${{ github.token }}`, which silently fails with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever the destination repo or its org disables the corresponding workflow-permissions toggle — as seen in https://github.com/awinogradov/symbiot/actions/runs/26237871034/job/77215992685. This PR removes the misleading default, makes `token` required, and surfaces actionable guidance when the wrong token is passed or when GitHub still refuses the PR.

- Mark `token` as required on both action.yml files and drop the `${{ github.token }}` default
- Add a `requiredToken()` helper in both entry points that points users at PAT / GitHub App setup and the relevant README section on missing token
- Catch 403 from `octokit.rest.pulls.create` in createSyncPullRequest and rethrow with destination repo, PAT/App guidance, and a link to the permissions docs (preserves the original error via `Error.cause`)
- Add createSyncPullRequest.test.ts covering the happy path, the 403 rethrow, and non-403 pass-through; wire `bun test` into the files-sync package
- Rewrite the Permissions section, Inputs table, and Usage snippet in both READMEs to document classic PAT, fine-grained PAT, and GitHub App installation token options

---

**Release notes:**

- BREAKING: The `token` input on `files-sync` and `agents-rules-sync` is now required — pass a PAT or GitHub App installation token via `token: ${{ secrets.<NAME> }}`. The workflow's default `GITHUB_TOKEN` is no longer supported.
- Improved error messages when the PR creation fails or the token is missing, with links to the actions' permissions docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an explicit `token` for the `files-sync` and `agents-rules-sync` actions to prevent opaque 403s when `GITHUB_TOKEN` can’t open PRs. Clarifies GitHub App token behavior, improves error messages, updates docs, and adds tests.

- **Bug Fixes**
  - Drop default `${{ github.token }}` and mark `token` as required in both actions.
  - Add `requiredToken()` to surface missing-token guidance; catch 403 on PR creation and rethrow with repo context, PAT/App guidance, and a README link.
  - Update READMEs (Inputs, Permissions, Usage) to require `token: ${{ secrets.SYNC_PAT }}` and clarify that the workflow-permissions toggle gates `GITHUB_TOKEN` only; GitHub App tokens are unaffected. Add tests and wire `bun test`.

- **Migration**
  - Create a secret (e.g., `SYNC_PAT`) with a classic PAT (`repo`), a fine‑grained PAT (`Contents: Read and write`, `Pull requests: Read and write`), or a GitHub App installation token with equivalent permissions.
  - Pass it to both actions: `token: ${{ secrets.SYNC_PAT }}`. For private source repos, also grant `Contents: Read` on the source.

<sup>Written for commit eff54de5f7d7e0dbb244e3654908370c013a2766. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/13?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

