### PR TITLE
Add contributing-sync action for syncing CONTRIBUTING, CODE_OF_CONDUCT, and LICENSE

### DIFF
--- a/.github/actions/contributing-sync/README.md
+++ b/.github/actions/contributing-sync/README.md
@@ -1,0 +1,87 @@
+# Contributing sync
+
+Composite GitHub Action that syncs `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md`
+from an upstream repository into the current repository and opens a single pull request with
+the differences.
+
+The action builds a fixed three-entry sync list and delegates the diff and PR mechanics to the
+[`files-sync`](../files-sync/README.md) action. It does not require `actions/checkout` and
+never touches the runner's working tree.
+
+## Usage
+
+```yaml
+name: Sync contributing files
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: awinogradov/code-assistants/.github/actions/contributing-sync@v1
+        with:
+          token: ${{ secrets.SYNC_PAT }}
+```
+
+## Inputs
+
+| Input         | Required | Default                       | Description                                                                                                                                                                                      |
+| ------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `token`       | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
+| `source-repo` | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the canonical `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md`.                                                                       |
+| `source-ref`  | no       | _(empty)_                     | Branch, tag, or SHA to read the source files from. Empty → source repository default branch.                                                                                                     |
+
+PR-shaping inputs (branch, title, body, commit message) are fixed by design — see
+[Behavior](#behavior).
+
+## Outputs
+
+| Output          | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `changed-files` | Newline-separated list of destination paths that were updated.       |
+| `pr-number`     | Number of the opened or reused PR. Empty when no changes detected.   |
+| `pr-url`        | HTML URL of the opened or reused PR. Empty when no changes detected. |
+
+## Permissions
+
+The `token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever this repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
+
+Pass one of the following:
+
+- A **classic Personal Access Token** with the `repo` scope.
+- A **fine-grained Personal Access Token** scoped to this repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on the source repo.
+- A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
+
+Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
+
+See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and [GitHub App installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
+
+## Behavior
+
+- Delegates to `files-sync` with three fixed entries — one for each of `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, and `LICENSE.md` — sourced from `source-repo` at `source-ref`.
+- The PR is opened on the fixed branch `maintenance-sync-contributing` with the title
+  `MAINTENANCE: Sync contributing files from upstream` and the commit message
+  `chore: sync contributing files from upstream`. These values are not configurable so the
+  action cannot collide with `files-sync`'s default branch and so every consumer gets the
+  same one-line setup.
+- The head branch is force-updated on every run (inherited from `files-sync`); local edits
+  to any of the three synced files will be overwritten when the upstream files change.
+- If all three destination files already match upstream, no PR is created.
+- Missing source files fail the run with `Source not found at <repo>:<path>`.
+
+## Versioning
+
+Reference the action by tag of the autopilot repo, e.g.:
+
+```yaml
+uses: awinogradov/code-assistants/.github/actions/contributing-sync@v1
+```

--- a/.github/actions/contributing-sync/action.yml
+++ b/.github/actions/contributing-sync/action.yml
@@ -1,0 +1,63 @@
+name: Contributing sync
+description: Sync CONTRIBUTING.md, CODE_OF_CONDUCT.md, and LICENSE.md from an upstream repository into the current repository.
+
+inputs:
+  token:
+    description: |
+      PAT (classic with `repo`, or fine-grained with `contents: write` + `pull-requests: write` on this repo) or GitHub App installation token. The workflow's default `GITHUB_TOKEN` is not supported — it cannot create pull requests when the repo/org has "Allow GitHub Actions to create and approve pull requests" disabled, and the resulting 403 is opaque. See README for setup.
+    required: true
+  source-repo:
+    description: Source repository in `owner/name` form that hosts the canonical `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md`.
+    required: false
+    default: awinogradov/code-assistants
+  source-ref:
+    description: Branch, tag, or SHA to read the source files from. Defaults to the source repository's default branch.
+    required: false
+    default: ""
+
+outputs:
+  changed-files:
+    description: Newline-separated list of destination paths that were updated. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.changed-files }}
+  pr-number:
+    description: Number of the opened or reused PR. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.pr-number }}
+  pr-url:
+    description: HTML URL of the opened or reused PR. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.pr-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build files list
+      id: resolve
+      shell: bash
+      env:
+        INPUT_SOURCE_REPO: ${{ inputs.source-repo }}
+        INPUT_SOURCE_REF: ${{ inputs.source-ref }}
+      run: |
+        set -euo pipefail
+        paths=(CONTRIBUTING.md CODE_OF_CONDUCT.md LICENSE.md)
+        {
+          echo "files<<__EOF__"
+          for path in "${paths[@]}"; do
+            echo "- repo: ${INPUT_SOURCE_REPO}"
+            echo "  source: ${path}"
+            echo "  dest: ${path}"
+            if [ -n "${INPUT_SOURCE_REF}" ]; then
+              echo "  ref: ${INPUT_SOURCE_REF}"
+            fi
+          done
+          echo "__EOF__"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Sync via files-sync
+      id: sync
+      uses: awinogradov/code-assistants/.github/actions/files-sync@main
+      with:
+        files: ${{ steps.resolve.outputs.files }}
+        token: ${{ inputs.token }}
+        branch: maintenance-sync-contributing
+        title: "MAINTENANCE: Sync contributing files from upstream"
+        body: Automated contributing files sync from upstream.
+        commit-message: "chore: sync contributing files from upstream"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See the [plugin README](./claude-plugins/autopilot/README.md#installation) for s
 
 - [`files-sync`](./.github/actions/files-sync/README.md) — sync declared files from upstream repos and open one PR with the differences
 - [`agents-rules-sync`](./.github/actions/agents-rules-sync/README.md) — sync the stack-appropriate `rules/<stack>.md` into `CLAUDE.md` based on `package.json` `agents.rules`
+- [`contributing-sync`](./.github/actions/contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md` from upstream
 
 ## Contributing
 


### PR DESCRIPTION
Adds a sibling to `agents-rules-sync` so consumer repos can keep their `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md` aligned with the canonical upstream with a one-line workflow step.

- New pure-composite action at `.github/actions/contributing-sync/` (no TS, no workspace entry) that builds a fixed 3-entry YAML and delegates to `files-sync`
- Inputs mirror `agents-rules-sync`: required `token`, optional `source-repo` (default `awinogradov/code-assistants`), optional `source-ref`
- Re-exports `changed-files`, `pr-number`, and `pr-url` from `files-sync`; PR is fixed to branch `maintenance-sync-contributing` with a `MAINTENANCE:`-prefixed title
- Links the new action from the root README's GitHub Actions section

---

**Issues:**

Closes #17

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `contributing-sync`, a composite action to sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md` from an upstream repo and open a single PR with any changes. Closes #17.

- **New Features**
  - New action at `.github/actions/contributing-sync/` that builds a fixed 3-file list and delegates syncing/PRs to `files-sync` (no checkout; no workspace changes).
  - Inputs: `token` (required), `source-repo` (default `awinogradov/code-assistants`), `source-ref` (optional). Outputs re-exported: `changed-files`, `pr-number`, `pr-url`.
  - PR is fixed to branch `maintenance-sync-contributing` with a `MAINTENANCE:` title and `chore:` commit message to avoid collisions and keep setup simple.
  - Linked from the root README under GitHub Actions.

<sup>Written for commit 16e82be0657bbbe6f808c72cbf3cc05f7befb4dd. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/18?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

