### PR TITLE
MAINTENANCE: Sync TypeScript version to 6.x in Bun rule docs

### DIFF
--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -39,7 +39,7 @@ Before making any changes:
 
 ### 2.1 Technology Stack
 
-- Bun, TypeScript 5.x, React 19, Vite
+- Bun, TypeScript 6.x, React 19, Vite
 - Tailwind CSS for styling
 - shadcn/ui + Radix UI for components
 - React Router for routing

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -37,7 +37,7 @@ Before making any changes:
 
 ### 2.1 Technology Stack
 
-- Bun, TypeScript 5.x
+- Bun, TypeScript 6.x
 - ESLint for linting
 - Prettier for formatting
 


### PR DESCRIPTION
Aligns the TypeScript version listed in the Bun-stack rule docs with the installed `typescript@6.0.3` pin. The React-stack rule docs already reference 6.x, so no further changes are needed there.

- Update `rules/Bun.md` Technology Stack to TypeScript 6.x
- Update `rules/Bun+React+Tailwind.md` Technology Stack to TypeScript 6.x

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the TypeScript version in Bun rule docs to 6.x to match the pinned `typescript@6.0.3`.

Updated Technology Stack entries in `rules/Bun.md` and `rules/Bun+React+Tailwind.md` from TypeScript 5.x to 6.x.

<sup>Written for commit 21cee08d3a040d299482bae6b7943d8d8bb9b7f9. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/16?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

