### PR TITLE
Add contributing-check action to enforce CONTRIBUTING.md rules in CI

### DIFF
--- a/.github/actions/contributing-check/README.md
+++ b/.github/actions/contributing-check/README.md
@@ -1,0 +1,82 @@
+# Contributing check
+
+Composite GitHub Action that validates the three CONTRIBUTING.md enforcement points on a pull
+request — branch name, commit messages, and PR title — in a single job. It wraps existing
+community actions (`deepakputhraya/action-branch-name`, `wagoid/commitlint-github-action`,
+`amannn/action-semantic-pull-request`) so consumer repos get the full check set with one `uses:`
+line.
+
+The action is propagated to consumer repos together with [`contributing.yml`](../../workflows/contributing.yml)
+by [`contributing-sync`](../contributing-sync/README.md), so every repo using the sync gets the
+same enforcement automatically.
+
+## Usage
+
+```yaml
+name: Contributing
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: contributing-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/contributing-check
+```
+
+## Inputs
+
+| Input  | Required | Default | Description                                                                                                        |
+| ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| _none_ | —        | —       | The action is configuration-free. Rules and regexes are baked in so every consumer enforces identical conventions. |
+
+## Outputs
+
+| Output | Description                                                                                                                                      |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| _none_ | The action signals violations through job status. Failed steps surface as inline annotations on the PR diff and a red check on the merge button. |
+
+## Permissions
+
+The workflow's default `GITHUB_TOKEN` is sufficient — no PAT or App token required. The action only reads:
+
+- `contents: read` — `actions/checkout` needs it so `wagoid/commitlint-github-action` can walk the PR commit range.
+- `pull-requests: read` — `amannn/action-semantic-pull-request` reads the PR title via the API.
+
+The action never writes to the repository or to the PR, so writes are not requested.
+
+## Behavior
+
+The action runs four steps sequentially. The first failure short-circuits the job — later steps do not run.
+
+1. **Branch name** — [`deepakputhraya/action-branch-name@v1.0.0`](https://github.com/deepakputhraya/action-branch-name) enforces the regex `^(issue-\d+-[a-z0-9]+(-[a-z0-9]+)*|(hotfix|trivial|maintenance|proposal)-[a-z0-9]+(-[a-z0-9]+)*|release-\d+\.\d+\.\d+)$` with `min_length: 5`, `max_length: 100`, and `ignore: main,master`. This matches the CONTRIBUTING.md `Branches` section.
+2. **Checkout** — `actions/checkout@v4` with `fetch-depth: 0` so commitlint can resolve the full PR commit range.
+3. **Commit messages** — [`wagoid/commitlint-github-action@v6`](https://github.com/wagoid/commitlint-github-action) runs against `./commitlint.config.mjs` with `failOnWarnings: false`. Level-1 (warning) rules — `body-max-line-length` and `footer-max-line-length` — are surfaced as warnings but do not block merge. Level-2 (error) rules — including the custom `body-required-for-types`, `no-issue-id-in-subject`, and `no-ai-coauthored-by` — block merge.
+4. **PR title (semantic)** — [`amannn/action-semantic-pull-request@v6`](https://github.com/amannn/action-semantic-pull-request) accepts the special prefixes (`HOTFIX`, `TRIVIAL`, `MAINTENANCE`, `PROPOSAL`, `Release`) and any capitalized business-style title via the `[A-Z]\w*` type pattern. Titles ending in a period are rejected with a CONTRIBUTING.md cross-reference.
+5. **PR title length** — Inline bash check fails the job if the PR title exceeds 120 characters. The title is read via the `PR_TITLE` env var (not shell-interpolated) to avoid command injection from a hostile title.
+
+All third-party action references are pinned to commit SHAs with `# vX.Y.Z` comments so a tag move does not silently change behavior.
+
+## Versioning
+
+Reference the action by tag of the autopilot repo, e.g.:
+
+```yaml
+uses: awinogradov/code-assistants/.github/actions/contributing-check@v1
+```
+
+In this repository (and in repos that receive the action via `contributing-sync`), the workflow references the action via the local `./.github/actions/contributing-check` path so the introducing PR can self-validate without a remote bootstrap dependency.

--- a/.github/actions/contributing-check/README.md
+++ b/.github/actions/contributing-check/README.md
@@ -6,9 +6,10 @@ community actions (`deepakputhraya/action-branch-name`, `wagoid/commitlint-githu
 `amannn/action-semantic-pull-request`) so consumer repos get the full check set with one `uses:`
 line.
 
-The action is propagated to consumer repos together with [`contributing.yml`](../../workflows/contributing.yml)
-by [`contributing-sync`](../contributing-sync/README.md), so every repo using the sync gets the
-same enforcement automatically.
+Consumer repos get the action by syncing [`contributing.yml`](../../workflows/contributing.yml)
+via [`contributing-sync`](../contributing-sync/README.md). The synced workflow references the
+action remotely (`awinogradov/code-assistants/.github/actions/contributing-check@main`), so the
+action itself does not need to be checked into the consumer repo.
 
 ## Usage
 
@@ -34,8 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/contributing-check
+      - uses: awinogradov/code-assistants/.github/actions/contributing-check@v1
 ```
 
 ## Inputs
@@ -79,4 +79,4 @@ Reference the action by tag of the autopilot repo, e.g.:
 uses: awinogradov/code-assistants/.github/actions/contributing-check@v1
 ```
 
-In this repository (and in repos that receive the action via `contributing-sync`), the workflow references the action via the local `./.github/actions/contributing-check` path so the introducing PR can self-validate without a remote bootstrap dependency.
+The synced `contributing.yml` workflow references the action via `@main` so consumer repos always pick up the latest validation rules. Pin to a tag if you want explicit control.

--- a/.github/actions/contributing-check/action.yml
+++ b/.github/actions/contributing-check/action.yml
@@ -1,0 +1,52 @@
+name: Contributing check
+description: Validate branch name, commit messages, and PR title against the conventions defined in CONTRIBUTING.md.
+
+runs:
+  using: composite
+  steps:
+    - name: Validate branch name
+      uses: deepakputhraya/action-branch-name@e0f8db53a8e289f1ae6f6c3e8dc70a3d366fd876 # v1.0.0
+      with:
+        regex: '^(issue-\d+-[a-z0-9]+(-[a-z0-9]+)*|(hotfix|trivial|maintenance|proposal)-[a-z0-9]+(-[a-z0-9]+)*|release-\d+\.\d+\.\d+)$'
+        min_length: 5
+        max_length: 100
+        ignore: main,master
+
+    - name: Checkout
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        fetch-depth: 0
+
+    - name: Validate commit messages
+      uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
+      with:
+        configFile: ./commitlint.config.mjs
+        failOnWarnings: false
+
+    - name: Validate PR title (semantic)
+      uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        types: |
+          HOTFIX
+          TRIVIAL
+          MAINTENANCE
+          PROPOSAL
+          Release
+          [A-Z]\w*
+        headerPattern: '^([A-Z]\S*?):?\s+(.+)$'
+        headerPatternCorrespondence: type, subject
+        subjectPattern: '.*[^.]$'
+        subjectPatternError: |
+          PR title must not end with a period. See CONTRIBUTING.md §pr-title.
+
+    - name: Validate PR title length
+      shell: bash
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        if [ ${#PR_TITLE} -gt 120 ]; then
+          echo "::error::PR title exceeds 120 character limit (${#PR_TITLE} chars). See CONTRIBUTING.md §pr-title."
+          exit 1
+        fi

--- a/.github/actions/contributing-sync/README.md
+++ b/.github/actions/contributing-sync/README.md
@@ -1,10 +1,21 @@
 # Contributing sync
 
-Composite GitHub Action that syncs `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md`
-from an upstream repository into the current repository and opens a single pull request with
-the differences.
+Composite GitHub Action that syncs the canonical contributing artefacts from an upstream
+repository into the current repository and opens a single pull request with the differences.
+The synced set is:
 
-The action builds a fixed three-entry sync list and delegates the diff and PR mechanics to the
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `LICENSE.md`
+- `.github/workflows/contributing.yml`
+- `.github/actions/contributing-check/action.yml`
+
+The first three are the contributor-facing documentation. The last two propagate the
+[`contributing-check`](../contributing-check/README.md) enforcement action and the workflow
+that runs it on every PR, so consumer repos get the full enforcement set without writing any
+extra glue.
+
+The action builds a fixed five-entry sync list and delegates the diff and PR mechanics to the
 [`files-sync`](../files-sync/README.md) action. It does not require `actions/checkout` and
 never touches the runner's working tree.
 
@@ -66,16 +77,17 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 
 ## Behavior
 
-- Delegates to `files-sync` with three fixed entries — one for each of `CONTRIBUTING.md`,
-  `CODE_OF_CONDUCT.md`, and `LICENSE.md` — sourced from `source-repo` at `source-ref`.
+- Delegates to `files-sync` with five fixed entries — `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, `LICENSE.md`, `.github/workflows/contributing.yml`, and
+  `.github/actions/contributing-check/action.yml` — sourced from `source-repo` at `source-ref`.
 - The PR is opened on the fixed branch `maintenance-sync-contributing` with the title
   `MAINTENANCE: Sync contributing files from upstream` and the commit message
   `chore: sync contributing files from upstream`. These values are not configurable so the
   action cannot collide with `files-sync`'s default branch and so every consumer gets the
   same one-line setup.
 - The head branch is force-updated on every run (inherited from `files-sync`); local edits
-  to any of the three synced files will be overwritten when the upstream files change.
-- If all three destination files already match upstream, no PR is created.
+  to any of the five synced files will be overwritten when the upstream files change.
+- If all five destination files already match upstream, no PR is created.
 - Missing source files fail the run with `Source not found at <repo>:<path>`.
 
 ## Versioning

--- a/.github/actions/contributing-sync/README.md
+++ b/.github/actions/contributing-sync/README.md
@@ -15,7 +15,7 @@ action itself stays in the upstream repository and is referenced from the synced
 `awinogradov/code-assistants/.github/actions/contributing-check@main`, so consumers do not need
 a local copy.
 
-The action builds a fixed four-entry sync list and delegates the diff and PR mechanics to the
+The action builds the sync list and delegates the diff and PR mechanics to the
 [`files-sync`](../files-sync/README.md) action. It does not require `actions/checkout` and
 never touches the runner's working tree.
 
@@ -77,17 +77,17 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 
 ## Behavior
 
-- Delegates to `files-sync` with four fixed entries — `CONTRIBUTING.md`,
-  `CODE_OF_CONDUCT.md`, `LICENSE.md`, and `.github/workflows/contributing.yml` — sourced
-  from `source-repo` at `source-ref`.
+- Delegates to `files-sync` with a fixed sync list — `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`,
+  `LICENSE.md`, and `.github/workflows/contributing.yml` — sourced from `source-repo` at
+  `source-ref`.
 - The PR is opened on the fixed branch `maintenance-sync-contributing` with the title
   `MAINTENANCE: Sync contributing files from upstream` and the commit message
   `chore: sync contributing files from upstream`. These values are not configurable so the
   action cannot collide with `files-sync`'s default branch and so every consumer gets the
   same one-line setup.
 - The head branch is force-updated on every run (inherited from `files-sync`); local edits
-  to any of the four synced files will be overwritten when the upstream files change.
-- If all four destination files already match upstream, no PR is created.
+  to any of the synced files will be overwritten when the upstream files change.
+- If every destination file already matches upstream, no PR is created.
 - Missing source files fail the run with `Source not found at <repo>:<path>`.
 
 ## Versioning

--- a/.github/actions/contributing-sync/README.md
+++ b/.github/actions/contributing-sync/README.md
@@ -8,14 +8,14 @@ The synced set is:
 - `CODE_OF_CONDUCT.md`
 - `LICENSE.md`
 - `.github/workflows/contributing.yml`
-- `.github/actions/contributing-check/action.yml`
 
-The first three are the contributor-facing documentation. The last two propagate the
-[`contributing-check`](../contributing-check/README.md) enforcement action and the workflow
-that runs it on every PR, so consumer repos get the full enforcement set without writing any
-extra glue.
+The first three are the contributor-facing documentation. The workflow propagates the CI that
+runs the [`contributing-check`](../contributing-check/README.md) action on every PR — the
+action itself stays in the upstream repository and is referenced from the synced workflow via
+`awinogradov/code-assistants/.github/actions/contributing-check@main`, so consumers do not need
+a local copy.
 
-The action builds a fixed five-entry sync list and delegates the diff and PR mechanics to the
+The action builds a fixed four-entry sync list and delegates the diff and PR mechanics to the
 [`files-sync`](../files-sync/README.md) action. It does not require `actions/checkout` and
 never touches the runner's working tree.
 
@@ -77,17 +77,17 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 
 ## Behavior
 
-- Delegates to `files-sync` with five fixed entries — `CONTRIBUTING.md`,
-  `CODE_OF_CONDUCT.md`, `LICENSE.md`, `.github/workflows/contributing.yml`, and
-  `.github/actions/contributing-check/action.yml` — sourced from `source-repo` at `source-ref`.
+- Delegates to `files-sync` with four fixed entries — `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, `LICENSE.md`, and `.github/workflows/contributing.yml` — sourced
+  from `source-repo` at `source-ref`.
 - The PR is opened on the fixed branch `maintenance-sync-contributing` with the title
   `MAINTENANCE: Sync contributing files from upstream` and the commit message
   `chore: sync contributing files from upstream`. These values are not configurable so the
   action cannot collide with `files-sync`'s default branch and so every consumer gets the
   same one-line setup.
 - The head branch is force-updated on every run (inherited from `files-sync`); local edits
-  to any of the five synced files will be overwritten when the upstream files change.
-- If all five destination files already match upstream, no PR is created.
+  to any of the four synced files will be overwritten when the upstream files change.
+- If all four destination files already match upstream, no PR is created.
 - Missing source files fail the run with `Source not found at <repo>:<path>`.
 
 ## Versioning

--- a/.github/actions/contributing-sync/action.yml
+++ b/.github/actions/contributing-sync/action.yml
@@ -1,5 +1,5 @@
 name: Contributing sync
-description: Sync CONTRIBUTING.md, CODE_OF_CONDUCT.md, and LICENSE.md from an upstream repository into the current repository.
+description: Sync CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE.md, the contributing workflow, and the contributing-check action from an upstream repository into the current repository.
 
 inputs:
   token:
@@ -37,7 +37,13 @@ runs:
         INPUT_SOURCE_REF: ${{ inputs.source-ref }}
       run: |
         set -euo pipefail
-        paths=(CONTRIBUTING.md CODE_OF_CONDUCT.md LICENSE.md)
+        paths=(
+          CONTRIBUTING.md
+          CODE_OF_CONDUCT.md
+          LICENSE.md
+          .github/workflows/contributing.yml
+          .github/actions/contributing-check/action.yml
+        )
         {
           echo "files<<__EOF__"
           for path in "${paths[@]}"; do

--- a/.github/actions/contributing-sync/action.yml
+++ b/.github/actions/contributing-sync/action.yml
@@ -1,5 +1,5 @@
 name: Contributing sync
-description: Sync CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE.md, the contributing workflow, and the contributing-check action from an upstream repository into the current repository.
+description: Sync CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE.md, and the contributing workflow from an upstream repository into the current repository.
 
 inputs:
   token:
@@ -42,7 +42,6 @@ runs:
           CODE_OF_CONDUCT.md
           LICENSE.md
           .github/workflows/contributing.yml
-          .github/actions/contributing-check/action.yml
         )
         {
           echo "files<<__EOF__"

--- a/.github/workflows/contributing.yml
+++ b/.github/workflows/contributing.yml
@@ -19,5 +19,4 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: ./.github/actions/contributing-check
+      - uses: awinogradov/code-assistants/.github/actions/contributing-check@main

--- a/.github/workflows/contributing.yml
+++ b/.github/workflows/contributing.yml
@@ -1,0 +1,23 @@
+name: Contributing
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: contributing-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/contributing-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,7 +249,7 @@ feat(api): add retry with exponential backoff to fetchUser
 fix(validator): handle null and empty-string inputs
 ```
 
-⚠️ Enforced locally by [`commitlint`](./commitlint.config.ts) on the `commit-msg` hook and in CI by [`wagoid/commitlint-github-action`](https://github.com/wagoid/commitlint-github-action). Invalid commits block PR merge.
+⚠️ Enforced locally by [`commitlint`](./commitlint.config.mjs) on the `commit-msg` hook and in CI by [`wagoid/commitlint-github-action`](https://github.com/wagoid/commitlint-github-action). Invalid commits block PR merge.
 
 #### Atomic Commits
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ See the [plugin README](./claude-plugins/autopilot/README.md#installation) for s
 
 - [`files-sync`](./.github/actions/files-sync/README.md) — sync declared files from upstream repos and open one PR with the differences
 - [`agents-rules-sync`](./.github/actions/agents-rules-sync/README.md) — sync the stack-appropriate `rules/<stack>.md` into `CLAUDE.md` based on `package.json` `agents.rules`
-- [`contributing-sync`](./.github/actions/contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md` from upstream
+- [`contributing-check`](./.github/actions/contributing-check/README.md) — validate branch name, commit messages, and PR title against `CONTRIBUTING.md`
+- [`contributing-sync`](./.github/actions/contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, the contributing workflow, and the `contributing-check` action from upstream
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See the [plugin README](./claude-plugins/autopilot/README.md#installation) for s
 - [`files-sync`](./.github/actions/files-sync/README.md) — sync declared files from upstream repos and open one PR with the differences
 - [`agents-rules-sync`](./.github/actions/agents-rules-sync/README.md) — sync the stack-appropriate `rules/<stack>.md` into `CLAUDE.md` based on `package.json` `agents.rules`
 - [`contributing-check`](./.github/actions/contributing-check/README.md) — validate branch name, commit messages, and PR title against `CONTRIBUTING.md`
-- [`contributing-sync`](./.github/actions/contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, the contributing workflow, and the `contributing-check` action from upstream
+- [`contributing-sync`](./.github/actions/contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, and the contributing workflow from upstream
 
 ## Contributing
 

--- a/claude-plugins/autopilot/agents/pr:review:standards.md
+++ b/claude-plugins/autopilot/agents/pr:review:standards.md
@@ -34,7 +34,7 @@ Evaluate only changes visible in the diff (lines prefixed with `+` or `-`). Skip
 
 GitHub issue references (e.g., `#123`, `Closes #123`) must NOT appear in commit messages. The PR description handles issue linking via magic words.
 
-- Platform ref: commitlint.config.ts custom rule `no-issue-id`
+- Platform ref: commitlint.config.mjs custom rule `no-issue-id`
 
 ### B. Lint and Suppression Hacks
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,6 +1,12 @@
-import type { UserConfig } from "@commitlint/types";
-
-const config: UserConfig = {
+/**
+ * Commitlint configuration.
+ *
+ * Enforced locally by the husky `commit-msg` hook and in CI by
+ * `wagoid/commitlint-github-action`. See CONTRIBUTING.md `Commits` section.
+ *
+ * @type {import("@commitlint/types").UserConfig}
+ */
+const config = {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "type-enum": [


### PR DESCRIPTION
Adds a reusable composite GitHub Action that enforces the branch-name, commit-message, and PR-title conventions defined in CONTRIBUTING.md, plus a thin workflow that invokes it on every pull request to main. The contributing-sync action is extended to propagate the new workflow and the action.yml to every consumer repo, so any repo on the sync gets identical enforcement out of the box.

- Wraps `deepakputhraya/action-branch-name`, `wagoid/commitlint-github-action`, and `amannn/action-semantic-pull-request` with SHA-pinned versions
- Single workflow job uses the action via a local `./` ref — the action.yml is also synced to consumers so the path resolves there too
- Converts `commitlint.config.ts` to `commitlint.config.mjs` because `wagoid/commitlint-github-action@v6` runs in Docker and cannot load `.ts` configs (custom rules would silently fall back to `config-conventional` otherwise)
- Updates root README, CONTRIBUTING.md, and the contributing-sync README to point at the new files

---

**Release notes:**

- Added `contributing-check` GitHub Action that validates branch name, commit messages, and PR title against `CONTRIBUTING.md` on every pull request
- Added `contributing.yml` workflow invoking the action on PRs to `main`
- `contributing-sync` now also propagates `contributing.yml` and `contributing-check/action.yml` to consumer repos

---

**Issues:**

Closes #19

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `contributing-check` composite action and a `contributing.yml` workflow to enforce branch names, commit messages, and PR titles per CONTRIBUTING.md. The workflow references the action remotely so consumer repos get the checks without vendoring the action.

- **New Features**
  - Added `.github/actions/contributing-check` wrapping `deepakputhraya/action-branch-name`, `wagoid/commitlint-github-action@v6`, and `amannn/action-semantic-pull-request@v6` (SHA-pinned), plus a 120‑char PR title limit.
  - Added `.github/workflows/contributing.yml` to run on PRs to `main`, referencing `awinogradov/code-assistants/.github/actions/contributing-check@main`.
  - Updated `contributing-sync` to also sync `.github/workflows/contributing.yml` (no action file sync) and revised its README to describe the synced set and remote reference; consumer repos reference the action remotely.
  - Renamed `commitlint.config.ts` to `commitlint.config.mjs` to work with `wagoid/commitlint-github-action@v6`.

<sup>Written for commit 881d9485082b667ab75edbd01e1f2ef97c740016. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/20?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

