### PR TITLE
HOTFIX: Render sync-action step summary with line breaks

### DIFF
--- a/.github/actions/agents-rules-sync/agents-rules-sync.ts
+++ b/.github/actions/agents-rules-sync/agents-rules-sync.ts
@@ -105,12 +105,13 @@ async function main(): Promise<void> {
   core.info(`Resolved agents.rules=${rules}; syncing rules/${rules}.md → CLAUDE.md from ${env.sourceRepo}`);
   core.setOutput('files', filesYaml);
 
-  core.summary
-    .addHeading('Agents rules sync', 3)
-    .addRaw(
-      `Resolved \`agents.rules=${rules}\` → syncing \`rules/${rules}.md\` to \`CLAUDE.md\` from ${env.sourceRepo}.`,
-      true,
-    );
+  const summary = [
+    '### Agents rules sync',
+    '',
+    `Resolved \`agents.rules=${rules}\` → syncing \`rules/${rules}.md\` to \`CLAUDE.md\` from ${env.sourceRepo}.`,
+    '',
+  ].join('\n');
+  await core.summary.addRaw(summary).write();
 }
 
 await main().catch((error: unknown) => {

--- a/.github/actions/files-sync/files-sync.ts
+++ b/.github/actions/files-sync/files-sync.ts
@@ -93,12 +93,17 @@ function composeBody(intro: string, paths: string[]): string {
 
 async function writeNoChangesSummary(entries: SyncEntry[]): Promise<void> {
   const sources = entries.map((entry) => `${entry.repo}:${entry.source} → ${entry.dest}`);
-  await core.summary
-    .addHeading('Files sync', 3)
-    .addRaw('No file differences detected. No PR created.', true)
-    .addRaw('**Checked entries:**', true)
-    .addRaw(formatFileList(sources), true)
-    .write();
+  const body = [
+    '### Files sync',
+    '',
+    'No file differences detected. No PR created.',
+    '',
+    '**Checked entries:**',
+    '',
+    formatFileList(sources),
+    '',
+  ].join('\n');
+  await core.summary.addRaw(body).write();
 }
 
 async function writePrReadySummary(
@@ -106,12 +111,17 @@ async function writePrReadySummary(
   title: string,
   paths: string[],
 ): Promise<void> {
-  await core.summary
-    .addHeading('Files sync', 3)
-    .addRaw(`PR ready: [#${pr.number}](${pr.htmlUrl}) — ${title}`, true)
-    .addRaw('**Updated files:**', true)
-    .addRaw(formatFileList(paths), true)
-    .write();
+  const body = [
+    '### Files sync',
+    '',
+    `PR ready: [#${pr.number}](${pr.htmlUrl}) — ${title}`,
+    '',
+    '**Updated files:**',
+    '',
+    formatFileList(paths),
+    '',
+  ].join('\n');
+  await core.summary.addRaw(body).write();
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
The step-summary block written by files-sync rendered as a single line because addRaw(text, true) only appends a single \n — markdown needs a blank line for paragraph breaks. The agents-rules-sync heading was also missing because GITHUB_STEP_SUMMARY is per-step (each composite-action entry-point runs in its own process), so the buffered summary was never flushed.

- Build each summary as joined lines with blank-line separators between heading, paragraph, and bullet list
- Call core.summary.write() in agents-rules-sync.ts so its heading is flushed to its own step's summary file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub Actions step summaries for `files-sync` and `agents-rules-sync` so headings and lists render with line breaks. Each action now flushes its own summary, restoring the missing Agents rules heading.

- Bug Fixes
  - Build summary bodies as joined lines with blank-line separators so Markdown renders paragraphs and lists.
  - In `agents-rules-sync`, call `core.summary.write()` to flush the step’s summary to `GITHUB_STEP_SUMMARY`.

<sup>Written for commit e3ebb69904f7960a88f72c09f75f2b8183f005f3. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/15?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

