### PR TITLE
Add hourly workflow to sync agent rules into this repo

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,0 +1,32 @@
+# Requires repo secret `GH_TOKEN`: a PAT (classic with `repo`, or fine-grained
+# with `contents: write` + `pull-requests: write`) or a GitHub App installation
+# token. The default `GITHUB_TOKEN` is not supported — see the action README
+# in `.github/actions/agents-rules-sync` for the rationale.
+
+name: Upstream
+
+on:
+  schedule:
+    # Every hour at minute 0 (UTC). Picks up upstream agent rules changes
+    # within ~1h and opens (or updates) a maintenance PR on
+    # `maintenance-sync-agents-rules`.
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: upstream-${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync agent rules
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: awinogradov/code-assistants/.github/actions/agents-rules-sync@main
+        with:
+          token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Add an hourly upstream workflow so this repository runs the `agents-rules-sync` composite action against itself. Until now the action was only exercised by downstream consumers (e.g. symbiot), so regressions in the sync mechanics surfaced there instead of here. Dogfooding closes that gap.

- New `.github/workflows/upstream.yml` running on `0 * * * *` cron and `workflow_dispatch`
- Permissions limited to `contents: write` + `pull-requests: write`
- 10-minute job timeout and `cancel-in-progress: false` concurrency so overlapping cron runs queue rather than cancel mid-sync
- Header comment documents the `GH_TOKEN` secret requirement (the default `GITHUB_TOKEN` cannot reliably open PRs)
- `contributing-sync` intentionally omitted — this repo is the source of the contributing files, so there is no upstream to pull from

---

**Issues:**

Closes #23

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an hourly workflow that runs the `agents-rules-sync` action against this repo so rule updates create/update a maintenance PR here and regressions surface sooner.

- **New Features**
  - Added `.github/workflows/upstream.yml` running on `0 * * * *` and `workflow_dispatch`; 10‑min timeout; queues overlapping runs.
  - Uses `awinogradov/code-assistants/.github/actions/agents-rules-sync@main` with `GH_TOKEN`; permissions set to `contents: write` and `pull-requests: write`.
  - Omits `contributing-sync` since this repo is the source of contributing files.

<sup>Written for commit 010c09978206a7c9cf72ec4be8829ea80334f18a. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/24?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

