### PR TITLE
Add upstream-source warning header to files synced into downstream repos

### DIFF
--- a/.github/workflows/contributing.yml
+++ b/.github/workflows/contributing.yml
@@ -1,3 +1,8 @@
+# Source: https://github.com/awinogradov/code-assistants/blob/main/.github/workflows/contributing.yml
+# This file is distributed to downstream repositories by an automated sync.
+# Edits made downstream are overwritten on the next run.
+# To change it, open a pull request against the source file above.
+
 name: Contributing
 
 on:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,10 @@
+<!--
+Source: https://github.com/awinogradov/code-assistants/blob/main/CODE_OF_CONDUCT.md
+This file is distributed to downstream repositories by an automated sync.
+Edits made downstream are overwritten on the next run.
+To change it, open a pull request against the source file above.
+-->
+
 # Code of Conduct
 
 ## Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+<!--
+Source: https://github.com/awinogradov/code-assistants/blob/main/CONTRIBUTING.md
+This file is distributed to downstream repositories by an automated sync.
+Edits made downstream are overwritten on the next run.
+To change it, open a pull request against the source file above.
+-->
+
 # Contributing
 
 Thank you for your interest in contributing! This guide will help you get started.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,10 @@
+<!--
+Source: https://github.com/awinogradov/code-assistants/blob/main/LICENSE.md
+This file is distributed to downstream repositories by an automated sync.
+Edits made downstream are overwritten on the next run.
+To change it, open a pull request against the source file above.
+-->
+
 # MIT License
 
 Copyright (c) 2026 Tony Vi

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -2,6 +2,13 @@
 alwaysApply: true
 ---
 
+<!--
+Source: https://github.com/awinogradov/code-assistants/blob/main/rules/Bun+React+Tailwind.md
+This file is distributed to downstream repositories by an automated sync.
+Edits made downstream are overwritten on the next run.
+To change it, open a pull request against the source file above.
+-->
+
 # Bun + React + Tailwind Project Rules
 
 ## Mandatory Context

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -2,6 +2,13 @@
 alwaysApply: true
 ---
 
+<!--
+Source: https://github.com/awinogradov/code-assistants/blob/main/rules/Bun.md
+This file is distributed to downstream repositories by an automated sync.
+Edits made downstream are overwritten on the next run.
+To change it, open a pull request against the source file above.
+-->
+
 # Bun Project Rules
 
 ## Mandatory Context

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -2,6 +2,13 @@
 alwaysApply: true
 ---
 
+<!--
+Source: https://github.com/awinogradov/code-assistants/blob/main/rules/NodeJS+React+Tailwind.md
+This file is distributed to downstream repositories by an automated sync.
+Edits made downstream are overwritten on the next run.
+To change it, open a pull request against the source file above.
+-->
+
 # NodeJS + React + Tailwind Project Rules
 
 ## Mandatory Context

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -2,6 +2,13 @@
 alwaysApply: true
 ---
 
+<!--
+Source: https://github.com/awinogradov/code-assistants/blob/main/rules/NodeJS+React.md
+This file is distributed to downstream repositories by an automated sync.
+Edits made downstream are overwritten on the next run.
+To change it, open a pull request against the source file above.
+-->
+
 # NodeJS + React Project Rules
 
 ## Mandatory Context


### PR DESCRIPTION
Adds a top-of-file warning to every file that this repo distributes to downstream repositories via the `contributing-sync` and `agents-rules-sync` composite GitHub Actions. The warning makes it obvious that local edits will be overwritten on the next sync and points readers at the source file for proposing changes.

- HTML comment block at the top of CONTRIBUTING.md, CODE_OF_CONDUCT.md, and LICENSE.md (invisible when rendered, visible in source view)
- HTML comment after the YAML frontmatter in `rules/Bun.md`, `rules/Bun+React+Tailwind.md`, `rules/NodeJS+React.md`, and `rules/NodeJS+React+Tailwind.md` — frontmatter remains the first content so AI tooling parses `alwaysApply: true` correctly
- Hash-prefixed comment block at the top of `.github/workflows/contributing.yml`
- Verified that licensee normalization strips `html_comment` before MIT matching, so the comment on LICENSE.md does not break GitHub's license detection
- Propagation requires no action version bump: `files-sync` compares destination and source content byte-for-byte, so the warning ships into every consumer on the next scheduled `contributing-sync` / `agents-rules-sync` run

---

**Release notes:**

- Adds an upstream-source warning header to files distributed via contributing-sync and agents-rules-sync
- Downstream repositories will see one extra MAINTENANCE: Sync … PR on the next scheduled run that propagates the warning into their copies of the files

---

**Issues:**

Closes #21

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an upstream-source warning header to all files synced to downstream repos via `contributing-sync` and `agents-rules-sync`. This warns that local edits will be overwritten and links to the source file. Closes #21.

- **New Features**
  - Added comment headers to CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE.md, and `.github/workflows/contributing.yml`; placed after YAML frontmatter in `rules/*.md`.
  - Confirmed GitHub license detection still works (licensee strips HTML comments).

- **Migration**
  - No action needed; headers will propagate on the next scheduled sync and may create one extra maintenance PR in downstream repos.

<sup>Written for commit b5118559e3a964e5ba87775efb5e6a86021a6bd6. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/22?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

