### PR TITLE
Add release composite action for npm, GitHub Actions, and Claude plugins

### DIFF
--- a/.github/actions/release-action/README.md
+++ b/.github/actions/release-action/README.md
@@ -1,0 +1,165 @@
+# Release action
+
+Composite GitHub Action that automates the release pipeline for npm packages, GitHub Actions, and Claude plugins.
+
+The action drives a two-phase flow — **create** opens a release PR that bumps the version, generates the changelog from [conventional commits](https://www.conventionalcommits.org/), enriches it with ticket details (Linear, Jira, GitHub Issues) and an optional AI-generated summary; **publish** runs when the release PR is merged and creates the git tag, npm publish, GitHub Release, floating major-version tag, and Slack notification — selecting the right artifacts based on the `release:` field in `platform.meta.yml`.
+
+## Usage
+
+### Create
+
+Runs on push to `main`. Generates the changelog and opens a release PR.
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: awinogradov/code-assistants/.github/actions/release-action@v1
+        with:
+          mode: create
+          github_token: ${{ secrets.GH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_RELEASE_KEY }}
+          linear_api_key: ${{ secrets.LINEAR_API_KEY }}
+          linear_keys: ${{ vars.LINEAR_KEYS }}
+```
+
+### Publish
+
+Triggers when a release PR is merged (detected via `.release_notes/**` changes).
+
+```yaml
+name: Publish
+
+on:
+  pull_request_target:
+    types: [closed]
+    paths: [.release_notes/**]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: awinogradov/code-assistants/.github/actions/release-action@v1
+        with:
+          mode: publish
+          github_token: ${{ secrets.GH_TOKEN }}
+          npm_token: ${{ secrets.NPM_TOKEN }}
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+```
+
+## Inputs
+
+| Input               | Required | Default             | Description                                                                                                     |
+| ------------------- | -------- | ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `mode`              | yes      | —                   | `create` or `publish`.                                                                                          |
+| `github_token`      | yes      | —                   | PAT or App installation token with `contents: write` + `pull-requests: write`. See [Permissions](#permissions). |
+| `npm_token`         | no       | —                   | NPM token. Required for `publish` with `lib-nodejs` or `lib-bun` release types.                                 |
+| `anthropic_api_key` | no       | —                   | Anthropic API key. When set, generates human-readable release-note summaries.                                   |
+| `name`              | no       | —                   | Service or library name for PR titles (e.g. `Dialog Manager` → `Release Dialog Manager 1.2.0`).                 |
+| `branch`            | no       | `release-{version}` | Release branch template. `{version}` is substituted. `create` mode only.                                        |
+| `linear_api_key`    | no       | —                   | Linear API key for ticket integration.                                                                          |
+| `linear_keys`       | no       | —                   | Comma-separated Linear key prefixes (e.g. `TEAM,PROJ`).                                                         |
+| `jira_base_url`     | no       | —                   | Jira instance base URL (used with `jira_email` + `jira_api_token`).                                             |
+| `jira_email`        | no       | —                   | Jira authentication email.                                                                                      |
+| `jira_api_token`    | no       | —                   | Jira API token.                                                                                                 |
+| `jira_keys`         | no       | —                   | Comma-separated Jira key prefixes.                                                                              |
+| `slack_token`       | no       | —                   | Slack bot token. Required to post release notifications.                                                        |
+
+## Outputs
+
+| Output         | Description                                     |
+| -------------- | ----------------------------------------------- |
+| `version`      | Released version number.                        |
+| `release-type` | Detected release type from `platform.meta.yml`. |
+| `pr-url`       | URL of the created or updated release PR.       |
+
+## Modes
+
+- **`create`** — analyzes commits since the last release tag, bumps the version per conventional-commit rules (`fix:` → patch, `feat:` → minor, `feat!:` / `BREAKING CHANGE:` → major), regenerates the changelog with ticket details and optional AI summary, and opens a `release-{version}` PR.
+- **`publish`** — runs after the release PR is merged. Tags the merge commit, publishes artifacts based on `platform.meta.yml`, creates a GitHub Release, and (for action repos) updates the floating major tag (e.g. `v1`).
+
+## `platform.meta.yml`
+
+Release behavior is driven by the `release:` field. The fallback chain for the version source is `version` file → `package.json` → `plugin.json` → `pyproject.toml`.
+
+| Value            | Version source   | NPM publish | GitHub Release | Major version tag (`v1`) |
+| ---------------- | ---------------- | ----------- | -------------- | ------------------------ |
+| `lib-nodejs`     | `package.json`   | Yes         | Yes            | No                       |
+| `lib-bun`        | `package.json`   | Yes         | Yes            | No                       |
+| `lib-python`     | `pyproject.toml` | No          | Yes            | No                       |
+| `service-nodejs` | `package.json`   | No          | Yes            | No                       |
+| `service-python` | `pyproject.toml` | No          | Yes            | No                       |
+| `github-action`  | `package.json`   | No          | Yes            | Yes                      |
+| `claude-plugin`  | `plugin.json`    | No          | Yes            | No                       |
+
+Minimal `platform.meta.yml`:
+
+```yaml
+release: lib-nodejs
+```
+
+The `.release_bot` working directory is added to `.gitignore` automatically on the first run.
+
+## Ticket integration
+
+Extract ticket IDs from PR titles and commit messages, then fetch details via API and embed them in the changelog.
+
+| System        | Pattern    | Environment variables                           |
+| ------------- | ---------- | ----------------------------------------------- |
+| Linear        | `TEAM-123` | `LINEAR_API_KEY`                                |
+| Jira          | `PROJ-456` | `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN` |
+| GitHub Issues | `#123`     | `GH_TOKEN`                                      |
+
+Optional key filtering via `LINEAR_KEYS` / `JIRA_KEYS` (e.g. `TEAM,PROJ`). When multiple ticket systems are configured, prefix keys are required so the action can route each ticket to the right system.
+
+## Slack notifications
+
+Add `slack.release` to `platform.meta.yml`:
+
+```yaml
+slack:
+  release: "#your-channel"
+```
+
+Then pass `slack_token` to the publish workflow. The bot token needs the `chat:write` scope. The notification includes the version, the AI-generated release notes (when present), and a link to the GitHub release.
+
+## Permissions
+
+The `github_token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever the repo or its org disables **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**.
+
+Pass one of:
+
+- A **classic Personal Access Token** with the `repo` scope.
+- A **fine-grained Personal Access Token** scoped to the repo with `Contents: Read and write` and `Pull requests: Read and write`.
+- A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
+
+Store the token as a secret (e.g. `GH_TOKEN`) and pass it via `github_token: ${{ secrets.GH_TOKEN }}`.
+
+The Configure Git step inside the action commits as `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`.
+
+## Versioning
+
+Reference the action by tag, for example:
+
+```yaml
+uses: awinogradov/code-assistants/.github/actions/release-action@v1
+```

--- a/.github/actions/release-action/action.yml
+++ b/.github/actions/release-action/action.yml
@@ -1,0 +1,304 @@
+name: "Release"
+description: "Automated release and publish for npm packages, GitHub Actions, and Claude Plugins"
+
+inputs:
+  mode:
+    description: |
+      Workflow mode:
+      - create — generate changelog and open a release PR
+      - publish — tag and publish the release
+    required: true
+  github_token:
+    description: |
+      GitHub token with contents:write and pull-requests:write permissions.
+      Required for all modes.
+    required: true
+  npm_token:
+    description: |
+      NPM token for publishing packages.
+      Required for publish mode with lib-nodejs or lib-bun release types.
+    required: false
+  anthropic_api_key:
+    description: |
+      Anthropic API key for AI-generated release notes.
+      When provided, generates human-readable summaries from the changelog.
+    required: false
+  name:
+    description: |
+      Service or library name for PR titles.
+      Used in monorepo setups (e.g. "Dialog Manager" → "Release Dialog Manager 1.2.0").
+    required: false
+  branch:
+    description: |
+      Release branch name template. Use {version} as placeholder.
+      Only used in create mode.
+    required: false
+    default: "release-{version}"
+  linear_api_key:
+    description: |
+      Linear API key for ticket integration.
+      Enables automatic ticket reference extraction from commits and PRs.
+    required: false
+  linear_keys:
+    description: |
+      Linear ticket key prefixes (comma-separated).
+      Filters which ticket IDs to extract (e.g. "TEAM,PROJ").
+    required: false
+  jira_base_url:
+    description: |
+      Jira instance base URL.
+      Required together with jira_email and jira_api_token for Jira integration.
+    required: false
+  jira_email:
+    description: |
+      Jira authentication email.
+      Used with jira_base_url and jira_api_token.
+    required: false
+  jira_api_token:
+    description: |
+      Jira API token.
+      Used with jira_base_url and jira_email.
+    required: false
+  jira_keys:
+    description: |
+      Jira ticket key prefixes (comma-separated).
+      Filters which Jira ticket IDs to extract.
+    required: false
+  slack_token:
+    description: |
+      Slack bot token for release notifications.
+      Posts release notes to the channel configured in platform.meta.yml.
+    required: false
+
+outputs:
+  version:
+    description: "Released version number"
+    value: ${{ steps.version.outputs.version }}
+  release-type:
+    description: "Detected release type from platform.meta.yml"
+    value: ${{ steps.detect-type.outputs.type }}
+  pr-url:
+    description: "URL of the created or updated release PR"
+    value: ${{ steps.release-pr.outputs.pr-url }}
+
+runs:
+  using: composite
+  steps:
+    # ── Shared Setup ──
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      with:
+        bun-version: 1.x
+
+    - name: Install workspace dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      run: bun install --frozen-lockfile --filter @code-assistants/release-action
+
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+
+    - name: Detect release type
+      id: detect-type
+      shell: bash
+      run: |
+        if [ ! -f "platform.meta.yml" ]; then
+          echo "::error::platform.meta.yml not found."
+          exit 1
+        fi
+        RELEASE_TYPE=$(grep '^release:' platform.meta.yml | awk '{print $2}' || true)
+        if [ -z "$RELEASE_TYPE" ]; then
+          echo "::error::Missing 'release' field in platform.meta.yml."
+          exit 1
+        fi
+        echo "type=${RELEASE_TYPE}" >> "$GITHUB_OUTPUT"
+        echo "Detected release type: ${RELEASE_TYPE}"
+
+    # ── Mode: create ──
+
+    - name: Ensure .gitignore excludes .release_bot
+      if: inputs.mode == 'create'
+      shell: bash
+      run: bun "${{ github.action_path }}/src/prepareRelease.ts" --ensure-gitignore
+
+    - name: Generate Changelog
+      if: inputs.mode == 'create'
+      shell: bash
+      env:
+        LINEAR_API_KEY: ${{ inputs.linear_api_key }}
+        LINEAR_KEYS: ${{ inputs.linear_keys }}
+        JIRA_BASE_URL: ${{ inputs.jira_base_url }}
+        JIRA_EMAIL: ${{ inputs.jira_email }}
+        JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+        JIRA_KEYS: ${{ inputs.jira_keys }}
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: bun "${{ github.action_path }}/src/release.ts"
+
+    - name: Update Version Files
+      if: inputs.mode == 'create'
+      shell: bash
+      run: bun "${{ github.action_path }}/src/prepareRelease.ts" --update-version "$(cat version)"
+
+    - name: Update Release Badge
+      if: inputs.mode == 'create'
+      shell: bash
+      run: bun "${{ github.action_path }}/src/updateReleaseBadge.ts"
+
+    - name: Generate Release Notes
+      if: inputs.mode == 'create'
+      continue-on-error: true
+      shell: bash
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+      run: bun "${{ github.action_path }}/src/generateReleaseNotes.ts"
+
+    - name: Update Release Notes File
+      if: inputs.mode == 'create'
+      shell: bash
+      run: |
+        VERSION=$(cat version)
+        bun "${{ github.action_path }}/src/insert-release-notes.ts" "$VERSION"
+
+    - name: Assemble PR Body
+      if: inputs.mode == 'create'
+      shell: bash
+      env:
+        INPUT_BRANCH: ${{ inputs.branch }}
+      run: bun "${{ github.action_path }}/src/assemble-pr-body.ts"
+
+    - name: Commit and Push Release
+      if: inputs.mode == 'create'
+      shell: bash
+      env:
+        INPUT_BRANCH: ${{ inputs.branch }}
+      run: |
+        VERSION=$(cat version)
+        BRANCH="${INPUT_BRANCH//\{version\}/$VERSION}"
+        git checkout -B "$BRANCH"
+        git add .
+        git commit -n -m "chore: release ${VERSION}"
+        git push --no-verify --force origin "$BRANCH"
+        echo "Committed and pushed to $BRANCH"
+
+    - name: Create Pull Request
+      id: release-pr
+      if: inputs.mode == 'create'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        INPUT_NAME: ${{ inputs.name }}
+      run: |
+        VERSION=$(cat version)
+
+        if [ -n "$INPUT_NAME" ]; then
+          TITLE="Release ${INPUT_NAME} ${VERSION}"
+        else
+          TITLE="Release ${VERSION}"
+        fi
+
+        BRANCH=$(git branch --show-current)
+
+        # Ensure label exists
+        gh label create release-action --color 85e131 --description "Release PR" 2>/dev/null || true
+
+        # Check for existing PR
+        PR_URL=$(gh pr view --head "$BRANCH" --json url -q .url 2>/dev/null || true)
+
+        if [ -n "$PR_URL" ]; then
+          echo "PR already exists, updating..."
+          gh pr edit --title "$TITLE" --body-file .release_bot/body_enhanced
+        else
+          PR_URL=$(gh pr create --head "$BRANCH" --title "$TITLE" --label release-action -F .release_bot/body_enhanced)
+        fi
+
+        echo "::notice title=${TITLE}::${PR_URL}"
+        echo "pr-url=${PR_URL}" >> "$GITHUB_OUTPUT"
+        echo "### [${TITLE}](${PR_URL})" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Output version
+      id: version
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        PUBLISH_VERSION: ${{ steps.determine-version.outputs.version }}
+      run: |
+        VERSION=""
+        if [ "$MODE" = "publish" ] && [ -n "$PUBLISH_VERSION" ]; then
+          VERSION="$PUBLISH_VERSION"
+        else
+          [ -f version ] && VERSION=$(cat version | tr -d '[:space:]')
+        fi
+        if [ -n "$VERSION" ]; then
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Output version: ${VERSION}"
+        fi
+
+    # ── Mode: publish ──
+
+    - name: Determine Version
+      id: determine-version
+      if: inputs.mode == 'publish'
+      shell: bash
+      run: |
+        VERSION=$(cat version | tr -d '[:space:]')
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "Determined version: ${VERSION} (tag: v${VERSION})"
+
+    - name: Setup packages
+      if: inputs.mode == 'publish' && (steps.detect-type.outputs.type == 'lib-nodejs' || steps.detect-type.outputs.type == 'lib-bun')
+      shell: bash
+      run: bun install
+
+    - name: Publish to NPM
+      if: inputs.mode == 'publish' && (steps.detect-type.outputs.type == 'lib-nodejs' || steps.detect-type.outputs.type == 'lib-bun')
+      shell: bash
+      env:
+        NPM_TOKEN: ${{ inputs.npm_token }}
+      run: |
+        npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
+        npm publish
+
+    - name: Release Tag
+      if: inputs.mode == 'publish'
+      shell: bash
+      run: |
+        TAG="${{ steps.determine-version.outputs.tag }}"
+        git tag "$TAG"
+        git push --no-verify origin "$TAG"
+        echo "Created and pushed tag $TAG"
+
+    - name: Major Version Tag
+      if: inputs.mode == 'publish' && steps.detect-type.outputs.type == 'github-action'
+      shell: bash
+      run: |
+        VERSION="$(cat version)"
+        MAJOR="v${VERSION%%.*}"
+        git tag -fa "$MAJOR" -m "Update $MAJOR tag"
+        git push origin "$MAJOR" --force
+        echo "Updated major version tag $MAJOR"
+
+    - name: GitHub Release
+      if: inputs.mode == 'publish'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        TAG: ${{ steps.determine-version.outputs.tag }}
+        VERSION: ${{ steps.determine-version.outputs.version }}
+      run: |
+        gh release create "$TAG" \
+          --title "Release $VERSION" \
+          -F ".release_notes/${VERSION}.md"
+        echo "Created GitHub release Release ${VERSION} (${TAG})"
+
+    - name: Slack Release Notification
+      if: inputs.mode == 'publish' && inputs.slack_token != ''
+      continue-on-error: true
+      shell: bash
+      env:
+        SLACK_TOKEN: ${{ inputs.slack_token }}
+      run: bun "${{ github.action_path }}/src/slackNotify.ts"

--- a/.github/actions/release-action/action.yml
+++ b/.github/actions/release-action/action.yml
@@ -110,7 +110,7 @@ runs:
           echo "::error::platform.meta.yml not found."
           exit 1
         fi
-        RELEASE_TYPE=$(grep '^release:' platform.meta.yml | awk '{print $2}' || true)
+        RELEASE_TYPE=$(grep '^release:' platform.meta.yml | head -1 | sed -E 's/^release:[[:space:]]*//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/' | tr -d '[:space:]' || true)
         if [ -z "$RELEASE_TYPE" ]; then
           echo "::error::Missing 'release' field in platform.meta.yml."
           exit 1

--- a/.github/actions/release-action/package.json
+++ b/.github/actions/release-action/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@code-assistants/release-action",
+  "version": "0.0.0",
+  "description": "Composite GitHub Action that automates conventional-commit releases for npm packages, GitHub Actions, and Claude plugins.",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "clean": "rm -rf node_modules .turbo"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "0.92.0",
+    "@slack/web-api": "7.15.1",
+    "conventional-changelog": "7.2.0",
+    "conventional-changelog-conventionalcommits": "9.3.1",
+    "conventional-recommended-bump": "11.2.0",
+    "semver": "7.7.4",
+    "smol-toml": "1.6.1"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "@types/conventional-changelog": "6.0.1",
+    "@types/semver": "7.7.1",
+    "typescript": "6.0.3"
+  }
+}

--- a/.github/actions/release-action/src/assemble-pr-body.test.ts
+++ b/.github/actions/release-action/src/assemble-pr-body.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for PR body assembly and truncation
+ *
+ * Verifies that release notes are read from file, the enhanced body
+ * is assembled correctly with changelog link, and large bodies are
+ * truncated with a link to the release notes file.
+ */
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import { $ } from "bun";
+
+import { withTempDir } from "./testHelpers.ts";
+
+/** Base env stripped of GitHub CI variables that affect URL generation */
+const ciVarKeys = ["GITHUB_SERVER_URL", "GITHUB_REPOSITORY", "INPUT_BRANCH"];
+const cleanEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !ciVarKeys.includes(key))
+) as Record<string, string>;
+
+/** GitHub env vars for tests that verify absolute URL generation */
+const githubEnv = {
+  GITHUB_SERVER_URL: "https://github.com",
+  GITHUB_REPOSITORY: "test-owner/test-repo",
+};
+
+/** Run the assemble-pr-body script in a temp directory */
+async function runAssemblePrBody(
+  cwd: string,
+  extraEnv?: Record<string, string>
+): Promise<{ exitCode: number; output: string }> {
+  const scriptPath = join(import.meta.dirname, "assemble-pr-body.ts");
+  const result = await $`bun ${scriptPath}`
+    .cwd(cwd)
+    .env({ ...cleanEnv, ...extraEnv })
+    .quiet()
+    .nothrow();
+  return {
+    exitCode: result.exitCode,
+    output: result.stdout.toString() + result.stderr.toString(),
+  };
+}
+
+/** Create .release_bot/body with a simple changelog */
+async function createBody(cwd: string, content: string): Promise<void> {
+  await Bun.write(join(cwd, ".release_bot/body"), content, { createPath: true });
+}
+
+/** Create .release_bot/release_notes.md */
+async function createReleaseNotes(cwd: string, content: string): Promise<void> {
+  await Bun.write(join(cwd, ".release_bot/release_notes.md"), content, { createPath: true });
+}
+
+/** Read the assembled body_enhanced output */
+async function readEnhanced(cwd: string): Promise<string> {
+  return Bun.file(join(cwd, ".release_bot/body_enhanced")).text();
+}
+
+/** Generate a string of a specific length */
+function generateLargeContent(length: number): string {
+  return "x".repeat(length);
+}
+
+describe("assemble-pr-body", () => {
+  describe("normal assembly", () => {
+    test("combines badges, release notes, tickets table, and changelog link", () =>
+      withTempDir(async (dir) => {
+        await createBody(
+          dir,
+          "![release:minor](badge)\n\n## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| [TOOLS-1: Fix](url) | [#10](pr) | @dev |\n\n### Features\n\n* feat A"
+        );
+        await createReleaseNotes(dir, "Some AI release notes");
+        await Bun.write(join(dir, "version"), "1.0.0");
+
+        await runAssemblePrBody(dir, githubEnv);
+
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain("![release:minor](badge)");
+        expect(enhanced).toContain("## Release Notes");
+        expect(enhanced).toContain("Some AI release notes");
+        expect(enhanced).toContain("<h2>Linear</h2>");
+        expect(enhanced).toContain("TOOLS-1");
+        expect(enhanced).toContain("| Issue | PR | Author |");
+        expect(enhanced).toContain("📋 [Detailed changelog]");
+        expect(enhanced).toContain("CHANGELOG.md");
+        // Should NOT contain inline changelog
+        expect(enhanced).not.toContain("feat A");
+      }));
+
+    test("handles missing release notes file gracefully", () =>
+      withTempDir(async (dir) => {
+        await createBody(dir, "![release:patch](badge)\n\n### Bug Fixes\n\n* fix B");
+
+        const { exitCode } = await runAssemblePrBody(dir);
+
+        expect(exitCode).toBe(0);
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain("## Release Notes");
+        expect(enhanced).toContain("📋 Detailed changelog");
+      }));
+
+    test("handles empty release notes file", () =>
+      withTempDir(async (dir) => {
+        await createBody(dir, "![release:patch](badge)\n\n### Features\n\n* feat C");
+        await createReleaseNotes(dir, "   ");
+
+        const { exitCode } = await runAssemblePrBody(dir);
+
+        expect(exitCode).toBe(0);
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain("## Release Notes");
+      }));
+
+    test("exits with error when body file is missing", () =>
+      withTempDir(async (dir) => {
+        await createReleaseNotes(dir, "Some notes");
+
+        const { exitCode } = await runAssemblePrBody(dir);
+
+        expect(exitCode).not.toBe(0);
+      }));
+
+    test("body without ticket sections has no ticket details blocks", () =>
+      withTempDir(async (dir) => {
+        await createBody(dir, "![badge](url)\n\n### Features\n\n* feat D");
+        await createReleaseNotes(dir, "Notes");
+
+        await runAssemblePrBody(dir);
+
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).not.toContain("<summary><h2>");
+        expect(enhanced).toContain("📋 Detailed changelog");
+      }));
+
+    test("changelog link points to CHANGELOG.md on the release branch", () =>
+      withTempDir(async (dir) => {
+        await createBody(dir, "![badge](url)\n\n### Features\n\n* feat E");
+        await createReleaseNotes(dir, "Notes");
+        await Bun.write(join(dir, "version"), "2.0.0");
+
+        await runAssemblePrBody(dir, githubEnv);
+
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain(
+          "📋 [Detailed changelog](https://github.com/test-owner/test-repo/blob/release-2.0.0/CHANGELOG.md)"
+        );
+      }));
+
+    test("changelog link uses relative path without GitHub env vars", () =>
+      withTempDir(async (dir) => {
+        await createBody(dir, "![badge](url)\n\n### Features\n\n* feat G");
+        await createReleaseNotes(dir, "Notes");
+        await Bun.write(join(dir, "version"), "1.5.0");
+
+        await runAssemblePrBody(dir);
+
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain("📋 [Detailed changelog](CHANGELOG.md)");
+      }));
+  });
+
+  describe("truncation", () => {
+    test("truncates body with link to release notes", () =>
+      withTempDir(async (dir) => {
+        await createBody(dir, `![badge](url)\n\n### Features\n\n* feat`);
+        await createReleaseNotes(dir, generateLargeContent(70000));
+        await Bun.write(join(dir, "version"), "1.5.0");
+
+        const { exitCode, output } = await runAssemblePrBody(dir, githubEnv);
+
+        expect(exitCode).toBe(0);
+        expect(output).toContain("::warning::");
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced.length).toBeLessThanOrEqual(65536);
+        expect(enhanced).toContain(
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-1.5.0/.release_notes/1.5.0.md)"
+        );
+      }));
+
+    test("truncation preserves badges and ticket sections", () =>
+      withTempDir(async (dir) => {
+        await createBody(
+          dir,
+          `![release:major](badge)\n\n## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| [TOOLS-321: Fix](url) | [#10](pr) | @dev |\n\n### Features\n\n* feat`
+        );
+        await createReleaseNotes(dir, generateLargeContent(70000));
+        await Bun.write(join(dir, "version"), "10.0.0");
+
+        await runAssemblePrBody(dir, githubEnv);
+
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain("![release:major](badge)");
+        expect(enhanced).toContain("<h2>Linear</h2>");
+        expect(enhanced).toContain("TOOLS-321");
+        expect(enhanced).toContain(
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-10.0.0/.release_notes/10.0.0.md)"
+        );
+      }));
+
+    test("truncation with no version file uses generic message", () =>
+      withTempDir(async (dir) => {
+        await createBody(dir, `![badge](url)\n\n### Features\n\n* feat`);
+        await createReleaseNotes(dir, generateLargeContent(70000));
+
+        await runAssemblePrBody(dir);
+
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain("See release notes file for detailed changes.");
+        expect(enhanced).not.toContain("[full release notes]");
+      }));
+
+    test("uses custom branch template from INPUT_BRANCH", () =>
+      withTempDir(async (dir) => {
+        await createBody(dir, `![badge](url)\n\n### Features\n\n* feat`);
+        await createReleaseNotes(dir, generateLargeContent(70000));
+        await Bun.write(join(dir, "version"), "3.1.0");
+
+        await runAssemblePrBody(dir, { ...githubEnv, INPUT_BRANCH: "rel/{version}" });
+
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain(
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/rel/3.1.0/.release_notes/3.1.0.md)"
+        );
+      }));
+
+    test("wraps multiple ticket types in separate details blocks", () =>
+      withTempDir(async (dir) => {
+        await createBody(
+          dir,
+          `![badge](url)\n\n## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| [TOOLS-99: Fix](url) | [#5](pr) | @dev |\n\n## GitHub Issues\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| #42 | [#6](pr) | @dev |\n\n### Features\n\n* feat`
+        );
+        await createReleaseNotes(dir, generateLargeContent(70000));
+        await Bun.write(join(dir, "version"), "7.0.0");
+
+        await runAssemblePrBody(dir, githubEnv);
+
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain("<h2>Linear</h2>");
+        expect(enhanced).toContain("TOOLS-99");
+        expect(enhanced).toContain("<h2>GitHub Issues</h2>");
+        expect(enhanced).toContain("#42");
+
+        const detailsCount = (enhanced.match(/<details><summary><h2>/g) ?? []).length;
+        expect(detailsCount).toBe(2);
+      }));
+
+    test("drops tickets section when tickets alone exceed the limit", () =>
+      withTempDir(async (dir) => {
+        const hugeTickets = `## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n${generateLargeContent(70000)}`;
+        await createBody(
+          dir,
+          `![release:major](badge)\n\n${hugeTickets}\n\n### Features\n\n* feat`
+        );
+        await createReleaseNotes(dir, "Small release notes");
+        await Bun.write(join(dir, "version"), "25.0.0");
+
+        const { exitCode, output } = await runAssemblePrBody(dir, githubEnv);
+
+        expect(exitCode).toBe(0);
+        expect(output).toContain("Dropping tickets section");
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced.length).toBeLessThanOrEqual(65536);
+        expect(enhanced).toContain("![release:major](badge)");
+        expect(enhanced).not.toContain("<h2>Linear</h2>");
+        expect(enhanced).toContain(
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-25.0.0/.release_notes/25.0.0.md)"
+        );
+      }));
+
+    test("hard-truncates when even summary-only body exceeds limit", () =>
+      withTempDir(async (dir) => {
+        const hugeSummary = `![release:major](badge)\n\n${generateLargeContent(70000)}`;
+        await createBody(dir, `${hugeSummary}\n\n### Features\n\n* feat`);
+        await createReleaseNotes(dir, "Notes");
+        await Bun.write(join(dir, "version"), "9.0.0");
+
+        const { exitCode, output } = await runAssemblePrBody(dir, githubEnv);
+
+        expect(exitCode).toBe(0);
+        expect(output).toContain("Hard-truncating");
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced.length).toBeLessThanOrEqual(65536);
+        expect(enhanced.startsWith("![release:major](badge)")).toBe(true);
+        expect(enhanced).toContain(
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-9.0.0/.release_notes/9.0.0.md)"
+        );
+        expect(enhanced).toContain(
+          "📋 [Detailed changelog](https://github.com/test-owner/test-repo/blob/release-9.0.0/CHANGELOG.md)"
+        );
+      }));
+  });
+});

--- a/.github/actions/release-action/src/assemble-pr-body.ts
+++ b/.github/actions/release-action/src/assemble-pr-body.ts
@@ -1,0 +1,237 @@
+/**
+ * Assemble enhanced PR body with AI-generated release notes
+ *
+ * Reads release notes from `.release_bot/release_notes.md` and the raw changelog
+ * from `.release_bot/body`, then combines them into an enhanced PR body.
+ * Replaces inline conventional changelog with a link to the CHANGELOG file.
+ * Truncates the body when it exceeds GitHub's 65536 character PR body limit:
+ * first replaces release notes with a link, then drops the tickets section if
+ * still too long, and hard-truncates as a last resort.
+ *
+ * @example
+ * ```bash
+ * bun src/assemble-pr-body.ts
+ * ```
+ */
+
+export {};
+
+/** GitHub's maximum character limit for PR body */
+const githubBodyMaxLength = 65536;
+
+const releaseNotesFile = Bun.file(".release_bot/release_notes.md");
+const releaseNotes = (await releaseNotesFile.exists())
+  ? (await releaseNotesFile.text()).trim()
+  : "";
+
+const rawBody = await Bun.file(".release_bot/body").text();
+const lines = rawBody.split("\n");
+
+// Find ticket sections (## Linear, ## Jira, ## GitHub Issues) - these stay visible
+const ticketStartIndex = lines.findIndex(
+  (line) =>
+    line.startsWith("## Linear") ||
+    line.startsWith("## Jira") ||
+    line.startsWith("## GitHub Issues")
+);
+
+// Find conventional changelog sections (### Features, ### Bug Fixes, etc.) - replaced with link
+const changelogStartIndex = lines.findIndex((line) => line.startsWith("### "));
+
+// Determine where summary ends
+function getSummaryEndIndex(): number {
+  if (ticketStartIndex > 0) return ticketStartIndex;
+  if (changelogStartIndex > 0) return changelogStartIndex;
+  return lines.length;
+}
+
+const summarySection = lines.slice(0, getSummaryEndIndex()).join("\n");
+
+// Extract ticket section (between ## tickets and ### changelog)
+function getTicketSection(): string {
+  if (ticketStartIndex <= 0) return "";
+  if (changelogStartIndex > ticketStartIndex) {
+    return lines.slice(ticketStartIndex, changelogStartIndex).join("\n");
+  }
+  return lines.slice(ticketStartIndex).join("\n");
+}
+
+const ticketSection = getTicketSection();
+
+// Safety net: strip any leading markdown headers AI may generate despite instructions
+const cleanedNotes = releaseNotes.replace(/^(#+\s+.*\n+)+/, "");
+
+/** Release notes file path and the branch it will be committed to */
+interface ReleaseNotesTarget {
+  path: string;
+  branch: string;
+}
+
+/**
+ * Detect the release notes file path and branch for linking.
+ *
+ * Reads the `version` file and resolves the branch from the `INPUT_BRANCH` template.
+ */
+async function getReleaseNotesTarget(): Promise<ReleaseNotesTarget | undefined> {
+  const versionFile = Bun.file("version");
+  if (await versionFile.exists()) {
+    const version = (await versionFile.text()).trim();
+    if (version) {
+      const template = process.env.INPUT_BRANCH ?? "release-{version}";
+      return {
+        path: `.release_notes/${version}.md`,
+        branch: template.replace("{version}", version),
+      };
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Build an absolute blob URL for a file on the release branch.
+ *
+ * Falls back to the relative path when GitHub environment variables are not available.
+ */
+function buildBlobUrl(branch: string, filePath: string): string {
+  const serverUrl = process.env.GITHUB_SERVER_URL;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (serverUrl && repository) {
+    return `${serverUrl}/${repository}/blob/${branch}/${filePath}`;
+  }
+  console.log(
+    "::warning::GITHUB_SERVER_URL or GITHUB_REPOSITORY not set. Using relative path for link."
+  );
+  return filePath;
+}
+
+/** Wrap each ticket section heading in a collapsible `<details>` block */
+function wrapTicketsInDetails(tickets: string): string {
+  if (!tickets.trim()) return "";
+
+  const parts = tickets.split(/^(?=## (?:Linear|Jira|GitHub Issues))/m);
+
+  return parts
+    .filter((part) => part.trim())
+    .map((part) => {
+      const [fullMatch, heading] = part.match(/^## (Linear|Jira|GitHub Issues)/)!;
+      const content = part.slice(fullMatch.length).trim();
+      return `<details><summary><h2>${heading}</h2></summary>\n\n${content}\n\n</details>`;
+    })
+    .join("\n\n");
+}
+
+// Resolve target once — reused for both changelog link and truncation
+const releaseTarget = await getReleaseNotesTarget();
+
+// Build changelog link and final body
+const changelogLink = releaseTarget
+  ? `📋 [Detailed changelog](${buildBlobUrl(releaseTarget.branch, "CHANGELOG.md")})`
+  : "📋 Detailed changelog";
+
+// Build final body: Badges → Release Notes → Tickets → Changelog Link
+const wrappedTickets = wrapTicketsInDetails(ticketSection);
+const ticketBlock = wrappedTickets ? `${wrappedTickets}\n\n` : "";
+
+const enhanced = `${summarySection.trimEnd()}
+
+## Release Notes
+
+${cleanedNotes}
+
+${ticketBlock}${changelogLink}
+`;
+
+/**
+ * Build a truncated PR body that fits within GitHub's limit.
+ *
+ * Replaces release notes with a link to the release notes file.
+ * Keeps tickets and changelog link.
+ *
+ * @param summary - Badge/summary section from the raw body
+ * @param ticketsBlock - Pre-formatted ticket section block (may be empty)
+ * @param changelogLinkLine - Pre-formatted changelog link line
+ * @param target - Resolved release notes target (avoids redundant file I/O)
+ */
+function truncateBody(
+  summary: string,
+  ticketsBlock: string,
+  changelogLinkLine: string,
+  target: ReleaseNotesTarget | undefined
+): string {
+  const linkText = target
+    ? `See [full release notes](${buildBlobUrl(target.branch, target.path)}) for detailed changes.`
+    : "See release notes file for detailed changes.";
+
+  return `${summary.trimEnd()}
+
+## Release Notes
+
+${linkText}
+
+${ticketsBlock}${changelogLinkLine}
+`;
+}
+
+/**
+ * Build a hard-truncated PR body that preserves the release notes and
+ * changelog links by trimming the summary to whatever budget remains.
+ *
+ * Only reached when even the tickets-dropped body exceeds the limit —
+ * typically means the summary itself is enormous.
+ */
+function hardTruncateBody(
+  summary: string,
+  changelogLinkLine: string,
+  target: ReleaseNotesTarget | undefined
+): string {
+  const shell = truncateBody("", "", changelogLinkLine, target);
+  const budget = githubBodyMaxLength - shell.length;
+  if (budget <= 0) return shell.slice(0, githubBodyMaxLength);
+  return truncateBody(summary.slice(0, budget), "", changelogLinkLine, target);
+}
+
+/**
+ * Pick a body variant that fits within GitHub's PR body limit.
+ *
+ * Cascades: full → release notes replaced with link → tickets also dropped
+ * → hard-truncated as last resort. Each step falls through only when the
+ * previous variant still exceeds the limit.
+ */
+function pickBodyWithinLimit(
+  full: string,
+  summary: string,
+  ticketsBlock: string,
+  changelogLinkLine: string,
+  target: ReleaseNotesTarget | undefined
+): string {
+  if (full.length <= githubBodyMaxLength) return full;
+
+  console.log(
+    `::warning::PR body exceeds GitHub limit (${full.length}/${githubBodyMaxLength} chars). Truncating release notes.`
+  );
+  const withoutNotes = truncateBody(summary, ticketsBlock, changelogLinkLine, target);
+  if (withoutNotes.length <= githubBodyMaxLength) return withoutNotes;
+
+  console.log(
+    `::warning::Truncated body still exceeds GitHub limit (${withoutNotes.length}/${githubBodyMaxLength} chars). Dropping tickets section.`
+  );
+  const withoutTickets = truncateBody(summary, "", changelogLinkLine, target);
+  if (withoutTickets.length <= githubBodyMaxLength) return withoutTickets;
+
+  console.log(
+    `::warning::Body still exceeds GitHub limit (${withoutTickets.length}/${githubBodyMaxLength} chars). Hard-truncating.`
+  );
+  return hardTruncateBody(summary, changelogLinkLine, target);
+}
+
+const finalBody = pickBodyWithinLimit(
+  enhanced,
+  summarySection,
+  ticketBlock,
+  changelogLink,
+  releaseTarget
+);
+await Bun.write(".release_bot/body_enhanced", finalBody);
+
+console.log("Enhanced PR body written to .release_bot/body_enhanced");

--- a/.github/actions/release-action/src/generateReleaseNotes.test.ts
+++ b/.github/actions/release-action/src/generateReleaseNotes.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for AI release notes generation
+ */
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { withTempDir } from "./testHelpers.ts";
+
+import {
+  type AnthropicMessages,
+  callAnthropicApi,
+  verifyReleaseNotes,
+} from "./generateReleaseNotes.ts";
+import {
+  buildUserMessage,
+  filterChangelogForAi,
+  readServiceContext,
+  systemPrompt,
+} from "./releaseNotesPrompt.ts";
+
+describe("filterChangelogForAi", () => {
+  test("strips Chores, CI, Tests, and Build sections", () => {
+    const changelog = [
+      "### Features",
+      "",
+      "* add new endpoint",
+      "",
+      "### Chores",
+      "",
+      "* **deps:** bump eslint from 9 to 10",
+      "* update CONTRIBUTING.md",
+      "",
+      "### CI",
+      "",
+      "* update code-review workflow",
+      "",
+      "### Tests",
+      "",
+      "* **release:** increase test timeout to 30s",
+      "",
+      "### Build",
+      "",
+      "* regenerate bun.lock",
+    ].join("\n");
+
+    const result = filterChangelogForAi(changelog);
+
+    expect(result).toContain("### Features");
+    expect(result).toContain("add new endpoint");
+    expect(result).not.toContain("### Chores");
+    expect(result).not.toContain("bump eslint");
+    expect(result).not.toContain("### CI");
+    expect(result).not.toContain("code-review workflow");
+    expect(result).not.toContain("### Tests");
+    expect(result).not.toContain("test timeout");
+    expect(result).not.toContain("### Build");
+    expect(result).not.toContain("bun.lock");
+  });
+
+  test("preserves Features, Bug Fixes, Refactoring, Documentation, Performance", () => {
+    const changelog = [
+      "### Features",
+      "",
+      "* new feature",
+      "",
+      "### Bug Fixes",
+      "",
+      "* fix bug",
+      "",
+      "### Refactoring",
+      "",
+      "* refactor module",
+      "",
+      "### Documentation",
+      "",
+      "* update docs",
+      "",
+      "### Performance",
+      "",
+      "* optimize query",
+    ].join("\n");
+
+    const result = filterChangelogForAi(changelog);
+
+    expect(result).toContain("### Features");
+    expect(result).toContain("### Bug Fixes");
+    expect(result).toContain("### Refactoring");
+    expect(result).toContain("### Documentation");
+    expect(result).toContain("### Performance");
+  });
+
+  test("handles empty input", () => {
+    expect(filterChangelogForAi("")).toBe("");
+  });
+
+  test("returns empty when changelog has only irrelevant sections", () => {
+    const changelog = ["### Chores", "", "* bump deps", "", "### CI", "", "* update workflow"].join(
+      "\n"
+    );
+
+    expect(filterChangelogForAi(changelog)).toBe("");
+  });
+
+  test("collapses multiple blank lines after filtering", () => {
+    const changelog = [
+      "### Features",
+      "",
+      "* feature one",
+      "",
+      "### Chores",
+      "",
+      "* bump deps",
+      "",
+      "### Bug Fixes",
+      "",
+      "* fix bug",
+    ].join("\n");
+
+    const result = filterChangelogForAi(changelog);
+
+    expect(result).not.toMatch(/\n{3,}/);
+    expect(result).toContain("### Features");
+    expect(result).toContain("### Bug Fixes");
+  });
+});
+
+describe("readServiceContext", () => {
+  test("reads README.md from directory", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, "README.md"), "# My Service\n\nA cool service.");
+
+      const context = await readServiceContext(dir);
+
+      expect(context).toContain("README:");
+      expect(context).toContain("My Service");
+    }));
+
+  test("reads docs/*.md files", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, "docs", "api.md"), "# API Reference\n\nEndpoint docs.", {
+        createPath: true,
+      });
+
+      const context = await readServiceContext(dir);
+
+      expect(context).toContain("api.md");
+      expect(context).toContain("API Reference");
+    }));
+
+  test("truncates large README", () =>
+    withTempDir(async (dir) => {
+      const largeContent = "x".repeat(5000);
+      await Bun.write(join(dir, "README.md"), largeContent);
+
+      const context = await readServiceContext(dir);
+
+      expect(context.length).toBeLessThan(5000);
+      expect(context).toContain("...");
+    }));
+
+  test("returns empty string when no files exist", () =>
+    withTempDir(async (dir) => {
+      const context = await readServiceContext(dir);
+
+      expect(context).toBe("");
+    }));
+});
+
+describe("buildUserMessage", () => {
+  test("assembles changelog only", () => {
+    const message = buildUserMessage("### Features\n\n* feature");
+
+    expect(message).toContain("CHANGELOG:");
+    expect(message).toContain("feature");
+    expect(message).not.toContain("SERVICE CONTEXT");
+    expect(message).not.toContain("TICKET CONTEXT");
+    expect(message).not.toContain("PR DESCRIPTIONS");
+  });
+
+  test("includes service context when provided", () => {
+    const message = buildUserMessage("changelog", "README:\n# Service");
+
+    expect(message).toContain("SERVICE CONTEXT:");
+    expect(message).toContain("# Service");
+  });
+
+  test("includes tickets when provided", () => {
+    const message = buildUserMessage("changelog", undefined, '[{"id": "T-1"}]');
+
+    expect(message).toContain("TICKET CONTEXT");
+    expect(message).toContain("T-1");
+  });
+
+  test("includes PR descriptions when provided", () => {
+    const message = buildUserMessage("changelog", undefined, undefined, "- PR #1: Feature");
+
+    expect(message).toContain("PR DESCRIPTIONS");
+    expect(message).toContain("PR #1: Feature");
+  });
+
+  test("includes all sources", () => {
+    const message = buildUserMessage("changelog", "context", "tickets", "pr descs");
+
+    expect(message).toContain("SERVICE CONTEXT:");
+    expect(message).toContain("CHANGELOG:");
+    expect(message).toContain("TICKET CONTEXT");
+    expect(message).toContain("PR DESCRIPTIONS");
+  });
+});
+
+describe("systemPrompt", () => {
+  test("contains audience description", () => {
+    expect(systemPrompt).toContain("delivery/integration team");
+  });
+
+  test("contains all section headings", () => {
+    expect(systemPrompt).toContain("## ✨ What's New");
+    expect(systemPrompt).toContain("## 🐛 Bug Fixes");
+    expect(systemPrompt).toContain("## 📋 Protocol & Contract Changes");
+    expect(systemPrompt).toContain("## ⚙️ Configuration Required");
+    expect(systemPrompt).toContain("## ⚠️ Breaking Changes");
+    expect(systemPrompt).toContain("## 📚 Documentation & Settings Updates");
+  });
+
+  test("contains exclusion rules", () => {
+    expect(systemPrompt).toContain("EXCLUDE");
+    expect(systemPrompt).toContain("CI/CD pipeline");
+    expect(systemPrompt).toContain("Dependency version bumps");
+    expect(systemPrompt).toContain("CONTRIBUTING.md");
+    expect(systemPrompt).toContain("test infrastructure");
+    expect(systemPrompt).toContain("lockfile");
+  });
+
+  test("contains service context instruction", () => {
+    expect(systemPrompt).toContain("SERVICE CONTEXT");
+  });
+});
+
+describe("filterChangelogForAi + buildUserMessage pipeline", () => {
+  const changelog = "### Features\n\n* add new endpoint\n\n### Chores\n\n* bump eslint\n";
+
+  test("filters irrelevant sections and builds user message", () => {
+    const filtered = filterChangelogForAi(changelog);
+    const message = buildUserMessage(filtered);
+
+    expect(message).toContain("CHANGELOG:");
+    expect(message).toContain("add new endpoint");
+    expect(message).not.toContain("bump eslint");
+    expect(message).not.toContain("### Chores");
+  });
+
+  test("includes all sources together", () => {
+    const filtered = filterChangelogForAi(changelog);
+    const tickets = '[{"id": "T-1"}]';
+    const prDesc = "- PR #1: Feature\n";
+    const message = buildUserMessage(filtered, "context", tickets, prDesc);
+
+    expect(message).toContain("SERVICE CONTEXT:");
+    expect(message).toContain("TICKET CONTEXT");
+    expect(message).toContain("PR DESCRIPTIONS");
+    expect(message).not.toContain("### Chores");
+  });
+});
+
+describe("verifyReleaseNotes", () => {
+  test("keeps existing non-empty notes", () =>
+    withTempDir(async (dir) => {
+      const notesPath = join(dir, "release_notes.md");
+      const bodyPath = join(dir, "body");
+      await Bun.write(notesPath, "Existing release notes");
+      await Bun.write(bodyPath, "Changelog body");
+
+      await verifyReleaseNotes(notesPath, bodyPath);
+
+      const content = await Bun.file(notesPath).text();
+      expect(content).toBe("Existing release notes");
+    }));
+
+  test("falls back to body when notes are empty", () =>
+    withTempDir(async (dir) => {
+      const notesPath = join(dir, "release_notes.md");
+      const bodyPath = join(dir, "body");
+      await Bun.write(notesPath, "");
+      await Bun.write(bodyPath, "Changelog content here");
+
+      await verifyReleaseNotes(notesPath, bodyPath);
+
+      const content = await Bun.file(notesPath).text();
+      expect(content).toBe("Changelog content here");
+    }));
+
+  test("strips badge images from body fallback", () =>
+    withTempDir(async (dir) => {
+      const notesPath = join(dir, "release_notes.md");
+      const bodyPath = join(dir, "body");
+      await Bun.write(bodyPath, "![badge](url)\n\nActual content");
+
+      await verifyReleaseNotes(notesPath, bodyPath);
+
+      const content = await Bun.file(notesPath).text();
+      expect(content).not.toContain("![badge]");
+      expect(content).toContain("Actual content");
+    }));
+
+  test("uses default message when no body available", () =>
+    withTempDir(async (dir) => {
+      const notesPath = join(dir, "release_notes.md");
+      const bodyPath = join(dir, "body");
+
+      await verifyReleaseNotes(notesPath, bodyPath);
+
+      const content = await Bun.file(notesPath).text();
+      expect(content).toContain("See changelog for detailed changes");
+    }));
+
+  test("uses default message when body is only badges", () =>
+    withTempDir(async (dir) => {
+      const notesPath = join(dir, "release_notes.md");
+      const bodyPath = join(dir, "body");
+      await Bun.write(bodyPath, "![badge1](url)\n![badge2](url)\n");
+
+      await verifyReleaseNotes(notesPath, bodyPath);
+
+      const content = await Bun.file(notesPath).text();
+      expect(content).toContain("See changelog for detailed changes");
+    }));
+});
+
+describe("callAnthropicApi", () => {
+  test("returns text from API response", async () => {
+    const mockMessages: AnthropicMessages = {
+      create: async () => ({
+        content: [{ type: "text", text: "Generated notes" }],
+      }),
+    };
+
+    const result = await callAnthropicApi("test-key", "test prompt", "system prompt", mockMessages);
+
+    expect(result).toBe("Generated notes");
+  });
+
+  test("forwards system prompt and user message to client", async () => {
+    let capturedSystem: string | undefined;
+    let capturedUserContent: string | undefined;
+    const mockMessages: AnthropicMessages = {
+      create: async (params) => {
+        capturedSystem = params.system;
+        capturedUserContent = params.messages[0]?.content;
+        return { content: [{ type: "text", text: "notes" }] };
+      },
+    };
+
+    await callAnthropicApi("test-key", "user msg", "my system prompt", mockMessages);
+
+    expect(capturedSystem).toBe("my system prompt");
+    expect(capturedUserContent).toBe("user msg");
+  });
+
+  test("throws when API returns no text content", async () => {
+    const mockMessages: AnthropicMessages = {
+      create: async () => ({
+        content: [{ type: "tool_use" }],
+      }),
+    };
+
+    await expect(
+      callAnthropicApi("test-key", "test prompt", "system", mockMessages)
+    ).rejects.toThrow("Anthropic API returned no text content");
+  });
+});

--- a/.github/actions/release-action/src/generateReleaseNotes.ts
+++ b/.github/actions/release-action/src/generateReleaseNotes.ts
@@ -1,0 +1,150 @@
+/**
+ * Generate AI-powered release notes via Anthropic API and verify output.
+ *
+ * Reads changelog and optional ticket/PR context from `.release_bot/`,
+ * calls the Anthropic Messages API to produce human-readable release notes,
+ * then verifies notes exist (with fallback to changelog body).
+ *
+ * @example
+ * ```bash
+ * ANTHROPIC_API_KEY=sk-... bun src/generateReleaseNotes.ts
+ * ```
+ */
+import Anthropic from "@anthropic-ai/sdk";
+
+import {
+  anthropicModel,
+  buildUserMessage,
+  filterChangelogForAi,
+  maxOutputTokens,
+  readServiceContext,
+  systemPrompt,
+} from "./releaseNotesPrompt.ts";
+
+/** Minimal interface for the Anthropic messages client (for testing) */
+export interface AnthropicMessages {
+  create(params: {
+    model: string;
+    max_tokens: number;
+    system?: string;
+    messages: Array<{ role: string; content: string }>;
+  }): Promise<{ content: Array<{ type: string; text?: string }> }>;
+}
+
+/**
+ * Call the Anthropic Messages API to generate release notes.
+ *
+ * @param apiKey - Anthropic API key
+ * @param userMessage - User message with changelog and context
+ * @param system - System prompt with stable instructions
+ * @param messages - Optional messages client (for testing)
+ * @returns Generated release notes text
+ * @throws On API error or timeout
+ */
+export async function callAnthropicApi(
+  apiKey: string,
+  userMessage: string,
+  system: string,
+  messages?: AnthropicMessages
+): Promise<string> {
+  const client = messages ?? new Anthropic({ apiKey, timeout: 120_000 }).messages;
+
+  const message = await client.create({
+    model: anthropicModel,
+    max_tokens: maxOutputTokens,
+    system,
+    messages: [{ role: "user", content: userMessage }],
+  });
+
+  for (const block of message.content) {
+    if (block.type === "text" && "text" in block) {
+      return block.text as string;
+    }
+  }
+
+  throw new Error("Anthropic API returned no text content");
+}
+
+/**
+ * Verify release notes exist and apply fallback if needed.
+ *
+ * Priority:
+ * 1. Use existing notes if non-empty
+ * 2. Fall back to changelog body (stripped of badge images)
+ * 3. Last resort: default placeholder message
+ *
+ * @param notesPath - Path to release_notes.md
+ * @param bodyPath - Path to changelog body file (fallback source)
+ */
+export async function verifyReleaseNotes(notesPath: string, bodyPath: string): Promise<void> {
+  const notesFile = Bun.file(notesPath);
+
+  if (await notesFile.exists()) {
+    const content = (await notesFile.text()).trim();
+    if (content.length > 0) {
+      console.log("Release notes present");
+      return;
+    }
+  }
+
+  console.log("AI release notes not generated, using full changelog");
+
+  const bodyFile = Bun.file(bodyPath);
+  if (await bodyFile.exists()) {
+    const body = await bodyFile.text();
+    const stripped = body.replace(/^!\[.*\n?/gm, "").trim();
+    if (stripped.length > 0) {
+      await Bun.write(notesPath, stripped);
+      return;
+    }
+  }
+
+  await Bun.write(notesPath, "- See changelog for detailed changes\n");
+}
+
+async function generateWithApi(apiKey: string, notesPath: string, bodyPath: string): Promise<void> {
+  try {
+    const changelog = await Bun.file(bodyPath).text();
+
+    const ticketsFile = Bun.file(".release_bot/tickets.json");
+    const tickets = (await ticketsFile.exists()) ? await ticketsFile.text() : undefined;
+
+    const prDescFile = Bun.file(".release_bot/pr_descriptions.yml");
+    const prDescriptions = (await prDescFile.exists()) ? await prDescFile.text() : undefined;
+
+    const serviceContext = await readServiceContext();
+
+    if (serviceContext) console.log("Found service documentation context");
+    if (tickets) console.log("Found tickets.json with context");
+    if (prDescriptions) console.log("Found pr_descriptions.yml with context");
+
+    const filtered = filterChangelogForAi(changelog);
+    const userMessage = buildUserMessage(filtered, serviceContext, tickets, prDescriptions);
+    const notes = await callAnthropicApi(apiKey, userMessage, systemPrompt);
+
+    await Bun.write(notesPath, notes, { createPath: true });
+    console.log("Release notes generated");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`::warning::Failed to generate release notes: ${message}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const notesPath = ".release_bot/release_notes.md";
+  const bodyPath = ".release_bot/body";
+
+  if (apiKey) {
+    await generateWithApi(apiKey, notesPath, bodyPath);
+  }
+
+  await verifyReleaseNotes(notesPath, bodyPath);
+}
+
+if (import.meta.main) {
+  main().catch((error: Error) => {
+    console.log(`::error::${error.message}`);
+    process.exit(1);
+  });
+}

--- a/.github/actions/release-action/src/gitTags.test.ts
+++ b/.github/actions/release-action/src/gitTags.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for git tag listing utility
+ */
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+
+import { getLatestReachableTag, listTags } from "./gitTags.ts";
+import { createCommit, withTempRepo } from "./testHelpers.ts";
+
+describe("listTags", () => {
+  test("returns empty array when no tags exist", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "init");
+
+      const tags = await listTags("v*", repo);
+
+      expect(tags).toEqual([]);
+    }));
+
+  test("returns single tag", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "init");
+      await $`git tag v1.0.0`.cwd(repo).quiet();
+
+      const tags = await listTags("v*", repo);
+
+      expect(tags).toEqual(["v1.0.0"]);
+    }));
+
+  test("returns tags sorted newest first", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "first");
+      await $`git tag v1.0.0`.cwd(repo).quiet();
+      await createCommit(repo, "second", "file2.txt");
+      await $`git tag v2.0.0`.cwd(repo).quiet();
+      await createCommit(repo, "third", "file3.txt");
+      await $`git tag v1.1.0`.cwd(repo).quiet();
+
+      const tags = await listTags("v*", repo);
+
+      expect(tags).toEqual(["v2.0.0", "v1.1.0", "v1.0.0"]);
+    }));
+
+  test("filters by pattern", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "init");
+      await $`git tag v1.0.0`.cwd(repo).quiet();
+      await $`git tag rc-1.0.0`.cwd(repo).quiet();
+
+      const vTags = await listTags("v*", repo);
+      const rcTags = await listTags("rc-*", repo);
+
+      expect(vTags).toEqual(["v1.0.0"]);
+      expect(rcTags).toEqual(["rc-1.0.0"]);
+    }));
+});
+
+describe("getLatestReachableTag", () => {
+  test("returns null when no tags exist", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "init");
+
+      const tag = await getLatestReachableTag("v*", repo);
+
+      expect(tag).toBeNull();
+    }));
+
+  test("returns the only tag", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "init");
+      await $`git tag v1.0.0`.cwd(repo).quiet();
+
+      const tag = await getLatestReachableTag("v*", repo);
+
+      expect(tag).toBe("v1.0.0");
+    }));
+
+  test("returns topologically closest tag, not highest version", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "first");
+      await $`git tag v1.0.0`.cwd(repo).quiet();
+      await createCommit(repo, "second", "file2.txt");
+      await $`git tag v0.16.0`.cwd(repo).quiet();
+      await createCommit(repo, "third", "file3.txt");
+      await $`git tag v0.16.1`.cwd(repo).quiet();
+      await createCommit(repo, "fourth", "file4.txt");
+
+      const tag = await getLatestReachableTag("v*", repo);
+
+      // v0.16.1 is closer to HEAD than v1.0.0, even though v1.0.0 is a higher version
+      expect(tag).toBe("v0.16.1");
+    }));
+
+  test("respects pattern filter", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "init");
+      await $`git tag v1.0.0`.cwd(repo).quiet();
+      await $`git tag rc-1.0.0`.cwd(repo).quiet();
+
+      expect(await getLatestReachableTag("v*", repo)).toBe("v1.0.0");
+      expect(await getLatestReachableTag("rc-*", repo)).toBe("rc-1.0.0");
+    }));
+
+  test("respects custom ref", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "first");
+      await $`git tag v1.0.0`.cwd(repo).quiet();
+      await createCommit(repo, "second", "file2.txt");
+      await $`git tag v1.1.0`.cwd(repo).quiet();
+      await createCommit(repo, "third", "file3.txt");
+
+      const tag = await getLatestReachableTag("v*", repo, "v1.1.0");
+
+      expect(tag).toBe("v1.1.0");
+    }));
+
+  test("returns null for non-existent ref", () =>
+    withTempRepo(async (repo) => {
+      await createCommit(repo, "init");
+      await $`git tag v1.0.0`.cwd(repo).quiet();
+
+      const tag = await getLatestReachableTag("v*", repo, "nonexistent-ref");
+
+      expect(tag).toBeNull();
+    }));
+});
+

--- a/.github/actions/release-action/src/gitTags.ts
+++ b/.github/actions/release-action/src/gitTags.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared utility for listing git tags sorted by version.
+ *
+ * @example
+ * ```typescript
+ * import { listTags } from "./gitTags.ts";
+ *
+ * const tags = await listTags("v*", process.cwd());
+ * // → ["v2.0.0", "v1.1.0", "v1.0.0"]
+ * ```
+ */
+import { $ } from "bun";
+
+/**
+ * List git tags matching a pattern, sorted newest-first by version.
+ *
+ * @param pattern - Glob pattern for tags (e.g. "v*")
+ * @param cwd - Working directory for the git command
+ * @returns Sorted tags (newest first), empty array if none found
+ */
+export async function listTags(pattern: string, cwd: string): Promise<string[]> {
+  const result = await $`git tag -l ${pattern} --sort=-v:refname`.cwd(cwd).quiet().nothrow();
+  return result.stdout.toString().trim().split("\n").filter(Boolean);
+}
+
+/**
+ * Find the most recent tag reachable from a given ref by commit topology.
+ *
+ * Unlike {@link listTags} (which sorts globally by version number),
+ * this walks the commit graph backwards from `ref` and returns the first
+ * matching tag. This correctly handles repos where a higher semver tag
+ * (e.g. v1.0.0) exists on an older commit than a lower semver tag (e.g. v0.16.1).
+ *
+ * @param pattern - Glob pattern for tags (e.g. "v*")
+ * @param cwd - Working directory for the git command
+ * @param ref - Git ref to search from (default: "HEAD")
+ * @returns The closest matching tag, or null if none found
+ */
+export async function getLatestReachableTag(
+  pattern: string,
+  cwd: string,
+  ref = "HEAD"
+): Promise<string | null> {
+  const result = await $`git describe --tags --abbrev=0 --match=${pattern} ${ref}`
+    .cwd(cwd)
+    .quiet()
+    .nothrow();
+  if (result.exitCode !== 0) {
+    return null;
+  }
+  return result.stdout.toString().trim() || null;
+}

--- a/.github/actions/release-action/src/insert-release-notes.ts
+++ b/.github/actions/release-action/src/insert-release-notes.ts
@@ -1,0 +1,101 @@
+/**
+ * Insert AI release notes into CHANGELOG.md and .release_notes/<version>.md
+ *
+ * Reads AI-generated notes from `.release_bot/release_notes.md` and inserts them
+ * as a "## Release Notes" section after the version header in both files.
+ * Uses string matching (not regex) to avoid issues with markdown metacharacters.
+ *
+ * @example
+ * ```bash
+ * bun src/insert-release-notes.ts 1.2.0
+ * ```
+ */
+
+export {};
+
+const [, , version] = process.argv;
+
+if (!version?.trim()) {
+  console.error("Usage: bun src/insert-release-notes.ts <version>");
+  process.exit(1);
+}
+
+const notesFile = Bun.file(".release_bot/release_notes.md");
+
+if (!(await notesFile.exists())) {
+  console.log("No .release_bot/release_notes.md found, skipping release notes insertion");
+  process.exit(0);
+}
+
+const notes = (await notesFile.text()).trim();
+
+if (!notes) {
+  console.log("Release notes file is empty, skipping insertion");
+  process.exit(0);
+}
+
+const releaseNotesSection = `## Release Notes\n\n${notes}\n`;
+
+/**
+ * Insert a release notes section after the version header in markdown content
+ *
+ * Finds the first line containing `## ` followed by the version string,
+ * then inserts the release notes block after the header and its trailing blank line.
+ *
+ * @param content - Markdown file content
+ * @param ver - Version string to locate (e.g. "1.2.0")
+ * @param notesBlock - Formatted release notes block to insert
+ * @returns Updated content, or original if version header not found
+ */
+function insertAfterVersionHeader(content: string, ver: string, notesBlock: string): string {
+  const lines = content.split("\n");
+  const headerIndex = lines.findIndex((line) => line.startsWith("## ") && line.includes(ver));
+
+  if (headerIndex === -1) {
+    return content;
+  }
+
+  // Find the blank line after the header
+  let insertAt = headerIndex + 1;
+  if (insertAt < lines.length && lines[insertAt]?.trim() === "") {
+    insertAt += 1;
+  }
+
+  lines.splice(insertAt, 0, notesBlock, "");
+  return lines.join("\n");
+}
+
+async function insertIntoChangelog(ver: string, notesBlock: string): Promise<void> {
+  const changelogFile = Bun.file("CHANGELOG.md");
+  if (!(await changelogFile.exists())) return;
+
+  const changelog = await changelogFile.text();
+  const updated = insertAfterVersionHeader(changelog, ver, notesBlock);
+
+  if (updated !== changelog) {
+    await Bun.write("CHANGELOG.md", updated);
+    console.log("Inserted release notes into CHANGELOG.md");
+  } else {
+    console.log(`Version header for ${ver} not found in CHANGELOG.md, skipping`);
+  }
+}
+
+// Insert into CHANGELOG.md
+await insertIntoChangelog(version, releaseNotesSection);
+
+// Insert into .release_notes/<version>.md
+const releaseNotePath = `.release_notes/${version}.md`;
+const releaseNoteFile = Bun.file(releaseNotePath);
+if (await releaseNoteFile.exists()) {
+  const releaseNote = await releaseNoteFile.text();
+  const updated = insertAfterVersionHeader(releaseNote, version, releaseNotesSection);
+
+  if (updated !== releaseNote) {
+    await Bun.write(releaseNotePath, updated);
+    console.log(`Inserted release notes into ${releaseNotePath}`);
+  } else {
+    // Version header may not be present in .release_notes file — prepend instead
+    await Bun.write(releaseNotePath, `${releaseNotesSection}\n${releaseNote}`);
+    console.log(`Prepended release notes to ${releaseNotePath}`);
+  }
+}

--- a/.github/actions/release-action/src/platformMeta.test.ts
+++ b/.github/actions/release-action/src/platformMeta.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for platform.meta.yml parsing utilities
+ */
+import { describe, expect, test } from "bun:test";
+
+import { parseReleaseType, parseSlackRelease } from "./platformMeta.ts";
+
+describe("parseReleaseType", () => {
+  test("extracts release type from valid content", () => {
+    const content = `language: typescript
+rules: Bun
+release: github-action
+`;
+    expect(parseReleaseType(content)).toBe("github-action");
+  });
+
+  test("handles lib-nodejs release type", () => {
+    expect(parseReleaseType("release: lib-nodejs\n")).toBe("lib-nodejs");
+  });
+
+  test("handles lib-bun release type", () => {
+    expect(parseReleaseType("release: lib-bun\n")).toBe("lib-bun");
+  });
+
+  test("returns null when release field is missing", () => {
+    const content = `language: typescript
+rules: Bun
+`;
+    expect(parseReleaseType(content)).toBeNull();
+  });
+
+  test("returns null for empty content", () => {
+    expect(parseReleaseType("")).toBeNull();
+  });
+
+  test("returns null when release value is empty", () => {
+    expect(parseReleaseType("release:\n")).toBeNull();
+  });
+
+  test("does not match nested release fields", () => {
+    const content = `slack:
+  release: "#channel"
+`;
+    expect(parseReleaseType(content)).toBeNull();
+  });
+});
+
+describe("parseSlackRelease", () => {
+  test("extracts release channel from platform.meta.yml content", () => {
+    const content = `language: typescript
+slack:
+  channel: "#platform"
+  release: "#platform-engineering"
+`;
+    expect(parseSlackRelease(content)).toBe("#platform-engineering");
+  });
+
+  test("returns null when no slack block exists", () => {
+    expect(parseSlackRelease("language: typescript\n")).toBeNull();
+  });
+
+  test("returns null when slack block has no release field", () => {
+    const content = `slack:
+  channel: "#platform"
+`;
+    expect(parseSlackRelease(content)).toBeNull();
+  });
+
+  test("stops at next top-level block", () => {
+    const content = `slack:
+  channel: "#platform"
+linear:
+  release: "#wrong"
+`;
+    expect(parseSlackRelease(content)).toBeNull();
+  });
+
+  test("strips quotes from channel name", () => {
+    const content = `slack:
+  release: "#quoted-channel"
+`;
+    expect(parseSlackRelease(content)).toBe("#quoted-channel");
+  });
+});

--- a/.github/actions/release-action/src/platformMeta.test.ts
+++ b/.github/actions/release-action/src/platformMeta.test.ts
@@ -43,6 +43,14 @@ rules: Bun
 `;
     expect(parseReleaseType(content)).toBeNull();
   });
+
+  test("strips double quotes from quoted scalar", () => {
+    expect(parseReleaseType('release: "github-action"\n')).toBe("github-action");
+  });
+
+  test("strips single quotes from quoted scalar", () => {
+    expect(parseReleaseType("release: 'lib-nodejs'\n")).toBe("lib-nodejs");
+  });
 });
 
 describe("parseSlackRelease", () => {

--- a/.github/actions/release-action/src/platformMeta.ts
+++ b/.github/actions/release-action/src/platformMeta.ts
@@ -25,7 +25,13 @@
 export function parseReleaseType(content: string): string | null {
   for (const line of content.split("\n")) {
     if (line.startsWith("release:")) {
-      const value = line.slice("release:".length).trim();
+      // Strip surrounding double or single quotes so quoted YAML scalars
+      // (`release: "github-action"`) match the same values as bare ones.
+      const value = line
+        .slice("release:".length)
+        .trim()
+        .replace(/^"([^"]*)"$/, "$1")
+        .replace(/^'([^']*)'$/, "$1");
       return value || null;
     }
   }

--- a/.github/actions/release-action/src/platformMeta.ts
+++ b/.github/actions/release-action/src/platformMeta.ts
@@ -1,0 +1,64 @@
+/**
+ * Parse fields from `platform.meta.yml` content.
+ *
+ * Lightweight line-by-line parsing for flat YAML structures.
+ * No YAML parser dependency needed.
+ *
+ * @example
+ * ```typescript
+ * import { parseReleaseType, parseSlackRelease } from "../platformMeta/platformMeta.ts";
+ *
+ * const content = await Bun.file("platform.meta.yml").text();
+ * const type = parseReleaseType(content);     // "github-action"
+ * const channel = parseSlackRelease(content);  // "#platform-engineering"
+ * ```
+ */
+
+/**
+ * Extract `release` field value from platform.meta.yml content.
+ *
+ * Matches the first line starting with `release:` and returns the value.
+ *
+ * @param content - Raw platform.meta.yml file content
+ * @returns Release type string or null if not found
+ */
+export function parseReleaseType(content: string): string | null {
+  for (const line of content.split("\n")) {
+    if (line.startsWith("release:")) {
+      const value = line.slice("release:".length).trim();
+      return value || null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse `slack.release` channel from platform.meta.yml content.
+ *
+ * Walks lines to find the `slack:` block, then extracts the `release:` value.
+ *
+ * @param content - Raw platform.meta.yml file content
+ * @returns Slack channel string or null if not found
+ */
+export function parseSlackRelease(content: string): string | null {
+  const lines = content.split("\n");
+  let inSlack = false;
+
+  for (const line of lines) {
+    if (line === "slack:") {
+      inSlack = true;
+      continue;
+    }
+    if (inSlack && line.length > 0 && !line.startsWith(" ")) {
+      break;
+    }
+    if (inSlack && line.trim().startsWith("release:")) {
+      return line
+        .trim()
+        .replace(/^release:\s+/, "")
+        .replace(/"/g, "");
+    }
+  }
+
+  return null;
+}

--- a/.github/actions/release-action/src/prepareRelease.test.ts
+++ b/.github/actions/release-action/src/prepareRelease.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for release preparation utilities
+ */
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { withTempDir } from "./testHelpers.ts";
+
+import { ensureGitignoreEntry, updateUvLockVersion, updateVersionFiles } from "./prepareRelease.ts";
+
+describe("ensureGitignoreEntry", () => {
+  test("creates .gitignore with entry when file does not exist", () =>
+    withTempDir(async (dir) => {
+      const result = await ensureGitignoreEntry(".release_bot", dir);
+
+      expect(result).toBe(true);
+      const content = await Bun.file(join(dir, ".gitignore")).text();
+      expect(content).toBe(".release_bot\n");
+    }));
+
+  test("adds entry to existing .gitignore", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, ".gitignore"), "node_modules\n");
+
+      const result = await ensureGitignoreEntry(".release_bot", dir);
+
+      expect(result).toBe(true);
+      const content = await Bun.file(join(dir, ".gitignore")).text();
+      expect(content).toBe("node_modules\n.release_bot\n");
+    }));
+
+  test("returns false when entry already exists", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, ".gitignore"), "node_modules\n.release_bot\n");
+
+      const result = await ensureGitignoreEntry(".release_bot", dir);
+
+      expect(result).toBe(false);
+    }));
+
+  test("does not duplicate entry with surrounding whitespace", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, ".gitignore"), "  .release_bot  \n");
+
+      const result = await ensureGitignoreEntry(".release_bot", dir);
+
+      expect(result).toBe(false);
+    }));
+});
+
+describe("updateVersionFiles", () => {
+  test("updates package.json version", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "test", version: "1.0.0" }, null, 2)
+      );
+
+      const updated = await updateVersionFiles("2.0.0", dir);
+
+      expect(updated).toEqual(["package.json"]);
+      const pkg = (await Bun.file(join(dir, "package.json")).json()) as { version: string };
+      expect(pkg.version).toBe("2.0.0");
+    }));
+
+  test("updates pyproject.toml version", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, "pyproject.toml"), '[project]\nname = "test"\nversion = "1.0.0"\n');
+
+      const updated = await updateVersionFiles("2.0.0", dir);
+
+      expect(updated).toEqual(["pyproject.toml"]);
+      const content = await Bun.file(join(dir, "pyproject.toml")).text();
+      expect(content).toContain('version = "2.0.0"');
+    }));
+
+  test("updates plugin.json version", () =>
+    withTempDir(async (dir) => {
+      const pluginDir = join(dir, "my-plugin", ".claude-plugin");
+      await Bun.write(
+        join(pluginDir, "plugin.json"),
+        JSON.stringify({ name: "my-plugin", version: "1.0.0" }, null, 2),
+        { createPath: true }
+      );
+
+      const updated = await updateVersionFiles("2.0.0", dir);
+
+      expect(updated).toContainEqual("my-plugin/.claude-plugin/plugin.json");
+      const plugin = (await Bun.file(join(pluginDir, "plugin.json")).json()) as { version: string };
+      expect(plugin.version).toBe("2.0.0");
+    }));
+
+  test("updates multiple files at once", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "test", version: "1.0.0" }, null, 2)
+      );
+      await Bun.write(join(dir, "pyproject.toml"), '[project]\nname = "test"\nversion = "1.0.0"\n');
+
+      const updated = await updateVersionFiles("3.0.0", dir);
+
+      expect(updated).toContain("package.json");
+      expect(updated).toContain("pyproject.toml");
+    }));
+
+  test("returns empty array when no version files exist", () =>
+    withTempDir(async (dir) => {
+      const updated = await updateVersionFiles("1.0.0", dir);
+
+      expect(updated).toEqual([]);
+    }));
+
+  test("updates uv.lock alongside pyproject.toml", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(
+        join(dir, "pyproject.toml"),
+        '[project]\nname = "my-service"\nversion = "1.0.0"\n'
+      );
+      await Bun.write(
+        join(dir, "uv.lock"),
+        [
+          "version = 1",
+          "",
+          "[[package]]",
+          'name = "my-service"',
+          'version = "1.0.0"',
+          'source = { virtual = "." }',
+          "",
+          "[[package]]",
+          'name = "requests"',
+          'version = "2.31.0"',
+          'source = { registry = "https://pypi.org/simple" }',
+          "",
+        ].join("\n")
+      );
+
+      const updated = await updateVersionFiles("2.0.0", dir);
+
+      expect(updated).toContain("uv.lock");
+      const lockContent = await Bun.file(join(dir, "uv.lock")).text();
+      expect(lockContent).toContain('name = "my-service"\nversion = "2.0.0"');
+      expect(lockContent).toContain('name = "requests"\nversion = "2.31.0"');
+    }));
+
+  test("skips uv.lock when pyproject.toml is missing", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(
+        join(dir, "uv.lock"),
+        '[[package]]\nname = "my-service"\nversion = "1.0.0"\nsource = { virtual = "." }\n'
+      );
+
+      const updated = await updateVersionFiles("2.0.0", dir);
+
+      expect(updated).not.toContain("uv.lock");
+    }));
+});
+
+describe("updateUvLockVersion", () => {
+  const baseLock = [
+    "version = 1",
+    "",
+    "[[package]]",
+    'name = "my-service"',
+    'version = "1.0.0"',
+    'source = { virtual = "." }',
+    "",
+    "[[package]]",
+    'name = "requests"',
+    'version = "2.31.0"',
+    'source = { registry = "https://pypi.org/simple" }',
+    "",
+  ].join("\n");
+
+  test("updates version in project package block", () => {
+    const result = updateUvLockVersion(baseLock, "2.0.0");
+
+    expect(result).toContain('name = "my-service"\nversion = "2.0.0"');
+  });
+
+  test("does not modify other packages", () => {
+    const result = updateUvLockVersion(baseLock, "2.0.0");
+
+    expect(result).toContain('name = "requests"\nversion = "2.31.0"');
+  });
+
+  test("handles editable source", () => {
+    const lock = baseLock.replace('virtual = "."', 'editable = "."');
+    const result = updateUvLockVersion(lock, "2.0.0");
+
+    expect(result).toContain('name = "my-service"\nversion = "2.0.0"');
+  });
+
+  test("returns content unchanged when no local source block", () => {
+    const lock = [
+      "version = 1",
+      "",
+      "[[package]]",
+      'name = "requests"',
+      'version = "2.31.0"',
+      'source = { registry = "https://pypi.org/simple" }',
+      "",
+    ].join("\n");
+
+    const result = updateUvLockVersion(lock, "2.0.0");
+
+    expect(result).toBe(lock);
+  });
+
+  test("returns content unchanged when version already matches", () => {
+    const result = updateUvLockVersion(baseLock, "1.0.0");
+
+    expect(result).toBe(baseLock);
+  });
+});

--- a/.github/actions/release-action/src/prepareRelease.test.ts
+++ b/.github/actions/release-action/src/prepareRelease.test.ts
@@ -75,6 +75,31 @@ describe("updateVersionFiles", () => {
       expect(content).toContain('version = "2.0.0"');
     }));
 
+  test("only updates the [project] version, not other sections with a version key", () =>
+    withTempDir(async (dir) => {
+      const original = [
+        '[project]',
+        'name = "test"',
+        'version = "1.0.0"',
+        '',
+        '[tool.uv.workspace]',
+        'version = "9.9.9"',
+        '',
+        '[[tool.poetry.source]]',
+        'name = "internal"',
+        'version = "0.1.0"',
+        '',
+      ].join("\n");
+      await Bun.write(join(dir, "pyproject.toml"), original);
+
+      await updateVersionFiles("2.0.0", dir);
+
+      const content = await Bun.file(join(dir, "pyproject.toml")).text();
+      expect(content).toContain('[project]\nname = "test"\nversion = "2.0.0"');
+      expect(content).toContain('[tool.uv.workspace]\nversion = "9.9.9"');
+      expect(content).toContain('version = "0.1.0"');
+    }));
+
   test("updates plugin.json version", () =>
     withTempDir(async (dir) => {
       const pluginDir = join(dir, "my-plugin", ".claude-plugin");
@@ -212,5 +237,33 @@ describe("updateUvLockVersion", () => {
     const result = updateUvLockVersion(baseLock, "1.0.0");
 
     expect(result).toBe(baseLock);
+  });
+
+  test("ignores workspace members whose source is not the project root", () => {
+    const lock = [
+      "version = 1",
+      "",
+      "[[package]]",
+      'name = "my-service"',
+      'version = "1.0.0"',
+      'source = { virtual = "." }',
+      "",
+      "[[package]]",
+      'name = "shared-utils"',
+      'version = "0.5.0"',
+      'source = { virtual = "packages/utils" }',
+      "",
+      "[[package]]",
+      'name = "shared-types"',
+      'version = "0.5.0"',
+      'source = { editable = "packages/types" }',
+      "",
+    ].join("\n");
+
+    const result = updateUvLockVersion(lock, "2.0.0");
+
+    expect(result).toContain('name = "my-service"\nversion = "2.0.0"');
+    expect(result).toContain('name = "shared-utils"\nversion = "0.5.0"');
+    expect(result).toContain('name = "shared-types"\nversion = "0.5.0"');
   });
 });

--- a/.github/actions/release-action/src/prepareRelease.ts
+++ b/.github/actions/release-action/src/prepareRelease.ts
@@ -62,9 +62,11 @@ export function updateUvLockVersion(lockContent: string, version: string): strin
   const packages = parsed.package as Array<Record<string, unknown>> | undefined;
   if (!packages) return lockContent;
 
+  // Match the project's own package — its source points at the repo root (".").
+  // Other workspace members may also use `virtual`/`editable` with different paths.
   const projectPkg = packages.find((pkg) => {
     const source = pkg.source as Record<string, unknown> | undefined;
-    return source && ("virtual" in source || "editable" in source);
+    return source && (source.virtual === "." || source.editable === ".");
   });
   if (!projectPkg || projectPkg.version === version) return lockContent;
 
@@ -103,14 +105,20 @@ export async function updateVersionFiles(version: string, cwd = process.cwd()): 
     updated.push("package.json");
   }
 
-  // pyproject.toml
+  // pyproject.toml — scoped to [project] section so unrelated `version` keys
+  // in other tables (e.g., [tool.uv.workspace], dependency declarations) are untouched
   const pyPath = `${cwd}/pyproject.toml`;
   const pyFile = Bun.file(pyPath);
   if (await pyFile.exists()) {
     const content = await pyFile.text();
-    const newContent = content.replace(/^version\s*=\s*"[^"]*"/m, `version = "${version}"`);
-    await Bun.write(pyPath, newContent);
-    updated.push("pyproject.toml");
+    const newContent = content.replace(
+      /(^\[project\][\s\S]*?^)version\s*=\s*"[^"]*"/m,
+      `$1version = "${version}"`
+    );
+    if (newContent !== content) {
+      await Bun.write(pyPath, newContent);
+      updated.push("pyproject.toml");
+    }
   }
 
   // uv.lock — update project version without resolving dependencies

--- a/.github/actions/release-action/src/prepareRelease.ts
+++ b/.github/actions/release-action/src/prepareRelease.ts
@@ -1,0 +1,179 @@
+/**
+ * Prepare repository for release: ensure .gitignore entries and update version files.
+ *
+ * Combines two pre-release operations:
+ * 1. Ensure `.release_bot` is in `.gitignore`
+ * 2. Update version across package managers (package.json, pyproject.toml, plugin.json)
+ *
+ * @example
+ * ```bash
+ * # Ensure .gitignore entry only
+ * bun src/prepareRelease.ts --ensure-gitignore
+ *
+ * # Update version files only
+ * bun src/prepareRelease.ts --update-version 1.2.3
+ * ```
+ */
+import { $, Glob } from "bun";
+import { parse } from "smol-toml";
+
+/**
+ * Ensure an entry exists in `.gitignore`, creating the file if needed.
+ *
+ * @param entry - Line to ensure exists in .gitignore
+ * @param cwd - Working directory (default: process.cwd())
+ * @returns true if entry was added, false if already present
+ */
+export async function ensureGitignoreEntry(entry: string, cwd = process.cwd()): Promise<boolean> {
+  const gitignorePath = `${cwd}/.gitignore`;
+  const file = Bun.file(gitignorePath);
+
+  if (await file.exists()) {
+    const content = await file.text();
+    const lines = content.split("\n");
+    if (lines.some((line) => line.trim() === entry)) {
+      return false;
+    }
+    await Bun.write(gitignorePath, `${content.trimEnd()}\n${entry}\n`);
+  } else {
+    await Bun.write(gitignorePath, `${entry}\n`);
+  }
+
+  return true;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Update the project's own version in a uv.lock file without resolving dependencies.
+ *
+ * Uses smol-toml to parse and identify the project's package entry
+ * (source.virtual or source.editable = "."), then does a targeted string
+ * replacement to preserve formatting.
+ *
+ * @param lockContent - Raw uv.lock file content
+ * @param version - New version string
+ * @returns Modified lock content, or original if no change needed
+ */
+export function updateUvLockVersion(lockContent: string, version: string): string {
+  const parsed = parse(lockContent);
+  const packages = parsed.package as Array<Record<string, unknown>> | undefined;
+  if (!packages) return lockContent;
+
+  const projectPkg = packages.find((pkg) => {
+    const source = pkg.source as Record<string, unknown> | undefined;
+    return source && ("virtual" in source || "editable" in source);
+  });
+  if (!projectPkg || projectPkg.version === version) return lockContent;
+
+  const oldVersion = projectPkg.version as string;
+  const projectName = projectPkg.name as string;
+
+  const blockPattern = new RegExp(
+    `(\\[\\[package\\]\\]\\s*\\nname\\s*=\\s*"${escapeRegExp(projectName)}"\\s*\\n)version\\s*=\\s*"${escapeRegExp(oldVersion)}"`,
+    "m"
+  );
+  return lockContent.replace(blockPattern, `$1version = "${version}"`);
+}
+
+/**
+ * Update version string across all detected package manager files.
+ *
+ * Supports:
+ * - `package.json` — JSON field update
+ * - `pyproject.toml` — regex replacement
+ * - `**\/.claude-plugin/plugin.json` — JSON field update via glob
+ *
+ * @param version - New version string (e.g. "1.2.3")
+ * @param cwd - Working directory (default: process.cwd())
+ * @returns List of updated file paths (relative to cwd)
+ */
+export async function updateVersionFiles(version: string, cwd = process.cwd()): Promise<string[]> {
+  const updated: string[] = [];
+
+  // package.json
+  const pkgPath = `${cwd}/package.json`;
+  const pkgFile = Bun.file(pkgPath);
+  if (await pkgFile.exists()) {
+    const pkg = (await pkgFile.json()) as Record<string, unknown>;
+    const updatedPkg = { ...pkg, version };
+    await Bun.write(pkgPath, `${JSON.stringify(updatedPkg, null, 2)}\n`);
+    updated.push("package.json");
+  }
+
+  // pyproject.toml
+  const pyPath = `${cwd}/pyproject.toml`;
+  const pyFile = Bun.file(pyPath);
+  if (await pyFile.exists()) {
+    const content = await pyFile.text();
+    const newContent = content.replace(/^version\s*=\s*"[^"]*"/m, `version = "${version}"`);
+    await Bun.write(pyPath, newContent);
+    updated.push("pyproject.toml");
+  }
+
+  // uv.lock — update project version without resolving dependencies
+  const uvLockPath = `${cwd}/uv.lock`;
+  const uvLockFile = Bun.file(uvLockPath);
+  if ((await uvLockFile.exists()) && updated.includes("pyproject.toml")) {
+    const lockContent = await uvLockFile.text();
+    const newLockContent = updateUvLockVersion(lockContent, version);
+    if (newLockContent !== lockContent) {
+      await Bun.write(uvLockPath, newLockContent);
+      updated.push("uv.lock");
+    }
+  }
+
+  // plugin.json files
+  const glob = new Glob("**/.claude-plugin/plugin.json");
+  for await (const match of glob.scan({ cwd, dot: true, absolute: false })) {
+    if (match.includes("node_modules")) continue;
+    const pluginPath = `${cwd}/${match}`;
+    const plugin = (await Bun.file(pluginPath).json()) as Record<string, unknown>;
+    const updatedPlugin = { ...plugin, version };
+    await Bun.write(pluginPath, `${JSON.stringify(updatedPlugin, null, 2)}\n`);
+    updated.push(match);
+    console.log(`Updated ${match} to ${version}`);
+  }
+
+  return updated;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--ensure-gitignore")) {
+    const added = await ensureGitignoreEntry(".release_bot");
+    if (added) {
+      console.log("Added .release_bot to .gitignore");
+      // Commit the .gitignore change separately so it doesn't get folded into
+      // the release commit. Uses --no-verify because pre-commit hooks are
+      // irrelevant for this change.
+      await $`git add .gitignore`.quiet();
+      await $`git commit -n -m "chore: add .release_bot to .gitignore"`.quiet();
+    } else {
+      console.log(".release_bot already in .gitignore");
+    }
+  }
+
+  const versionIndex = args.indexOf("--update-version");
+  if (versionIndex !== -1) {
+    const version = args[versionIndex + 1];
+    if (!version) {
+      console.log("::error::--update-version requires a version argument");
+      process.exit(1);
+    }
+    const files = await updateVersionFiles(version);
+    for (const file of files) {
+      console.log(`Updated ${file} to ${version}`);
+    }
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error: Error) => {
+    console.log(`::error::${error.message}`);
+    process.exit(1);
+  });
+}

--- a/.github/actions/release-action/src/release.test.ts
+++ b/.github/actions/release-action/src/release.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Tests for Release CLI
+ *
+ * Uses isolated temporary git repositories for integration tests
+ * to test git-dependent functionality.
+ */
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import { $ } from "bun";
+
+import {
+  bumpVersion,
+  changelogHeader,
+  generateChangelog,
+  getCurrentVersion,
+  main,
+  startOfLastReleasePattern,
+} from "./release.ts";
+import { createCommit, createInitialCommitAndTag, withTempRepo } from "./testHelpers.ts";
+
+/** Creates a package.json in the test repo */
+async function createPackageJson(repoPath: string, version = "1.0.0"): Promise<void> {
+  const pkg = { name: "test-pkg", version };
+  await Bun.write(join(repoPath, "package.json"), JSON.stringify(pkg, null, 2));
+}
+
+/** Creates a version file in the test repo */
+async function createVersionFile(repoPath: string, version = "1.0.0"): Promise<void> {
+  await Bun.write(join(repoPath, "version"), version);
+}
+
+/** Creates a plugin.json in the test repo */
+async function createPluginJson(
+  repoPath: string,
+  pluginName: string,
+  version = "1.0.0"
+): Promise<void> {
+  const pluginDir = join(repoPath, pluginName, ".claude-plugin");
+  await $`mkdir -p ${pluginDir}`.quiet();
+  await Bun.write(
+    join(pluginDir, "plugin.json"),
+    JSON.stringify({ name: pluginName, version }, null, 2)
+  );
+}
+
+/** Creates a pyproject.toml in the test repo */
+async function createPyprojectToml(repoPath: string, version = "1.0.0"): Promise<void> {
+  await Bun.write(
+    join(repoPath, "pyproject.toml"),
+    `[project]\nname = "test-pkg"\nversion = "${version}"\n`
+  );
+}
+
+describe("release CLI", () => {
+  describe("startOfLastReleasePattern", () => {
+    test("matches markdown header with bracketed version", () => {
+      const content = "## [1.0.0] (2025-01-01)\n\n### Features";
+      const match = content.search(startOfLastReleasePattern);
+      expect(match).toBe(0);
+    });
+
+    test("matches markdown header with plain version", () => {
+      const content = "## 1.0.0 (2025-01-01)\n\n### Features";
+      const match = content.search(startOfLastReleasePattern);
+      expect(match).toBe(0);
+    });
+
+    test("matches anchor tag format", () => {
+      const content = '<a name="1.0.0"></a>\n## 1.0.0';
+      const match = content.search(startOfLastReleasePattern);
+      expect(match).toBe(0);
+    });
+
+    test("returns -1 for non-release content", () => {
+      const content = "# Changelog\n\nSome description text without version";
+      const match = content.search(startOfLastReleasePattern);
+      expect(match).toBe(-1);
+    });
+
+    test("finds version after header text", () => {
+      const content = "# Changelog\n\nSome text\n\n## [2.0.0] Release";
+      const match = content.search(startOfLastReleasePattern);
+      expect(match).toBeGreaterThan(0);
+      expect(content.substring(match)).toStartWith("## [2.0.0]");
+    });
+  });
+
+  describe("changelogHeader", () => {
+    test("starts with # Changelog", () => {
+      expect(changelogHeader).toStartWith("# Changelog");
+    });
+
+    test("contains conventional commits link", () => {
+      expect(changelogHeader).toContain("conventionalcommits.org");
+    });
+  });
+
+  describe("getCurrentVersion()", () => {
+    test("reads from version file first", () =>
+      withTempRepo(async (testRepo) => {
+        await createVersionFile(testRepo, "2.0.0");
+        await createPackageJson(testRepo, "1.0.0");
+
+        const result = await getCurrentVersion(testRepo);
+
+        expect(result.version).toBe("2.0.0");
+        expect(result.source).toBe("version-file");
+      }));
+
+    test("falls back to package.json when no version file", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo, "1.5.0");
+
+        const result = await getCurrentVersion(testRepo);
+
+        expect(result.version).toBe("1.5.0");
+        expect(result.source).toBe("package-json");
+      }));
+
+    test("falls back to plugin.json when no package.json", () =>
+      withTempRepo(async (testRepo) => {
+        await createPluginJson(testRepo, "my-plugin", "3.0.0");
+
+        const result = await getCurrentVersion(testRepo);
+
+        expect(result.version).toBe("3.0.0");
+        expect(result.source).toBe("plugin-json");
+      }));
+
+    test("falls back to pyproject.toml when nothing else exists", () =>
+      withTempRepo(async (testRepo) => {
+        await createPyprojectToml(testRepo, "0.5.0");
+
+        const result = await getCurrentVersion(testRepo);
+
+        expect(result.version).toBe("0.5.0");
+        expect(result.source).toBe("pyproject-toml");
+      }));
+
+    test("creates version file with 0.0.0 when no version source and no tags", () =>
+      withTempRepo(async (testRepo) => {
+        const result = await getCurrentVersion(testRepo);
+
+        expect(result.version).toBe("0.0.0");
+        expect(result.source).toBe("version-file");
+        expect(await Bun.file(join(testRepo, "version")).text()).toBe("0.0.0");
+      }));
+
+    test("creates version file from latest git tag when no version source", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo, "1.2.3");
+        await createInitialCommitAndTag(testRepo, "1.2.3");
+        // Remove package.json so no manifest exists, but v1.2.3 tag remains
+        await $`rm ${join(testRepo, "package.json")}`.quiet();
+
+        const result = await getCurrentVersion(testRepo);
+
+        expect(result.version).toBe("1.2.3");
+        expect(result.source).toBe("version-file");
+        expect(await Bun.file(join(testRepo, "version")).text()).toBe("1.2.3");
+      }));
+
+    test("skips invalid semver in version file", () =>
+      withTempRepo(async (testRepo) => {
+        await createVersionFile(testRepo, "not-a-version");
+        await createPackageJson(testRepo, "1.0.0");
+
+        const result = await getCurrentVersion(testRepo);
+
+        expect(result.version).toBe("1.0.0");
+        expect(result.source).toBe("package-json");
+      }));
+  });
+
+  describe("bumpVersion()", () => {
+    test("feat commit returns minor bump", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: add new feature");
+
+        const result = await bumpVersion("1.0.0", testRepo);
+
+        expect(result.type).toBe("minor");
+        expect(result.newVersion).toBe("1.1.0");
+        expect(result.newTag).toBe("v1.1.0");
+      }));
+
+    test("fix commit returns patch bump", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "fix: resolve bug");
+
+        const result = await bumpVersion("1.0.0", testRepo);
+
+        expect(result.type).toBe("patch");
+        expect(result.newVersion).toBe("1.0.1");
+        expect(result.newTag).toBe("v1.0.1");
+      }));
+
+    test("breaking change returns major bump", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat!: breaking API change");
+
+        const result = await bumpVersion("1.0.0", testRepo);
+
+        expect(result.type).toBe("major");
+        expect(result.newVersion).toBe("2.0.0");
+        expect(result.newTag).toBe("v2.0.0");
+      }));
+
+    test("BREAKING CHANGE in footer returns major bump", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await Bun.write(join(testRepo, "breaking.txt"), "content");
+        await $`git add breaking.txt`.cwd(testRepo).quiet();
+        await $`git commit -m ${"feat: new feature\n\nBREAKING CHANGE: removed old API"}`
+          .cwd(testRepo)
+          .quiet();
+
+        const result = await bumpVersion("1.0.0", testRepo);
+
+        expect(result.type).toBe("major");
+        expect(result.newVersion).toBe("2.0.0");
+      }));
+
+    test("returns patch bump when only non-breaking commits", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "docs: update readme");
+
+        const result = await bumpVersion("1.0.0", testRepo);
+
+        expect(result.type).toBe("patch");
+        expect(result.newVersion).toBe("1.0.1");
+      }));
+
+    test("multiple feat commits still returns minor", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: first feature", "file1.txt");
+        await createCommit(testRepo, "feat: second feature", "file2.txt");
+        await createCommit(testRepo, "feat: third feature", "file3.txt");
+
+        const result = await bumpVersion("1.0.0", testRepo);
+
+        expect(result.type).toBe("minor");
+        expect(result.newVersion).toBe("1.1.0");
+      }));
+  });
+
+  describe("generateChangelog()", () => {
+    test("creates CHANGELOG.md if missing", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: new feature");
+
+        await generateChangelog("1.1.0", testRepo);
+
+        expect(await Bun.file(join(testRepo, "CHANGELOG.md")).exists()).toBe(true);
+      }));
+
+    test("release contains version number", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: new feature");
+
+        const result = await generateChangelog("1.1.0", testRepo);
+
+        expect(result.release).toContain("1.1.0");
+      }));
+
+    test("release contains commit message", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: add awesome feature");
+
+        const result = await generateChangelog("1.1.0", testRepo);
+
+        expect(result.release).toContain("add awesome feature");
+      }));
+
+    test("preserves existing changelog history", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+
+        // Create existing changelog with history
+        const existingContent = "## [1.0.0] (2025-01-01)\n\n### Features\n\n* initial release";
+        await Bun.write(join(testRepo, "CHANGELOG.md"), existingContent);
+
+        await createCommit(testRepo, "feat: new feature");
+
+        const result = await generateChangelog("1.1.0", testRepo);
+
+        expect(result.history).toContain("[1.0.0]");
+        expect(result.history).toContain("initial release");
+      }));
+
+    test("header is the standard changelog header", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: new feature");
+
+        const result = await generateChangelog("1.1.0", testRepo);
+
+        expect(result.header).toBe(changelogHeader);
+      }));
+  });
+
+  describe("main()", () => {
+    test("creates version file with correct content", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo, "1.0.0");
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: new feature");
+
+        await main({ cwd: testRepo });
+
+        const version = await Bun.file(join(testRepo, "version")).text();
+        expect(version).toBe("1.1.0");
+      }));
+
+    test("creates .release_bot/body file", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: new feature");
+
+        await main({ cwd: testRepo });
+
+        expect(await Bun.file(join(testRepo, ".release_bot/body")).exists()).toBe(true);
+      }));
+
+    test("summary body contains release type badge", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: new feature");
+
+        await main({ cwd: testRepo });
+
+        const body = await Bun.file(join(testRepo, ".release_bot/body")).text();
+        expect(body).toContain(
+          "![release:minor](https://img.shields.io/badge/release-minor-brightgreen)"
+        );
+        expect(body).not.toContain("## Summary");
+        expect(body).not.toContain("breaking%20changes");
+      }));
+
+    test("summary body contains breaking changes badge for major release", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat!: breaking API change");
+
+        await main({ cwd: testRepo });
+
+        const body = await Bun.file(join(testRepo, ".release_bot/body")).text();
+        expect(body).toContain("![release:major](https://img.shields.io/badge/release-major-red)");
+        expect(body).toContain("breaking%20changes-1-red");
+      }));
+
+    test("creates release notes file", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo, "1.0.0");
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: new feature");
+
+        await main({ cwd: testRepo });
+
+        expect(await Bun.file(join(testRepo, ".release_notes/1.1.0.md")).exists()).toBe(true);
+      }));
+
+    test("updates CHANGELOG.md", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo, "1.0.0");
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "feat: awesome feature");
+
+        await main({ cwd: testRepo });
+
+        const changelog = await Bun.file(join(testRepo, "CHANGELOG.md")).text();
+        expect(changelog).toContain("# Changelog");
+        expect(changelog).toContain("1.1.0");
+        expect(changelog).toContain("awesome feature");
+      }));
+
+    test("includes chore commits in changelog", () =>
+      withTempRepo(async (testRepo) => {
+        await createPackageJson(testRepo);
+        await createInitialCommitAndTag(testRepo);
+        await createCommit(testRepo, "chore: update readme");
+
+        const version = await main({ cwd: testRepo });
+
+        expect(version).toBe("1.0.1"); // patch bump for chore
+        const changelog = await Bun.file(join(testRepo, "CHANGELOG.md")).text();
+        expect(changelog).toContain("### Chores");
+        expect(changelog).toContain("update readme");
+      }));
+  });
+});

--- a/.github/actions/release-action/src/release.ts
+++ b/.github/actions/release-action/src/release.ts
@@ -131,9 +131,11 @@ export async function getCurrentVersion(cwd: string): Promise<VersionResult> {
     }
   }
 
-  // 3. First plugin.json found via glob
+  // 3. First plugin.json found via glob (skip node_modules to avoid picking
+  // a dependency's plugin.json instead of one belonging to this repo)
   const glob = new Glob("**/.claude-plugin/plugin.json");
   for await (const match of glob.scan({ cwd, dot: true, absolute: true })) {
+    if (match.includes("node_modules")) continue;
     const plugin = (await Bun.file(match).json()) as { version?: string };
     if (plugin.version) {
       return { version: plugin.version, source: "plugin-json" };

--- a/.github/actions/release-action/src/release.ts
+++ b/.github/actions/release-action/src/release.ts
@@ -1,0 +1,473 @@
+/**
+ * Release CLI
+ *
+ * Generates changelog via conventional commits, release notes for every version,
+ * and meta info for release workflows. Supports ticket system integration.
+ *
+ * @example
+ * ```bash
+ * # Run directly
+ * bun src/release.ts
+ *
+ * # With ticket integration
+ * LINEAR_API_KEY=xxx bun src/release.ts --tickets=linear:TEAM,PROJ
+ *
+ * # Or via bin
+ * ./bin/release
+ * ```
+ */
+import { join } from "node:path";
+
+import { Glob } from "bun";
+import { Bumper } from "conventional-recommended-bump";
+import { ConventionalChangelog } from "conventional-changelog";
+import semver from "semver";
+
+import { listTags } from "./gitTags.ts";
+import type { TicketConfig, TicketSystemEntry } from "./tickets/tickets.types.ts";
+import {
+  autoDetectTicketSystems,
+  generateTicketsSection,
+  loadTicketEnv,
+  parseTicketArgs,
+  serializePrDescriptionsToYaml,
+} from "./tickets/tickets.ts";
+
+/** Sources from which version can be read, in priority order */
+type VersionSource = "version-file" | "package-json" | "plugin-json" | "pyproject-toml";
+
+/** Result of version detection including source for logging */
+interface VersionResult {
+  version: string;
+  source: VersionSource;
+}
+
+/** Bump result containing version information */
+export interface BumpResult {
+  summary: string;
+  type: string;
+  newVersion: string;
+  newTag: string;
+}
+
+/** Changelog result containing generated content */
+export interface ChangelogResult {
+  header: string;
+  release: string;
+  history: string;
+}
+
+/** Options for release workflow */
+export interface ReleaseOptions {
+  /** Working directory (default: process.cwd()) */
+  cwd?: string;
+  /** Ticket systems configuration */
+  ticketSystems?: TicketSystemEntry[];
+  /** GitHub repository owner (required for tickets) */
+  owner?: string;
+  /** GitHub repository name (required for tickets) */
+  repo?: string;
+}
+
+/**
+ * Conventional changelog section names used in the conventionalcommits preset.
+ *
+ * These map commit types to `### Section` headings in the generated changelog.
+ * Also used by `slackNotify.ts` to detect where AI content ends.
+ */
+export const changelogSectionNames = [
+  "Features",
+  "Bug Fixes",
+  "Performance",
+  "Reverts",
+  "Documentation",
+  "Chores",
+  "Refactoring",
+  "Tests",
+  "Build",
+  "CI",
+] as const;
+
+/** Pattern to find the start of the last release in changelog */
+export const startOfLastReleasePattern = /(^#+ \[?[0-9]+\.[0-9]+\.[0-9]+|<a name=)/m;
+
+/** Changelog header with conventional commits link */
+export const changelogHeader =
+  "# Changelog\n\nAll notable changes to this project will be documented in this file. " +
+  "See [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit guidelines.\n\n";
+
+/**
+ * Get current version using a fallback chain
+ *
+ * Priority order:
+ * 1. `version` file at root (plain text semver)
+ * 2. `package.json` → `.version` field
+ * 3. First `plugin.json` found at `**\/.claude-plugin/plugin.json` → `.version`
+ * 4. `pyproject.toml` → version in `[project]` section
+ *
+ * @param cwd - Working directory
+ * @returns Version string and the source it was read from
+ *
+ * When no version source is found, checks git tags (`v*`) for an existing
+ * semver version and falls back to `0.0.0`. Creates a `version` file
+ * automatically so downstream steps can read it.
+ */
+export async function getCurrentVersion(cwd: string): Promise<VersionResult> {
+  // 1. version file at root
+  const versionFile = Bun.file(join(cwd, "version"));
+  if (await versionFile.exists()) {
+    const content = (await versionFile.text()).trim();
+    if (content && semver.valid(content)) {
+      return { version: content, source: "version-file" };
+    }
+  }
+
+  // 2. package.json
+  const pkgFile = Bun.file(join(cwd, "package.json"));
+  if (await pkgFile.exists()) {
+    const pkg = (await pkgFile.json()) as { version?: string };
+    if (pkg.version) {
+      return { version: pkg.version, source: "package-json" };
+    }
+  }
+
+  // 3. First plugin.json found via glob
+  const glob = new Glob("**/.claude-plugin/plugin.json");
+  for await (const match of glob.scan({ cwd, dot: true, absolute: true })) {
+    const plugin = (await Bun.file(match).json()) as { version?: string };
+    if (plugin.version) {
+      return { version: plugin.version, source: "plugin-json" };
+    }
+  }
+
+  // 4. pyproject.toml
+  const pyFile = Bun.file(join(cwd, "pyproject.toml"));
+  if (await pyFile.exists()) {
+    const content = await pyFile.text();
+    const versionMatch = content.match(/^\[project\][\s\S]*?^version\s*=\s*["']([^"']+)["']/m);
+    if (versionMatch?.[1]) {
+      return { version: versionMatch[1], source: "pyproject-toml" };
+    }
+  }
+
+  // No manifest found — derive version from git tags, default to 0.0.0
+  const tags = await listTags("v*", cwd);
+  let initialVersion = "0.0.0";
+  for (const tag of tags) {
+    const parsed = semver.valid(tag.replace(/^v/, ""));
+    if (parsed) {
+      initialVersion = parsed;
+      break;
+    }
+  }
+
+  await Bun.write(join(cwd, "version"), initialVersion);
+  console.log(`::warning::No version source found. Created version file with ${initialVersion}`);
+  return { version: initialVersion, source: "version-file" };
+}
+
+/**
+ * Bump version based on conventional commits
+ *
+ * @param currentVersion - Current semver version
+ * @param cwd - Working directory (default: process.cwd())
+ */
+export async function bumpVersion(
+  currentVersion: string,
+  cwd = process.cwd()
+): Promise<BumpResult> {
+  const bumper = new Bumper(cwd).loadPreset("conventionalcommits");
+  const recommendation = await bumper.bump();
+
+  if (!("releaseType" in recommendation)) {
+    throw new Error("No commits found to determine release type");
+  }
+
+  const releaseType = recommendation.releaseType ?? "patch";
+  const newVersion = semver.valid(releaseType) ?? semver.inc(currentVersion, releaseType);
+
+  if (!newVersion) {
+    throw new Error(`Failed to calculate new version from ${currentVersion} with ${releaseType}`);
+  }
+
+  return {
+    summary: "reason" in recommendation ? (recommendation.reason ?? "") : "",
+    type: releaseType,
+    newVersion,
+    newTag: `v${newVersion}`,
+  };
+}
+
+/**
+ * Generate changelog content from git history
+ *
+ * @param newVersion - Version to generate changelog for
+ * @param cwd - Working directory (default: process.cwd())
+ */
+export async function generateChangelog(
+  newVersion: string,
+  cwd = process.cwd()
+): Promise<ChangelogResult> {
+  const changelogFile = join(cwd, "CHANGELOG.md");
+
+  if (!(await Bun.file(changelogFile).exists())) {
+    await Bun.write(changelogFile, "\n");
+  }
+
+  const historyContent = await Bun.file(changelogFile).text();
+  const historyStart = historyContent.search(startOfLastReleasePattern);
+  const history = historyStart !== -1 ? historyContent.substring(historyStart) : historyContent;
+
+  const generator = new ConventionalChangelog(cwd)
+    .readPackage()
+    .loadPreset({
+      name: "conventionalcommits",
+      types: [
+        { type: "feat", section: "Features" },
+        { type: "fix", section: "Bug Fixes" },
+        { type: "perf", section: "Performance" },
+        { type: "revert", section: "Reverts" },
+        { type: "docs", section: "Documentation", hidden: false },
+        { type: "chore", section: "Chores", hidden: false },
+        { type: "refactor", section: "Refactoring", hidden: false },
+        { type: "test", section: "Tests", hidden: false },
+        { type: "build", section: "Build", hidden: false },
+        { type: "ci", section: "CI", hidden: false },
+      ],
+    })
+    .tags({ prefix: "v" })
+    .context({ version: newVersion });
+
+  let release = "";
+  for await (const chunk of generator.write()) {
+    release += chunk;
+  }
+
+  return { header: changelogHeader, release, history };
+}
+
+/** Generate tickets section and save artifacts if configured */
+async function processTickets(params: {
+  ticketSystems?: TicketSystemEntry[];
+  owner?: string;
+  repo?: string;
+  cwd: string;
+  releaseBotDir: string;
+}): Promise<string> {
+  const { ticketSystems, owner, repo, cwd, releaseBotDir } = params;
+
+  if (!ticketSystems || ticketSystems.length === 0 || !owner || !repo) {
+    return "";
+  }
+
+  const ticketConfig: TicketConfig = { systems: ticketSystems, owner, repo };
+  const env = loadTicketEnv();
+  const result = await generateTicketsSection({
+    config: ticketConfig,
+    env,
+    cwd,
+  });
+
+  if (result.tickets.length > 0) {
+    await Bun.write(join(releaseBotDir, "tickets.json"), JSON.stringify(result.tickets, null, 2), {
+      createPath: true,
+    });
+  }
+
+  if (result.prDescriptions.length > 0) {
+    await Bun.write(
+      join(releaseBotDir, "pr_descriptions.yml"),
+      serializePrDescriptionsToYaml(result.prDescriptions),
+      { createPath: true }
+    );
+  }
+
+  for (const warning of result.warnings) {
+    console.warn(`Warning: ${warning}`);
+  }
+
+  return result.markdown;
+}
+
+/**
+ * Main release workflow
+ *
+ * @param options - Release options
+ */
+export async function main(options: ReleaseOptions = {}): Promise<string> {
+  const { cwd = process.cwd(), ticketSystems, owner, repo } = options;
+
+  const { version: currentVersion, source: versionSource } = await getCurrentVersion(cwd);
+  console.log(`Detected version ${currentVersion} from ${versionSource}`);
+  const { newVersion, type: releaseType, summary: releaseSummary } = await bumpVersion(
+    currentVersion,
+    cwd
+  );
+
+  const log = await generateChangelog(newVersion, cwd);
+
+  const releaseLines = log.release.split("\n").slice(1).join("\n").trim();
+  if (!releaseLines) {
+    throw new Error("There are no changes in the release. Do some commits before next one");
+  }
+
+  const releaseBotDir = join(cwd, ".release_bot");
+  const ticketsMarkdown = await processTickets({
+    ticketSystems,
+    owner,
+    repo,
+    cwd,
+    releaseBotDir,
+  });
+
+  const releaseNotesDir = join(cwd, ".release_notes");
+  const releaseWithTickets = insertTicketsInRelease(log.release, ticketsMarkdown);
+
+  // Strip version header from body since it's already in PR title
+  const bodyContent = releaseWithTickets.replace(/^## (?:\[[^\]]+\]|\d+\.\d+\.\d+).*\n\n/, "");
+
+  const breakingBadge = breakingChangesBadge(releaseSummary);
+  const badgeLine = [releaseTypeBadge(releaseType), breakingBadge].filter(Boolean).join(" ");
+  const summaryBody = [`${badgeLine}\n`, bodyContent].join("\n");
+
+  // Write PR body
+  await Bun.write(join(releaseBotDir, "body"), summaryBody, { createPath: true });
+
+  // Release: write version file, changelog, and release notes
+  const changelogFile = join(cwd, "CHANGELOG.md");
+  await Bun.write(join(cwd, "version"), newVersion);
+  await Bun.write(join(releaseNotesDir, `${newVersion}.md`), releaseWithTickets, {
+    createPath: true,
+  });
+  await Bun.write(
+    changelogFile,
+    (log.header + releaseWithTickets + log.history).replace(/\n+$/, "\n")
+  );
+
+  return newVersion;
+}
+
+/**
+ * Generate a shields.io badge for the release type
+ *
+ * @param type - Semver release type (patch, minor, major)
+ * @returns Markdown image string
+ */
+function releaseTypeBadge(type: string): string {
+  const color = type === "major" ? "red" : "brightgreen";
+  return `![release:${type}](https://img.shields.io/badge/release-${type}-${color})`;
+}
+
+/**
+ * Generate a shields.io badge for breaking changes count
+ *
+ * Returns empty string when count is 0 or cannot be determined.
+ *
+ * @param summary - Bump reason string from conventional-recommended-bump
+ * @returns Markdown image string or empty string
+ */
+function breakingChangesBadge(summary: string): string {
+  const match = summary.match(/(\d+)\s+BREAKING CHANGES?/);
+  const count = match?.[1] ? parseInt(match[1], 10) : 0;
+  if (count === 0) return "";
+  return `![breaking changes:${count}](https://img.shields.io/badge/breaking%20changes-${count}-red)`;
+}
+
+/**
+ * Insert tickets markdown after the version header in release notes
+ *
+ * @param release - Original release notes
+ * @param tickets - Tickets markdown section
+ * @returns Release notes with tickets inserted
+ */
+function insertTicketsInRelease(release: string, tickets: string): string {
+  if (!tickets) {
+    return release;
+  }
+
+  // Find version header (## [x.x.x]...) followed by blank line
+  // Insert tickets immediately after, before any ### sections
+  const headerMatch = release.match(/^(## [^\n]+\n\n)/);
+  const header = headerMatch?.[1];
+  if (header) {
+    const rest = release.slice(header.length);
+    return `${header}${tickets}\n${rest}`;
+  }
+
+  // No header found, prepend tickets
+  return `${tickets}\n${release}`;
+}
+
+/**
+ * Parse CLI arguments into ReleaseOptions
+ *
+ * Uses explicit --tickets args if provided, otherwise auto-detects
+ * ticket systems from environment variables.
+ */
+async function parseCliArgs(): Promise<ReleaseOptions> {
+  const args = process.argv.slice(2);
+  const env = loadTicketEnv();
+
+  // Use explicit args if provided, otherwise auto-detect from env
+  const ticketSystems = parseTicketArgs(args) ?? autoDetectTicketSystems(env);
+
+  let owner: string | undefined;
+  let repo: string | undefined;
+
+  for (const arg of args) {
+    if (arg.startsWith("--owner=")) {
+      owner = arg.slice("--owner=".length);
+    } else if (arg.startsWith("--repo=")) {
+      repo = arg.slice("--repo=".length);
+    }
+  }
+
+  // Try to get owner/repo from git remote if not provided
+  if ((!owner || !repo) && ticketSystems.length > 0) {
+    const remoteInfo = await getGitRemoteInfo();
+    owner = owner ?? remoteInfo.owner;
+    repo = repo ?? remoteInfo.repo;
+  }
+
+  return {
+    ticketSystems: ticketSystems.length > 0 ? ticketSystems : undefined,
+    owner,
+    repo,
+  };
+}
+
+/**
+ * Get owner/repo from git remote origin URL
+ */
+async function getGitRemoteInfo(): Promise<{ owner?: string; repo?: string }> {
+  try {
+    const proc = Bun.spawn(["git", "remote", "get-url", "origin"]);
+    const url = await new Response(proc.stdout).text();
+    const trimmedUrl = url.trim();
+
+    // Parse GitHub URL formats:
+    // https://github.com/owner/repo.git
+    // git@github.com:owner/repo.git
+    const httpsMatch = trimmedUrl.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+    const sshMatch = trimmedUrl.match(/github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
+
+    const match = httpsMatch ?? sshMatch;
+    if (match) {
+      return { owner: match[1], repo: match[2] };
+    }
+  } catch {
+    // Ignore errors - return empty
+  }
+  return {};
+}
+
+// Only run when executed directly (not when imported for testing)
+if (import.meta.main) {
+  parseCliArgs()
+    .then((options) => main(options))
+    .then((version) => console.log(`Release ${version} prepared successfully`))
+    .catch((error: Error) => {
+      console.error(error.message);
+      process.exit(1);
+    });
+}

--- a/.github/actions/release-action/src/releaseNotesPrompt.ts
+++ b/.github/actions/release-action/src/releaseNotesPrompt.ts
@@ -1,0 +1,283 @@
+/**
+ * Release notes prompt configuration and content filtering
+ *
+ * Contains the AI prompt for generating release notes, changelog filtering
+ * logic, and service context reader. The prompt targets a delivery/integration
+ * team audience who deploy, configure, and integrate services.
+ *
+ * To modify release notes output:
+ * - Edit `systemPrompt` to change sections, rules, or exclusions
+ * - Edit `filterChangelogForAi` to change which changelog sections reach the AI
+ * - Edit `readServiceContext` to change what service documentation is included
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   systemPrompt,
+ *   filterChangelogForAi,
+ *   readServiceContext,
+ *   buildUserMessage,
+ *   anthropicModel,
+ * } from "./releaseNotesPrompt.ts";
+ *
+ * const filtered = filterChangelogForAi(changelog);
+ * const context = await readServiceContext();
+ * const message = buildUserMessage(filtered, context, tickets, prDescriptions);
+ * ```
+ */
+import { join } from "node:path";
+
+import { Glob } from "bun";
+
+/** Anthropic model used for release notes generation */
+export const anthropicModel = "claude-opus-4-20250514";
+
+/** Maximum output tokens for the API response */
+export const maxOutputTokens = 4096;
+
+/**
+ * Changelog sections that are irrelevant for the delivery team.
+ *
+ * These sections contain internal development changes (dependency bumps,
+ * CI pipeline tweaks, test infrastructure, build config) that add noise
+ * to release notes without providing integration or deployment value.
+ */
+const irrelevantSections = new Set(["Chores", "CI", "Tests", "Build"]);
+
+/** Maximum characters to include from README.md */
+const maxReadmeLength = 3000;
+
+/** Maximum total characters to include from docs/*.md files */
+const maxDocsLength = 5000;
+
+/** System prompt with audience, format, sections, rules, and exclusions */
+export const systemPrompt = `You generate release notes for the delivery/integration team.
+
+AUDIENCE: Technical delivery team (NOT programmers). They deploy, configure, and integrate services. They need to understand WHAT changed, WHY it matters, and HOW to set it up.
+
+When SERVICE CONTEXT is provided, use it to understand what the service does and write notes using domain-appropriate language. Reference service concepts and terminology the delivery team would recognize.
+
+SECTIONS (in order):
+
+Start with a one-sentence summary of the most impactful change (no heading).
+
+## ✨ What's New
+For each feature or improvement, use a ### heading with a short name, followed by a description paragraph:
+
+### <Feature Name>
+<Description paragraph explaining user benefit and deployment/integration impact>
+
+If related to tickets/PRs, add a collapsible section with full links:
+<details><summary>Related issues</summary>
+
+- [ARCH-90: Issue title](url)
+- [#1: Issue title](url)
+</details>
+
+## 🐛 Bug Fixes
+For each fix that affects behavior (skip internal/minor fixes), use a ### heading:
+
+### <Fix Name>
+<Description paragraph focusing on what was broken and is now working>
+
+## 📋 Protocol & Contract Changes
+Only include if there are API endpoint, request/response schema, or integration contract changes. Use a ### heading per change with before/after examples:
+
+### <Change Name>
+<What changed and why>
+
+**Before:**
+\`\`\`
+<old format/endpoint/schema>
+\`\`\`
+
+**After:**
+\`\`\`
+<new format/endpoint/schema>
+\`\`\`
+
+## ⚙️ Configuration Required
+For any new environment variables or config changes, use a ### heading:
+
+### <Config Change Name>
+<Description: what it does, WHY it's needed, required/optional>
+
+## ⚠️ Breaking Changes
+Only include if there are actual breaking changes. Use a ### heading per change:
+
+### <Breaking Change Name>
+<What will break if not addressed. Step-by-step migration instructions>
+
+## 📚 Documentation & Settings Updates
+Only include if there are product documentation or settings file changes. Use a ### heading per change:
+
+### <Change Name>
+<Description of what changed>
+
+RULES:
+- NO commit prefixes (feat/fix/chore)
+- Synthesize related commits into single clear descriptions
+- SKIP empty sections entirely
+- Explain in terms a non-programmer can understand
+- Write in a conversational tone — describe outcomes, not actions. Instead of "Added X" or "Fixed Y", describe what's now possible or what works better
+- Each item MUST use a ### heading followed by a description paragraph, NOT a bullet list
+- GitHub Issues/PRs: Use full link format [#45: Title](url) in Related issues sections
+- Linear/Jira tickets: Use full link format [ARCH-90: Title](url)
+- For items with related tickets, use <details><summary>Related issues</summary> collapsible sections
+- When PR descriptions contain explicit release notes, prefer that content as primary source
+
+EXCLUDE (never mention in release notes):
+- CI/CD pipeline or workflow file changes
+- Dependency version bumps without user-facing impact
+- Governance/legal documents (CONTRIBUTING.md, AGENTS.md, LICENSE, CODE_OF_CONDUCT.md)
+- Internal test infrastructure changes (test timeouts, test isolation, test helpers)
+- Build system or lockfile changes (bun.lock, package-lock.json)
+- Code formatting or linting configuration updates
+
+STYLE EXAMPLE:
+
+Good:
+### Smarter Slack notifications
+Release announcements no longer cut off mid-sentence or break up related sections when they hit Slack's message limits, ensuring your team gets coherent updates.
+
+<details><summary>Related issues</summary>
+
+- [TEAM-123: Smart truncate for the slack message](https://linear.app/example/issue/TEAM-123/smart-truncate-for-the-slack-message)
+</details>
+
+Bad:
+- **Smart truncate for the slack message** — fix(slack): truncate messages at paragraph, line, or word boundaries`;
+
+/**
+ * Strip irrelevant conventional changelog sections before sending to AI.
+ *
+ * Removes ### Chores, ### CI, ### Tests, and ### Build sections entirely.
+ * Keeps ### Features, ### Bug Fixes, ### Performance, ### Reverts,
+ * ### Refactoring, and ### Documentation for the AI to synthesize.
+ *
+ * @param changelog - Raw conventional changelog body
+ * @returns Filtered changelog with only relevant sections
+ */
+export function filterChangelogForAi(changelog: string): string {
+  const lines = changelog.split("\n");
+  const result: string[] = [];
+  let skip = false;
+
+  for (const line of lines) {
+    if (line.startsWith("### ")) {
+      const section = line.slice(4).trim();
+      skip = irrelevantSections.has(section);
+    }
+
+    if (!skip) {
+      result.push(line);
+    }
+  }
+
+  return result
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/** Collect docs/*.md file paths, returning empty array on errors */
+async function collectDocFiles(cwd: string): Promise<Array<{ path: string; relative: string }>> {
+  try {
+    const glob = new Glob("docs/**/*.md");
+    const files: Array<{ path: string; relative: string }> = [];
+
+    for await (const match of glob.scan({ cwd, absolute: true })) {
+      files.push({ path: match, relative: match.replace(`${cwd}/`, "") });
+    }
+
+    return files;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read service documentation to give the AI context about the service.
+ *
+ * Reads README.md and docs/*.md files from the service repository.
+ * This helps the AI write release notes using domain-appropriate language
+ * and explain changes in terms of the service's functionality.
+ *
+ * @param cwd - Working directory (default: process.cwd())
+ * @returns Combined service context string, or empty string if no docs found
+ */
+export async function readServiceContext(cwd = process.cwd()): Promise<string> {
+  const parts: string[] = [];
+
+  try {
+    const readmeFile = Bun.file(join(cwd, "README.md"));
+    if (await readmeFile.exists()) {
+      const content = await readmeFile.text();
+      const truncated =
+        content.length > maxReadmeLength ? `${content.slice(0, maxReadmeLength)}...` : content;
+      parts.push(`README:\n${truncated}`);
+    }
+  } catch {
+    // Ignore read errors — service context is optional
+  }
+
+  const docFiles = await collectDocFiles(cwd);
+  let totalLength = 0;
+
+  for (const { path, relative } of docFiles) {
+    if (totalLength >= maxDocsLength) break;
+
+    try {
+      const content = await Bun.file(path).text();
+      const remaining = maxDocsLength - totalLength;
+      const truncated = content.length > remaining ? `${content.slice(0, remaining)}...` : content;
+
+      parts.push(`${relative}:\n${truncated}`);
+      totalLength += truncated.length;
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  return parts.join("\n\n");
+}
+
+/**
+ * Assemble the dynamic user message for the Anthropic API.
+ *
+ * Combines filtered changelog, service context, ticket data, and PR
+ * descriptions into a single user message. The system prompt contains
+ * the stable instructions.
+ *
+ * @param changelog - Filtered changelog content
+ * @param serviceContext - Service README/docs content (optional)
+ * @param tickets - Ticket context JSON string (optional)
+ * @param prDescriptions - PR descriptions YAML string (optional)
+ * @returns Assembled user message string
+ */
+export function buildUserMessage(
+  changelog: string,
+  serviceContext?: string,
+  tickets?: string,
+  prDescriptions?: string
+): string {
+  const parts: string[] = [];
+
+  if (serviceContext) {
+    parts.push(`SERVICE CONTEXT:\n${serviceContext}`);
+  }
+
+  parts.push(`CHANGELOG:\n${changelog}`);
+
+  if (tickets) {
+    parts.push(`TICKET CONTEXT (use these IDs in your output):\n${tickets}`);
+  }
+
+  if (prDescriptions) {
+    parts.push(
+      `PR DESCRIPTIONS (developer-provided context from pull requests — prioritize any explicit release notes content over conventional commit messages):\n${prDescriptions}`
+    );
+  }
+
+  return parts.join("\n\n");
+}

--- a/.github/actions/release-action/src/slackNotify.test.ts
+++ b/.github/actions/release-action/src/slackNotify.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Tests for Slack release notification utilities
+ *
+ * Note: parseSlackRelease tests are in platformMeta/platformMeta.test.ts
+ */
+import { describe, expect, test } from "bun:test";
+
+import { extractReleaseNotes } from "./slackNotify.ts";
+
+describe("extractReleaseNotes", () => {
+  const fallback = "A new version has been released.";
+
+  test("returns fallback when no ## Release Notes heading", () => {
+    const content = `## [1.0.0](link) (2026-01-01)
+
+### Features
+
+* **auth:** add login ([abc123](link))
+`;
+    expect(extractReleaseNotes(content)).toBe(fallback);
+  });
+
+  test("returns fallback when ## Release Notes section is empty", () => {
+    const content = `## [1.0.0](link) (2026-01-01)
+
+## Release Notes
+
+## Linear
+`;
+    expect(extractReleaseNotes(content)).toBe(fallback);
+  });
+
+  test("extracts summary and multiple AI sections with ### headings", () => {
+    const content = `## [1.0.0](link) (2026-01-01)
+
+## Release Notes
+
+Summary line here.
+
+## ✨ What's New
+
+### Feature A
+Description of feature A
+
+## 🐛 Bug Fixes
+
+### Fix B
+Description of fix B
+
+## Linear
+
+| Issue | PR | Author |
+| --- | --- | --- |
+| [TOOLS-1: ticket](link) | [#10](pr) | @dev |
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("Summary line here.");
+    expect(result).toContain("*✨ What's New*");
+    expect(result).toContain("*Feature A*");
+    expect(result).toContain("Description of feature A");
+    expect(result).toContain("*🐛 Bug Fixes*");
+    expect(result).toContain("*Fix B*");
+    expect(result).not.toContain("Linear");
+    expect(result).not.toContain("TOOLS-1");
+  });
+
+  test("stops at ## Linear", () => {
+    const content = `## Release Notes
+
+Summary.
+
+## Linear
+
+Should not appear.
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("Summary.");
+    expect(result).not.toContain("Should not appear");
+  });
+
+  test("stops at ## Jira", () => {
+    const content = `## Release Notes
+
+Summary.
+
+## Jira
+
+Should not appear.
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("Summary.");
+    expect(result).not.toContain("Should not appear");
+  });
+
+  test("stops at ## GitHub Issues", () => {
+    const content = `## Release Notes
+
+Summary.
+
+## GitHub Issues
+
+- #42 should not appear
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("Summary.");
+    expect(result).not.toContain("#42");
+  });
+
+  test("does not stop at non-conventional ### headings (AI items use ### format)", () => {
+    const content = `## Release Notes
+
+Summary.
+
+## ✨ What's New
+
+### My Feature
+Feature description here.
+
+## Linear
+
+Should not appear.
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("Summary.");
+    expect(result).toContain("*My Feature*");
+    expect(result).toContain("Feature description here.");
+    expect(result).not.toContain("Linear");
+  });
+
+  test("stops at conventional changelog ### sections (e.g. ### Bug Fixes)", () => {
+    const content = `## Release Notes
+
+Summary.
+
+## 🐛 Bug Fixes
+
+### Fix A
+Description of fix A
+
+### Bug Fixes
+
+* **release:** some fix ([abc123](link))
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("Summary.");
+    expect(result).toContain("*Fix A*");
+    expect(result).toContain("Description of fix A");
+    expect(result).not.toContain("some fix");
+    expect(result).not.toContain("abc123");
+  });
+
+  test("stops at conventional changelog sections even without ticket sections", () => {
+    const content = `## [1.12.2](link) (2026-04-10)
+
+## Release Notes
+
+Teams will notice visual markers in release notes.
+
+## Bug Fixes
+
+### Visual markers restored
+Emoji icons are back in section headings.
+
+### Bug Fixes
+
+* **release:** restore emoji prefixes ([63c5534](link))
+
+### Refactoring
+
+* **release:** extract prompt ([8144abf](link))
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("Teams will notice visual markers");
+    expect(result).toContain("*Visual markers restored*");
+    expect(result).toContain("Emoji icons are back");
+    expect(result).not.toContain("restore emoji prefixes");
+    expect(result).not.toContain("63c5534");
+    expect(result).not.toContain("extract prompt");
+    expect(result).not.toContain("8144abf");
+  });
+
+  test("strips root-level <details> blocks", () => {
+    const content = `## Release Notes
+
+Summary.
+
+## ✨ What's New
+
+### Feature
+Description
+
+<details><summary>Related issues</summary>
+
+- [TOOLS-1: ticket](link)
+</details>
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("*Feature*");
+    expect(result).not.toContain("Related issues");
+    expect(result).not.toContain("TOOLS-1");
+    expect(result).not.toContain("<details>");
+  });
+
+  test("strips indented <details> blocks", () => {
+    const content = `## Release Notes
+
+Summary.
+
+## ✨ What's New
+
+### Feature
+Description
+
+  <details><summary>Related issues</summary>
+
+  - [TOOLS-1: ticket](link)
+  </details>
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("*Feature*");
+    expect(result).not.toContain("TOOLS-1");
+    expect(result).not.toContain("<details>");
+  });
+
+  test("escapes & < > for Slack mrkdwn", () => {
+    const content = `## Release Notes
+
+Use <your-id> for R&D teams. Check a > b.
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("&lt;your-id&gt;");
+    expect(result).toContain("R&amp;D");
+    expect(result).toContain("a &gt; b");
+    expect(result).not.toContain("<your-id>");
+  });
+
+  test("converts ## headings to Slack bold", () => {
+    const content = `## Release Notes
+
+Summary.
+
+## ✨ What's New
+
+Details.
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("*✨ What's New*");
+    expect(result).not.toContain("## ✨ What's New");
+  });
+
+  test("converts ### headings to Slack bold", () => {
+    const content = `## Release Notes
+
+## ✨ What's New
+
+### Cool Feature
+Description of cool feature.
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("*Cool Feature*");
+    expect(result).not.toContain("### Cool Feature");
+  });
+
+  test("converts **bold** to *bold* for Slack mrkdwn", () => {
+    const content = `## Release Notes
+
+- **Bold text** - description
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).toContain("*Bold text*");
+    expect(result).not.toContain("**Bold text**");
+  });
+
+  test("collapses multiple blank lines into one", () => {
+    const content = `## Release Notes
+
+Summary.
+
+
+
+## ✨ What's New
+
+Details.
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).not.toMatch(/\n{3,}/);
+  });
+
+  test("truncates at paragraph boundary", () => {
+    const content = `## Release Notes
+
+${"A".repeat(1400)}
+
+${"B".repeat(1400)}
+
+${"C".repeat(1400)}
+`;
+    const result = extractReleaseNotes(content);
+    expect(result.length).toBeLessThanOrEqual(2900);
+    expect(result).toEndWith("...");
+    // First two paragraphs included, third excluded entirely
+    expect(result).toContain("A".repeat(1400));
+    expect(result).toContain("B".repeat(1400));
+    expect(result).not.toContain("CCC");
+  });
+
+  test("truncates at line boundary when no paragraph break fits", () => {
+    // Lines with unique end markers, no double-newlines
+    const makeLine = (n: number) => `${"B".repeat(90)}${String(n).padStart(5, "0")}`;
+    const lines = Array.from({ length: 40 }, (_, i) => makeLine(i)).join("\n");
+    const content = `## Release Notes
+
+${lines}
+`;
+    const result = extractReleaseNotes(content);
+    expect(result.length).toBeLessThanOrEqual(2900);
+    expect(result).toEndWith("...");
+    // Last char before "..." should be a digit (end of a complete line), not mid-line
+    const beforeSuffix = result.slice(0, -3);
+    expect(beforeSuffix).toMatch(/\d$/);
+  });
+
+  test("truncates at word boundary when content is a single long line", () => {
+    const words = Array.from({ length: 600 }, () => "word").join(" ");
+    const content = `## Release Notes
+
+${words}
+`;
+    const result = extractReleaseNotes(content);
+    expect(result.length).toBeLessThanOrEqual(2900);
+    expect(result).toEndWith("...");
+    // Should cut at a space, not mid-word
+    expect(result).not.toMatch(/wor\.\.\.$/);
+  });
+
+  test("hard cuts when content has no separators", () => {
+    const content = `## Release Notes
+
+${"X".repeat(3000)}
+`;
+    const result = extractReleaseNotes(content);
+    expect(result.length).toBeLessThanOrEqual(2900);
+    expect(result).toEndWith("...");
+  });
+
+  test("does not truncate content under 2900 characters", () => {
+    const content = `## Release Notes
+
+Short summary.
+`;
+    const result = extractReleaseNotes(content);
+    expect(result).not.toEndWith("...");
+  });
+
+  test("handles real release notes with all transformations", () => {
+    const content = `## [1.7.1](https://github.com/org/repo/compare/v1.7.0...v1.7.1) (2026-03-24)
+
+## Release Notes
+
+Release notes generation improved.
+
+## 🐛 Bug Fixes
+
+### GitHub Issues filtering
+Fixed issue where PRs appeared in issues.
+
+<details><summary>Related issues</summary>
+
+- [TOOLS-250: Title](https://linear.app/issue/TOOLS-250)
+</details>
+
+## 📚 Documentation & Setup Changes
+
+### Workflow updates
+Updated workflows.
+
+
+## Linear
+
+| Issue | PR | Author |
+| --- | --- | --- |
+| [TOOLS-250: Title](link) | [#10](pr) | @dev |
+
+### Bug Fixes
+
+* **tickets:** fix something ([abc](link))
+`;
+    const result = extractReleaseNotes(content);
+
+    // Includes AI sections
+    expect(result).toContain("Release notes generation improved.");
+    expect(result).toContain("*🐛 Bug Fixes*");
+    expect(result).toContain("*GitHub Issues filtering*");
+    expect(result).toContain("*📚 Documentation &amp; Setup Changes*");
+    expect(result).toContain("*Workflow updates*");
+
+    // Excludes ticket/changelog content
+    expect(result).not.toContain("TOOLS-250");
+    expect(result).not.toContain("Linear");
+    expect(result).not.toContain("tickets");
+    expect(result).not.toContain("<details>");
+  });
+});

--- a/.github/actions/release-action/src/slackNotify.ts
+++ b/.github/actions/release-action/src/slackNotify.ts
@@ -1,0 +1,179 @@
+/**
+ * Post release notification to Slack with Block Kit formatting.
+ *
+ * Reads the release channel from `platform.meta.yml` (`slack.release` field),
+ * extracts AI-generated release notes, and posts a rich message with
+ * version, notes, and a link to the GitHub release.
+ *
+ * @example
+ * ```bash
+ * SLACK_TOKEN=xoxb-... bun src/slackNotify.ts
+ * ```
+ */
+import { WebClient } from "@slack/web-api";
+
+import { parseSlackRelease } from "./platformMeta.ts";
+import { changelogSectionNames } from "./release.ts";
+
+/** Heading prefix used by conventional changelog sections in release notes files */
+const changelogHeadingPrefix = "### ";
+
+/** Section names that mark the end of AI-generated content */
+const conventionalChangelogSections: Set<string> = new Set(changelogSectionNames);
+
+/**
+ * Extract AI-generated release notes from a release notes file.
+ *
+ * Captures all AI sections between `## Release Notes` and `## Linear`
+ * (or `## GitHub Issues` / `### ` conventional changelog headings).
+ * Strips `<details>` blocks, converts markdown to Slack mrkdwn format,
+ * and truncates at the nearest paragraph, line, or word boundary
+ * to fit within Slack's 3000 character section limit.
+ */
+export function extractReleaseNotes(content: string): string {
+  const lines = content.split("\n");
+  const startIndex = lines.findIndex((line) => line === "## Release Notes");
+
+  if (startIndex === -1) return "A new version has been released.";
+
+  const result: string[] = [];
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i] as string;
+    if (line === "## Linear" || line === "## Jira" || line === "## GitHub Issues") break;
+    if (
+      line.startsWith(changelogHeadingPrefix) &&
+      conventionalChangelogSections.has(line.slice(changelogHeadingPrefix.length))
+    )
+      break;
+    result.push(line);
+  }
+
+  let notes = result.join("\n").trim();
+  if (!notes) return "A new version has been released.";
+
+  // Strip <details>...</details> blocks (may be indented)
+  notes = notes.replaceAll(/\s*<details>[\s\S]*?<\/details>/g, "");
+
+  // Escape Slack special characters (must run before mrkdwn conversions)
+  notes = notes.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+
+  // Convert ### and ## headings to Slack bold
+  notes = notes.replaceAll(/^### (.+)$/gm, "*$1*");
+  notes = notes.replaceAll(/^## (.+)$/gm, "*$1*");
+
+  // Convert **bold** to *bold* for Slack mrkdwn
+  notes = notes.replaceAll(/\*\*([^*]+)\*\*/g, "*$1*");
+
+  // Collapse multiple blank lines into one
+  notes = notes.replaceAll(/\n{3,}/g, "\n\n").trim();
+
+  // Truncate at the nearest paragraph, line, or word boundary to avoid mid-word cuts
+  const maxLength = 2900;
+  if (notes.length > maxLength) {
+    const suffix = "...";
+    const budget = maxLength - suffix.length;
+    const lastParagraph = notes.lastIndexOf("\n\n", budget);
+    const lastLine = notes.lastIndexOf("\n", budget);
+    const lastSpace = notes.lastIndexOf(" ", budget);
+    let cutPoint = budget;
+    if (lastParagraph > 0) cutPoint = lastParagraph;
+    else if (lastLine > 0) cutPoint = lastLine;
+    else if (lastSpace > 0) cutPoint = lastSpace;
+    notes = `${notes.slice(0, cutPoint).trimEnd()}${suffix}`;
+  }
+
+  return notes;
+}
+
+// Only run when executed directly (not when imported for testing)
+if (import.meta.main) {
+  void (async () => {
+    const slackToken = process.env.SLACK_TOKEN;
+    if (!slackToken) {
+      console.log("SLACK_TOKEN not set, skipping Slack notification");
+      process.exit(0);
+    }
+
+    const repo = process.env.GITHUB_REPOSITORY ?? "";
+    const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+
+    // Read platform.meta.yml for channel
+    const metaFile = Bun.file("platform.meta.yml");
+    if (!(await metaFile.exists())) {
+      console.log("platform.meta.yml not found, skipping Slack notification");
+      process.exit(0);
+    }
+
+    const channel = parseSlackRelease(await metaFile.text());
+    if (!channel) {
+      console.log("No slack.release field in platform.meta.yml, skipping notification");
+      process.exit(0);
+    }
+
+    // Read version and release notes
+    const version = (await Bun.file("version").text()).trim();
+    const repoName = repo.split("/").pop() ?? repo;
+    const releaseUrl = `${serverUrl}/${repo}/releases/tag/v${version}`;
+
+    const releaseNotesFile = Bun.file(`.release_notes/${version}.md`);
+    const releaseNotesContent = (await releaseNotesFile.exists())
+      ? await releaseNotesFile.text()
+      : "";
+    const notes = extractReleaseNotes(releaseNotesContent);
+
+    // Post to Slack using Block Kit
+    const slack = new WebClient(slackToken);
+
+    try {
+      const result = await slack.chat.postMessage({
+        channel,
+        text: `${repo} v${version} released`,
+        unfurl_links: false,
+        blocks: [
+          {
+            type: "header",
+            text: {
+              type: "plain_text",
+              text: `📦 ${repoName} v${version}`,
+              emoji: true,
+            },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: notes,
+            },
+          },
+          {
+            type: "divider",
+          },
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                text: {
+                  type: "plain_text",
+                  text: "View release",
+                },
+                url: releaseUrl,
+                action_id: "view_release",
+                style: "primary",
+              },
+            ],
+          },
+        ],
+      });
+
+      if (result.ok) {
+        console.log(`Slack notification sent to ${channel}`);
+      } else {
+        console.log(`::warning::Slack notification failed: ${result.error}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(`::warning::Slack notification failed: ${message}`);
+    }
+  })();
+}

--- a/.github/actions/release-action/src/testHelpers.ts
+++ b/.github/actions/release-action/src/testHelpers.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared test helpers for temporary directories and git repositories.
+ *
+ * Provides reusable setup/teardown utilities used across test files
+ * to avoid duplicating temp dir and git repo creation logic.
+ *
+ * @example
+ * ```typescript
+ * import { withTempDir, withTempRepo, createCommit } from "../testHelpers.ts";
+ *
+ * test("my test", () => withTempDir(async (dir) => { ... }));
+ * test("git test", () => withTempRepo(async (repo) => { ... }));
+ * ```
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { $ } from "bun";
+
+/**
+ * Run a test function inside a temporary directory that is cleaned up afterward.
+ *
+ * @param fn - Test function receiving the temp directory path
+ */
+export async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "test-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Create an isolated temporary git repository with user config.
+ *
+ * @returns Path to the new git repository
+ */
+async function createTempGitRepo(): Promise<string> {
+  const repoPath = await mkdtemp(join(tmpdir(), "test-repo-"));
+  await $`git init`.cwd(repoPath).quiet();
+  await $`git config user.email "test@test.com"`.cwd(repoPath).quiet();
+  await $`git config user.name "Test"`.cwd(repoPath).quiet();
+  return repoPath;
+}
+
+/**
+ * Run a test function inside an isolated git repository that is cleaned up afterward.
+ *
+ * @param fn - Test function receiving the repo path
+ */
+export async function withTempRepo(fn: (repoPath: string) => Promise<void>): Promise<void> {
+  const repoPath = await createTempGitRepo();
+  try {
+    await fn(repoPath);
+  } finally {
+    await rm(repoPath, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Create a conventional commit in a test repository.
+ *
+ * @param repoPath - Path to the git repository
+ * @param message - Commit message
+ * @param file - File to create/modify (default: "file.txt")
+ */
+export async function createCommit(
+  repoPath: string,
+  message: string,
+  file = "file.txt"
+): Promise<void> {
+  await Bun.write(join(repoPath, file), `${Date.now()}\n`);
+  await $`git add ${file}`.cwd(repoPath).quiet();
+  await $`git commit -m ${message}`.cwd(repoPath).quiet();
+}
+
+/**
+ * Create an initial commit with package.json and tag it.
+ *
+ * @param repoPath - Path to the git repository
+ * @param version - Version to tag (default: "1.0.0")
+ */
+export async function createInitialCommitAndTag(
+  repoPath: string,
+  version = "1.0.0"
+): Promise<void> {
+  await $`git add package.json`.cwd(repoPath).quiet();
+  await $`git commit -m ${"chore: initial commit"}`.cwd(repoPath).quiet();
+  await $`git tag v${version}`.cwd(repoPath).quiet();
+}

--- a/.github/actions/release-action/src/tickets/githubClient.test.ts
+++ b/.github/actions/release-action/src/tickets/githubClient.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for GitHub client
+ *
+ * Tests the git-based commit retrieval using real git repos.
+ * API calls are tested with mocked fetch in integration tests.
+ */
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+
+import { createCommit, withTempRepo } from "../testHelpers.ts";
+
+import { getCommitsSinceLastTag } from "./githubClient.ts";
+
+describe("githubClient", () => {
+  describe("getCommitsSinceLastTag()", () => {
+    test("returns all commits when no tags exist", () =>
+      withTempRepo(async (testRepo) => {
+        await createCommit(testRepo, "feat: first commit");
+        await createCommit(testRepo, "fix: second commit", "file2.txt");
+
+        const commits = await getCommitsSinceLastTag(testRepo);
+
+        expect(commits).toHaveLength(2);
+        expect(commits[0]?.message).toBe("fix: second commit");
+        expect(commits[1]?.message).toBe("feat: first commit");
+      }));
+
+    test("returns only commits after tag", () =>
+      withTempRepo(async (testRepo) => {
+        await createCommit(testRepo, "chore: initial");
+        await $`git tag v1.0.0`.cwd(testRepo).quiet();
+        await createCommit(testRepo, "feat: new feature", "file2.txt");
+
+        const commits = await getCommitsSinceLastTag(testRepo);
+
+        expect(commits).toHaveLength(1);
+        expect(commits[0]?.message).toBe("feat: new feature");
+      }));
+
+    test("extracts PR number from squash merge format", () =>
+      withTempRepo(async (testRepo) => {
+        await createCommit(testRepo, "feat: add auth (#45)");
+
+        const commits = await getCommitsSinceLastTag(testRepo);
+
+        expect(commits[0]?.prNumber).toBe(45);
+      }));
+
+    test("returns undefined prNumber for non-squash commits", () =>
+      withTempRepo(async (testRepo) => {
+        await createCommit(testRepo, "feat: add auth");
+
+        const commits = await getCommitsSinceLastTag(testRepo);
+
+        expect(commits[0]?.prNumber).toBeUndefined();
+      }));
+
+    test("uses latest tag when multiple exist", () =>
+      withTempRepo(async (testRepo) => {
+        await createCommit(testRepo, "chore: initial");
+        await $`git tag v1.0.0`.cwd(testRepo).quiet();
+        await createCommit(testRepo, "feat: middle feature", "file2.txt");
+        await $`git tag v1.1.0`.cwd(testRepo).quiet();
+        await createCommit(testRepo, "feat: latest feature", "file3.txt");
+
+        const commits = await getCommitsSinceLastTag(testRepo);
+
+        expect(commits).toHaveLength(1);
+        expect(commits[0]?.message).toBe("feat: latest feature");
+      }));
+
+    test("includes commit SHA", () =>
+      withTempRepo(async (testRepo) => {
+        await createCommit(testRepo, "feat: test commit");
+
+        const commits = await getCommitsSinceLastTag(testRepo);
+
+        expect(commits[0]?.sha).toMatch(/^[a-f0-9]{40}$/);
+      }));
+
+    test("uses topologically closest tag, not highest version number", () =>
+      withTempRepo(async (testRepo) => {
+        // Reproduce: v1.0.0 tagged on old commit, v0.16.1 tagged later.
+        // Without the fix, version sort picks v1.0.0 as "latest" and
+        // git log v1.0.0..HEAD includes commits already in v0.16.0/v0.16.1.
+        await createCommit(testRepo, "chore: ancient");
+        await $`git tag v1.0.0`.cwd(testRepo).quiet();
+        await createCommit(testRepo, "feat: in 0.16.0", "a.txt");
+        await $`git tag v0.16.0`.cwd(testRepo).quiet();
+        await createCommit(testRepo, "feat: in 0.16.1", "b.txt");
+        await $`git tag v0.16.1`.cwd(testRepo).quiet();
+        await createCommit(testRepo, "feat: new for 0.16.2", "c.txt");
+
+        const commits = await getCommitsSinceLastTag(testRepo);
+
+        expect(commits).toHaveLength(1);
+        expect(commits[0]?.message).toBe("feat: new for 0.16.2");
+      }));
+  });
+});

--- a/.github/actions/release-action/src/tickets/githubClient.ts
+++ b/.github/actions/release-action/src/tickets/githubClient.ts
@@ -1,0 +1,254 @@
+/**
+ * GitHub API client for fetching commits and pull request details
+ *
+ * Uses git commands for commit history and GitHub REST API for PR details.
+ *
+ * @example
+ * ```typescript
+ * import { getCommitsSinceLastTag, fetchPullRequest } from "./githubClient.ts";
+ *
+ * const commits = await getCommitsSinceLastTag("v", process.cwd());
+ * const pr = await fetchPullRequest(45, "owner", "repo", "ghp_xxx");
+ * ```
+ */
+
+import { $ } from "bun";
+
+import { getLatestReachableTag } from "../gitTags.ts";
+
+import type { CommitInfo, PullRequestInfo } from "./tickets.types.ts";
+import { extractPrNumber } from "./ticketExtractor.ts";
+
+/** GitHub API base URL */
+const githubApiUrl = "https://api.github.com";
+
+/**
+ * Get all commits since the last `v*` tag reachable from HEAD.
+ *
+ * Uses reachability-based discovery: finds the closest tag reachable from HEAD by commit
+ * topology, not version number. This prevents picking a higher-versioned tag that sits on
+ * an older commit (e.g. v1.0.0 before v0.16.1).
+ *
+ * @param cwd - Working directory
+ * @returns Array of commit info with extracted PR numbers
+ *
+ * @example
+ * ```typescript
+ * const commits = await getCommitsSinceLastTag(process.cwd());
+ * // → [{ sha: "abc123", message: "feat: add auth (#45)", prNumber: 45 }]
+ * ```
+ */
+export async function getCommitsSinceLastTag(cwd: string): Promise<CommitInfo[]> {
+  const latestTag = await getLatestReachableTag("v*", cwd);
+
+  // Get commits with format: SHA|message
+  const format = "--format=%H|%s";
+  const logResult = latestTag
+    ? await $`git log ${`${latestTag}..HEAD`} ${format}`.cwd(cwd).quiet().nothrow()
+    : await $`git log HEAD ${format}`.cwd(cwd).quiet().nothrow();
+
+  const lines = logResult.stdout.toString().trim().split("\n").filter(Boolean);
+
+  const commits: CommitInfo[] = [];
+
+  for (const line of lines) {
+    const separatorIndex = line.indexOf("|");
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const sha = line.substring(0, separatorIndex);
+    const message = line.substring(separatorIndex + 1);
+    const prNumber = extractPrNumber(message);
+
+    commits.push({ sha, message, prNumber });
+  }
+
+  return commits;
+}
+
+/**
+ * Fetch pull request details from GitHub API
+ *
+ * @param prNumber - Pull request number
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @param token - GitHub token for authentication
+ * @returns Pull request info or null if not found
+ *
+ * @example
+ * ```typescript
+ * const pr = await fetchPullRequest(45, "owner", "repo", "ghp_xxx");
+ * // → { number: 45, title: "feat: TEAM-123 add auth", url: "...", author: "dev" }
+ * ```
+ */
+export async function fetchPullRequest(
+  prNumber: number,
+  owner: string,
+  repo: string,
+  token: string
+): Promise<PullRequestInfo | null> {
+  const url = `${githubApiUrl}/repos/${owner}/${repo}/pulls/${prNumber}`;
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "code-assistants-release-action",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null;
+    }
+    throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    number: number;
+    title: string;
+    body: string | null;
+    html_url: string;
+    user: { login: string };
+  };
+
+  return {
+    number: data.number,
+    title: data.title,
+    body: data.body ?? undefined,
+    url: data.html_url,
+    author: data.user.login,
+  };
+}
+
+/**
+ * Fetch multiple pull requests in parallel with rate limiting
+ *
+ * @param prNumbers - Array of PR numbers to fetch
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @param token - GitHub token for authentication
+ * @param concurrency - Max concurrent requests (default: 5)
+ * @returns Map of PR number to PR info
+ */
+export async function fetchPullRequests(
+  prNumbers: number[],
+  owner: string,
+  repo: string,
+  token: string,
+  concurrency = 5
+): Promise<Map<number, PullRequestInfo>> {
+  const results = new Map<number, PullRequestInfo>();
+  const uniquePrNumbers = [...new Set(prNumbers)];
+
+  // Process in batches for rate limiting
+  for (let i = 0; i < uniquePrNumbers.length; i += concurrency) {
+    const batch = uniquePrNumbers.slice(i, i + concurrency);
+    const promises = batch.map(async (prNumber) => {
+      const pr = await fetchPullRequest(prNumber, owner, repo, token);
+      if (pr) {
+        results.set(prNumber, pr);
+      }
+    });
+    await Promise.all(promises);
+  }
+
+  return results;
+}
+
+/**
+ * Fetch the pull request associated with a commit SHA
+ *
+ * Uses the GitHub API endpoint that returns PRs containing a specific commit.
+ * Works for all merge strategies (squash, rebase, merge commit).
+ *
+ * @param commitSha - Full or abbreviated commit SHA
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @param token - GitHub token for authentication
+ * @returns Pull request info or null if no PR found
+ *
+ * @example
+ * ```typescript
+ * const pr = await fetchPullRequestForCommit("52ff2cd", "owner", "repo", "ghp_xxx");
+ * // → { number: 44, title: "ARCH-90: Add feature", url: "...", author: "dev" }
+ * ```
+ */
+export async function fetchPullRequestForCommit(
+  commitSha: string,
+  owner: string,
+  repo: string,
+  token: string
+): Promise<PullRequestInfo | null> {
+  const url = `${githubApiUrl}/repos/${owner}/${repo}/commits/${commitSha}/pulls`;
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "code-assistants-release-action",
+    },
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = (await response.json()) as Array<{
+    number: number;
+    title: string;
+    body: string | null;
+    html_url: string;
+    user: { login: string };
+  }>;
+
+  // Return the first (most recent) PR associated with this commit
+  const [firstPr] = data;
+  if (!firstPr) {
+    return null;
+  }
+
+  return {
+    number: firstPr.number,
+    title: firstPr.title,
+    body: firstPr.body ?? undefined,
+    url: firstPr.html_url,
+    author: firstPr.user.login,
+  };
+}
+
+/**
+ * Fetch pull requests for multiple commits in parallel
+ *
+ * @param commitShas - Array of commit SHAs
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @param token - GitHub token for authentication
+ * @param concurrency - Max concurrent requests (default: 5)
+ * @returns Map of commit SHA to PR info
+ */
+export async function fetchPullRequestsForCommits(
+  commitShas: string[],
+  owner: string,
+  repo: string,
+  token: string,
+  concurrency = 5
+): Promise<Map<string, PullRequestInfo>> {
+  const results = new Map<string, PullRequestInfo>();
+  const uniqueShas = [...new Set(commitShas)];
+
+  // Process in batches for rate limiting
+  for (let i = 0; i < uniqueShas.length; i += concurrency) {
+    const batch = uniqueShas.slice(i, i + concurrency);
+    const promises = batch.map(async (sha) => {
+      const pr = await fetchPullRequestForCommit(sha, owner, repo, token);
+      if (pr) {
+        results.set(sha, pr);
+      }
+    });
+    await Promise.all(promises);
+  }
+
+  return results;
+}

--- a/.github/actions/release-action/src/tickets/githubClient.ts
+++ b/.github/actions/release-action/src/tickets/githubClient.ts
@@ -192,7 +192,13 @@ export async function fetchPullRequestForCommit(
   });
 
   if (!response.ok) {
-    return null;
+    // 404 → commit has no associated PR (legitimate "no data"). Anything else
+    // (401, 403, 429, 5xx) is an operational failure that must surface so the
+    // release doesn't silently lose ticket data.
+    if (response.status === 404) return null;
+    throw new Error(
+      `GitHub API error fetching PR for commit ${commitSha}: ${response.status} ${response.statusText}`
+    );
   }
 
   const data = (await response.json()) as Array<{

--- a/.github/actions/release-action/src/tickets/githubIssuesClient.test.ts
+++ b/.github/actions/release-action/src/tickets/githubIssuesClient.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for GitHub Issues client utilities
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  createGithubIssuesClient,
+  extractGithubIssueNumbers,
+  githubIssuePattern,
+} from "./githubIssuesClient.ts";
+
+describe("githubIssuesClient", () => {
+  describe("githubIssuePattern", () => {
+    test("matches #N at start of text", () => {
+      expect("#123 is the issue".match(githubIssuePattern)).toEqual(["#123"]);
+    });
+
+    test("matches #N mid-sentence", () => {
+      expect("see issue #456 for details".match(githubIssuePattern)).toEqual(["#456"]);
+    });
+
+    test("does not match in URL paths", () => {
+      githubIssuePattern.lastIndex = 0;
+      expect("https://github.com/org/repo/pull/123".match(githubIssuePattern)).toBeNull();
+    });
+
+    test("does not match preceded by word character", () => {
+      githubIssuePattern.lastIndex = 0;
+      expect("word#123".match(githubIssuePattern)).toBeNull();
+    });
+  });
+
+  describe("extractGithubIssueNumbers()", () => {
+    test("extracts single issue number", () => {
+      expect(extractGithubIssueNumbers("Fixes #123")).toEqual(["123"]);
+    });
+
+    test("extracts multiple issue numbers", () => {
+      expect(extractGithubIssueNumbers("Fixes #123 and relates to #456")).toEqual(["123", "456"]);
+    });
+
+    test("deduplicates issue numbers", () => {
+      expect(extractGithubIssueNumbers("#123 and #123")).toEqual(["123"]);
+    });
+
+    test("returns empty array when no matches", () => {
+      expect(extractGithubIssueNumbers("no issues here")).toEqual([]);
+    });
+
+    test("does not match numbers in URLs", () => {
+      expect(extractGithubIssueNumbers("https://github.com/org/repo/pull/123")).toEqual([]);
+    });
+
+    test("does not match numbers preceded by word characters", () => {
+      expect(extractGithubIssueNumbers("word#123")).toEqual([]);
+    });
+
+    test("handles empty string", () => {
+      expect(extractGithubIssueNumbers("")).toEqual([]);
+    });
+
+    test("excludes known PR numbers", () => {
+      const excludePrNumbers = new Set([273]);
+      expect(extractGithubIssueNumbers("Fixes #42 and refs #273", excludePrNumbers)).toEqual([
+        "42",
+      ]);
+    });
+
+    test("excludes multiple known PR numbers", () => {
+      const excludePrNumbers = new Set([273, 269, 235]);
+      expect(extractGithubIssueNumbers("#273 #269 #235 #42", excludePrNumbers)).toEqual(["42"]);
+    });
+
+    test("returns empty when all matches are excluded", () => {
+      const excludePrNumbers = new Set([273, 269]);
+      expect(extractGithubIssueNumbers("#273 #269", excludePrNumbers)).toEqual([]);
+    });
+
+    test("does not exclude when exclusion set is undefined", () => {
+      expect(extractGithubIssueNumbers("#273")).toEqual(["273"]);
+    });
+
+    test("does not exclude when exclusion set is empty", () => {
+      expect(extractGithubIssueNumbers("#273", new Set())).toEqual(["273"]);
+    });
+
+    test("exclusion matches exact number only", () => {
+      const excludePrNumbers = new Set([273]);
+      expect(extractGithubIssueNumbers("#27 #273 #2730", excludePrNumbers)).toEqual(["27", "2730"]);
+    });
+  });
+
+  describe("createGithubIssuesClient()", () => {
+    const originalFetch = globalThis.fetch;
+
+    function mockFetch(handler: (...args: unknown[]) => Promise<Response>): void {
+      globalThis.fetch = mock(handler) as unknown as typeof fetch;
+    }
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    test("returns ticket info for a real issue", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              number: 42,
+              title: "Bug in auth flow",
+              html_url: "https://github.com/org/repo/issues/42",
+            }),
+            { status: 200 }
+          )
+        )
+      );
+
+      const client = createGithubIssuesClient("org", "repo", "ghp_xxx");
+      const result = await client.fetchTicket("42");
+
+      expect(result).toEqual({
+        id: "#42",
+        title: "Bug in auth flow",
+        url: "https://github.com/org/repo/issues/42",
+        system: "github",
+      });
+    });
+
+    test("returns null when issue is actually a pull request", async () => {
+      mockFetch(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              number: 393,
+              title: "TOOLS-196: Fix release notes",
+              html_url: "https://github.com/org/repo/pull/393",
+              pull_request: {
+                url: "https://api.github.com/repos/org/repo/pulls/393",
+                html_url: "https://github.com/org/repo/pull/393",
+              },
+            }),
+            { status: 200 }
+          )
+        )
+      );
+
+      const client = createGithubIssuesClient("org", "repo", "ghp_xxx");
+      const result = await client.fetchTicket("393");
+
+      expect(result).toBeNull();
+    });
+
+    test("returns null for 404 response", async () => {
+      mockFetch(() => Promise.resolve(new Response(null, { status: 404 })));
+
+      const client = createGithubIssuesClient("org", "repo", "ghp_xxx");
+      const result = await client.fetchTicket("999");
+
+      expect(result).toBeNull();
+    });
+
+    test("throws on non-404 error response", async () => {
+      mockFetch(() =>
+        Promise.resolve(new Response(null, { status: 500, statusText: "Internal Server Error" }))
+      );
+
+      const client = createGithubIssuesClient("org", "repo", "ghp_xxx");
+
+      await expect(client.fetchTicket("42")).rejects.toThrow(
+        "GitHub API error: 500 Internal Server Error"
+      );
+    });
+
+    test("strips # prefix from ticket ID", async () => {
+      mockFetch((...args: unknown[]) => {
+        expect(String(args[0])).toContain("/issues/42");
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              number: 42,
+              title: "Issue",
+              html_url: "https://github.com/org/repo/issues/42",
+            }),
+            { status: 200 }
+          )
+        );
+      });
+
+      const client = createGithubIssuesClient("org", "repo", "ghp_xxx");
+      await client.fetchTicket("#42");
+    });
+  });
+});

--- a/.github/actions/release-action/src/tickets/githubIssuesClient.ts
+++ b/.github/actions/release-action/src/tickets/githubIssuesClient.ts
@@ -1,0 +1,137 @@
+/**
+ * GitHub Issues client for fetching issue details
+ *
+ * Uses GitHub REST API to fetch issue information.
+ * GitHub Issues use #123 format instead of PREFIX-123.
+ *
+ * @example
+ * ```typescript
+ * import { createGithubIssuesClient } from "./githubIssuesClient.ts";
+ *
+ * const client = createGithubIssuesClient("owner", "repo", "ghp_xxx");
+ * const ticket = await client.fetchTicket("123");
+ * ```
+ */
+
+import type { TicketClient, TicketInfo } from "./tickets.types.ts";
+
+/** GitHub API base URL */
+const githubApiUrl = "https://api.github.com";
+
+/** GitHub issue response type (includes pull_request field when item is a PR) */
+interface GithubIssueResponse {
+  number: number;
+  title: string;
+  html_url: string;
+  /** Present when the item is a pull request, not a true issue */
+  pull_request?: {
+    url: string;
+    html_url: string;
+  };
+}
+
+/**
+ * Create a GitHub Issues client
+ *
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @param token - GitHub token for authentication
+ * @returns TicketClient for fetching GitHub issues
+ *
+ * @example
+ * ```typescript
+ * const client = createGithubIssuesClient("owner", "repo", process.env.GITHUB_TOKEN);
+ * const ticket = await client.fetchTicket("123");
+ * ```
+ */
+export function createGithubIssuesClient(owner: string, repo: string, token: string): TicketClient {
+  return {
+    systemType: "github",
+
+    async fetchTicket(ticketId: string): Promise<TicketInfo | null> {
+      // Remove # prefix if present
+      const issueNumber = ticketId.replace(/^#/, "");
+      const url = `${githubApiUrl}/repos/${owner}/${repo}/issues/${issueNumber}`;
+
+      const response = await fetch(url, {
+        headers: {
+          Accept: "application/vnd.github.v3+json",
+          Authorization: `Bearer ${token}`,
+          "User-Agent": "code-assistants-release-action",
+        },
+      });
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          return null;
+        }
+        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+      }
+
+      const issue = (await response.json()) as GithubIssueResponse;
+
+      // GitHub Issues API returns PRs too — filter them out
+      if (issue.pull_request) {
+        return null;
+      }
+
+      return {
+        id: `#${issue.number}`,
+        title: issue.title,
+        url: issue.html_url,
+        system: "github",
+      };
+    },
+
+    buildUrl(ticketId: string): string {
+      const issueNumber = ticketId.replace(/^#/, "");
+      return `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
+    },
+  };
+}
+
+/**
+ * Pattern to extract GitHub issue references (#123)
+ *
+ * Note: This differs from PR extraction pattern which requires (#123) at end of line.
+ * This pattern matches #123 anywhere in text (except in URLs or #comments).
+ */
+export const githubIssuePattern = /(?<![/\w])#(\d+)\b/g;
+
+/**
+ * Extract GitHub issue numbers from text
+ *
+ * @param text - Text to search for issue references
+ * @param excludePrNumbers - Optional set of known PR numbers to exclude from results
+ * @returns Array of issue numbers (without # prefix)
+ *
+ * @example
+ * ```typescript
+ * extractGithubIssueNumbers("Fixes #123 and relates to #456");
+ * // → ["123", "456"]
+ *
+ * // Exclude known PR numbers to avoid misclassification
+ * extractGithubIssueNumbers("Refs #273 and fixes #42", new Set([273]));
+ * // → ["42"]
+ * ```
+ */
+export function extractGithubIssueNumbers(text: string, excludePrNumbers?: Set<number>): string[] {
+  const matches: string[] = [];
+  let match;
+
+  // Reset regex state
+  githubIssuePattern.lastIndex = 0;
+
+  while ((match = githubIssuePattern.exec(text)) !== null) {
+    const [, issueNumber] = match;
+    if (issueNumber) {
+      matches.push(issueNumber);
+    }
+  }
+
+  const unique = [...new Set(matches)];
+  if (!excludePrNumbers || excludePrNumbers.size === 0) {
+    return unique;
+  }
+  return unique.filter((num) => !excludePrNumbers.has(Number(num)));
+}

--- a/.github/actions/release-action/src/tickets/jiraClient.ts
+++ b/.github/actions/release-action/src/tickets/jiraClient.ts
@@ -1,0 +1,128 @@
+/**
+ * Jira API client for fetching issue details
+ *
+ * Uses Jira REST API v3 to fetch issue information.
+ *
+ * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/
+ *
+ * @example
+ * ```typescript
+ * import { createJiraClient } from "./jiraClient.ts";
+ *
+ * const client = createJiraClient(
+ *   "https://company.atlassian.net",
+ *   "user@company.com",
+ *   "api_token"
+ * );
+ * const ticket = await client.fetchTicket("PROJ-123");
+ * ```
+ */
+
+import type { TicketClient, TicketInfo } from "./tickets.types.ts";
+
+/** ADF content node (simplified) */
+interface AdfNode {
+  type: string;
+  text?: string;
+  content?: AdfNode[];
+}
+
+/** Jira issue response type */
+interface JiraIssueResponse {
+  key: string;
+  fields: {
+    summary: string;
+    description?: {
+      type: string;
+      content?: AdfNode[];
+    } | null;
+  };
+}
+
+/**
+ * Extract plain text from Jira ADF (Atlassian Document Format)
+ *
+ * @param adf - ADF document object
+ * @returns Plain text content
+ */
+function extractTextFromAdf(adf: { content?: AdfNode[] } | null | undefined): string {
+  if (!adf?.content) {
+    return "";
+  }
+
+  const texts: string[] = [];
+
+  function traverse(nodes: AdfNode[]): void {
+    for (const node of nodes) {
+      if (node.text) {
+        texts.push(node.text);
+      }
+      if (node.content) {
+        traverse(node.content);
+      }
+    }
+  }
+
+  traverse(adf.content);
+  return texts.join(" ").trim();
+}
+
+/**
+ * Create a Jira API client
+ *
+ * @param baseUrl - Jira instance URL (e.g., https://company.atlassian.net)
+ * @param email - User email for authentication
+ * @param apiToken - Jira API token
+ * @returns TicketClient for fetching Jira issues
+ *
+ * @example
+ * ```typescript
+ * const client = createJiraClient(
+ *   process.env.JIRA_BASE_URL,
+ *   process.env.JIRA_EMAIL,
+ *   process.env.JIRA_API_TOKEN
+ * );
+ * ```
+ */
+export function createJiraClient(baseUrl: string, email: string, apiToken: string): TicketClient {
+  // Remove trailing slash from base URL
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, "");
+  const authHeader = `Basic ${btoa(`${email}:${apiToken}`)}`;
+
+  return {
+    systemType: "jira",
+
+    async fetchTicket(ticketId: string): Promise<TicketInfo | null> {
+      const url = `${normalizedBaseUrl}/rest/api/3/issue/${ticketId}?fields=summary,description`;
+
+      const response = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+          Authorization: authHeader,
+        },
+      });
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          return null;
+        }
+        throw new Error(`Jira API error: ${response.status} ${response.statusText}`);
+      }
+
+      const issue = (await response.json()) as JiraIssueResponse;
+      const description = extractTextFromAdf(issue.fields.description);
+
+      return {
+        id: issue.key,
+        title: issue.fields.summary,
+        description: description || undefined,
+        url: `${normalizedBaseUrl}/browse/${issue.key}`,
+        system: "jira",
+      };
+    },
+
+    buildUrl(ticketId: string): string {
+      return `${normalizedBaseUrl}/browse/${ticketId}`;
+    },
+  };
+}

--- a/.github/actions/release-action/src/tickets/linearClient.ts
+++ b/.github/actions/release-action/src/tickets/linearClient.ts
@@ -1,0 +1,113 @@
+/**
+ * Linear API client for fetching issue details
+ *
+ * Uses Linear GraphQL API to fetch issue information by identifier.
+ *
+ * @see https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+ *
+ * @example
+ * ```typescript
+ * import { createLinearClient } from "./linearClient.ts";
+ *
+ * const client = createLinearClient("lin_api_xxx");
+ * const ticket = await client.fetchTicket("TEAM-123");
+ * // → { id: "TEAM-123", title: "Add auth", url: "https://linear.app/...", system: "linear" }
+ * ```
+ */
+
+import type { TicketClient, TicketInfo } from "./tickets.types.ts";
+
+/** Linear GraphQL API endpoint */
+const linearApiUrl = "https://api.linear.app/graphql";
+
+/** GraphQL query to fetch issue by identifier */
+const issueQuery = `
+  query IssueByIdentifier($id: String!) {
+    issue(id: $id) {
+      identifier
+      title
+      description
+      url
+    }
+  }
+`;
+
+/** Linear GraphQL response type */
+interface LinearIssueResponse {
+  data?: {
+    issue?: {
+      identifier: string;
+      title: string;
+      description: string | null;
+      url: string;
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+/**
+ * Create a Linear API client
+ *
+ * @param apiKey - Linear API key (starts with lin_api_)
+ * @returns TicketClient for fetching Linear issues
+ *
+ * @example
+ * ```typescript
+ * const client = createLinearClient(process.env.LINEAR_API_KEY);
+ * const ticket = await client.fetchTicket("TEAM-123");
+ * ```
+ */
+export function createLinearClient(apiKey: string): TicketClient {
+  return {
+    systemType: "linear",
+
+    async fetchTicket(ticketId: string): Promise<TicketInfo | null> {
+      const response = await fetch(linearApiUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: apiKey,
+        },
+        body: JSON.stringify({
+          query: issueQuery,
+          variables: { id: ticketId },
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Linear API error: ${response.status} ${response.statusText}`);
+      }
+
+      const result = (await response.json()) as LinearIssueResponse;
+
+      const firstError = result.errors?.[0];
+      if (firstError) {
+        const errorMessage = firstError.message;
+        // Not found errors are expected for invalid ticket IDs
+        if (errorMessage.includes("not found") || errorMessage.includes("Entity not found")) {
+          return null;
+        }
+        throw new Error(`Linear API error: ${errorMessage}`);
+      }
+
+      const issue = result.data?.issue;
+      if (!issue) {
+        return null;
+      }
+
+      return {
+        id: issue.identifier,
+        title: issue.title,
+        description: issue.description ?? undefined,
+        url: issue.url,
+        system: "linear",
+      };
+    },
+
+    buildUrl(ticketId: string): string {
+      // Linear URLs follow pattern: https://linear.app/team/issue/TEAM-123
+      // We can't construct this without knowing the team slug, so return a search URL
+      return `https://linear.app/issue/${ticketId}`;
+    },
+  };
+}

--- a/.github/actions/release-action/src/tickets/ticketExtractor.test.ts
+++ b/.github/actions/release-action/src/tickets/ticketExtractor.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for ticket ID extraction utilities
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildTicketPattern,
+  extractPrNumber,
+  extractTicketIds,
+  getAllKeys,
+  genericTicketPattern,
+  mapTicketToSystem,
+} from "./ticketExtractor.ts";
+
+describe("ticketExtractor", () => {
+  describe("genericTicketPattern", () => {
+    test("matches UPPERCASE-number format", () => {
+      expect("TEAM-123".match(genericTicketPattern)).toEqual(["TEAM-123"]);
+    });
+
+    test("matches multiple tickets in text", () => {
+      const text = "feat: TEAM-1 and PROJ-456 done";
+      expect(text.match(genericTicketPattern)).toEqual(["TEAM-1", "PROJ-456"]);
+    });
+
+    test("matches alphanumeric prefixes", () => {
+      expect("ABC123-456".match(genericTicketPattern)).toEqual(["ABC123-456"]);
+    });
+
+    test("does not match lowercase", () => {
+      expect("team-123".match(genericTicketPattern)).toBeNull();
+    });
+
+    test("does not match without number", () => {
+      expect("TEAM-".match(genericTicketPattern)).toBeNull();
+    });
+
+    test("does not match without hyphen", () => {
+      expect("TEAM123".match(genericTicketPattern)).toBeNull();
+    });
+  });
+
+  describe("buildTicketPattern()", () => {
+    test("returns generic pattern for empty keys", () => {
+      const pattern = buildTicketPattern([]);
+      expect("TEAM-123".match(pattern)).toEqual(["TEAM-123"]);
+    });
+
+    test("matches only specified keys", () => {
+      const pattern = buildTicketPattern(["TEAM", "PROJ"]);
+      expect("TEAM-1 PROJ-2 OTHER-3".match(pattern)).toEqual(["TEAM-1", "PROJ-2"]);
+    });
+
+    test("handles single key", () => {
+      const pattern = buildTicketPattern(["TEAM"]);
+      expect("TEAM-123".match(pattern)).toEqual(["TEAM-123"]);
+      expect("PROJ-456".match(pattern)).toBeNull();
+    });
+
+    test("escapes regex special characters in keys", () => {
+      const pattern = buildTicketPattern(["TE.AM"]);
+      expect("TE.AM-123".match(pattern)).toEqual(["TE.AM-123"]);
+      expect("TEXAM-123".match(pattern)).toBeNull();
+    });
+  });
+
+  describe("extractTicketIds()", () => {
+    test("extracts all tickets without keys filter", () => {
+      const result = extractTicketIds("feat: TEAM-123 PROJ-456 fix");
+      expect(result).toEqual(["TEAM-123", "PROJ-456"]);
+    });
+
+    test("filters by specified keys", () => {
+      const result = extractTicketIds("TEAM-1 PROJ-2 OTHER-3", ["TEAM"]);
+      expect(result).toEqual(["TEAM-1"]);
+    });
+
+    test("returns unique tickets only", () => {
+      const result = extractTicketIds("TEAM-123 fixed TEAM-123 again");
+      expect(result).toEqual(["TEAM-123"]);
+    });
+
+    test("returns empty array when no matches", () => {
+      const result = extractTicketIds("no tickets here");
+      expect(result).toEqual([]);
+    });
+
+    test("handles empty text", () => {
+      expect(extractTicketIds("")).toEqual([]);
+    });
+
+    test("handles multiple keys", () => {
+      const result = extractTicketIds("TEAM-1 PROJ-2 CORE-3 OTHER-4", ["TEAM", "PROJ", "CORE"]);
+      expect(result).toEqual(["TEAM-1", "PROJ-2", "CORE-3"]);
+    });
+
+    test("is case sensitive for prefixes", () => {
+      const result = extractTicketIds("TEAM-123 team-456 Team-789");
+      expect(result).toEqual(["TEAM-123"]);
+    });
+  });
+
+  describe("extractPrNumber()", () => {
+    test("extracts PR number from squash merge format", () => {
+      expect(extractPrNumber("feat: add auth (#45)")).toBe(45);
+    });
+
+    test("extracts from end of message only", () => {
+      expect(extractPrNumber("fix (#123) issue (#456)")).toBe(456);
+    });
+
+    test("handles large PR numbers", () => {
+      expect(extractPrNumber("chore: update (#12345)")).toBe(12345);
+    });
+
+    test("returns undefined when no PR number", () => {
+      expect(extractPrNumber("chore: update deps")).toBeUndefined();
+    });
+
+    test("returns undefined for non-parenthesized number", () => {
+      expect(extractPrNumber("fix #123")).toBeUndefined();
+    });
+
+    test("handles trailing whitespace", () => {
+      expect(extractPrNumber("feat: add feature (#99)  ")).toBe(99);
+    });
+  });
+
+  describe("mapTicketToSystem()", () => {
+    test("maps ticket to system with matching key", () => {
+      const systems = [
+        { type: "linear" as const, keys: ["TEAM"] },
+        { type: "jira" as const, keys: ["CORE"] },
+      ];
+      expect(mapTicketToSystem("TEAM-123", systems)).toBe("linear");
+      expect(mapTicketToSystem("CORE-456", systems)).toBe("jira");
+    });
+
+    test("returns undefined when no key matches", () => {
+      const systems = [{ type: "linear" as const, keys: ["TEAM"] }];
+      expect(mapTicketToSystem("OTHER-123", systems)).toBeUndefined();
+    });
+
+    test("returns single generic system for any ticket", () => {
+      const systems = [{ type: "linear" as const }];
+      expect(mapTicketToSystem("ANY-123", systems)).toBe("linear");
+    });
+
+    test("returns first non-github system when multiple generic systems", () => {
+      const systems = [{ type: "linear" as const }, { type: "github" as const }];
+      expect(mapTicketToSystem("TEAM-123", systems)).toBe("linear");
+    });
+
+    test("returns first system when multiple non-github generic systems", () => {
+      const systems = [{ type: "linear" as const }, { type: "jira" as const }];
+      expect(mapTicketToSystem("ANY-123", systems)).toBe("linear");
+    });
+
+    test("prefers specific key match over generic", () => {
+      const systems = [{ type: "linear" as const, keys: ["TEAM"] }, { type: "jira" as const }];
+      expect(mapTicketToSystem("TEAM-123", systems)).toBe("linear");
+    });
+
+    test("handles multiple keys per system", () => {
+      const systems = [{ type: "linear" as const, keys: ["TEAM", "PROJ", "DEV"] }];
+      expect(mapTicketToSystem("TEAM-1", systems)).toBe("linear");
+      expect(mapTicketToSystem("PROJ-2", systems)).toBe("linear");
+      expect(mapTicketToSystem("DEV-3", systems)).toBe("linear");
+    });
+  });
+
+  describe("getAllKeys()", () => {
+    test("collects all keys from systems", () => {
+      const systems = [
+        { type: "linear" as const, keys: ["TEAM", "PROJ"] },
+        { type: "jira" as const, keys: ["CORE"] },
+      ];
+      expect(getAllKeys(systems)).toEqual(["TEAM", "PROJ", "CORE"]);
+    });
+
+    test("returns empty array when any system is generic", () => {
+      const systems = [{ type: "linear" as const, keys: ["TEAM"] }, { type: "jira" as const }];
+      expect(getAllKeys(systems)).toEqual([]);
+    });
+
+    test("returns empty for empty keys array", () => {
+      const systems = [{ type: "linear" as const, keys: [] }];
+      expect(getAllKeys(systems)).toEqual([]);
+    });
+
+    test("deduplicates keys across systems", () => {
+      const systems = [
+        { type: "linear" as const, keys: ["TEAM", "SHARED"] },
+        { type: "jira" as const, keys: ["SHARED", "CORE"] },
+      ];
+      const keys = getAllKeys(systems);
+      expect(keys).toContain("TEAM");
+      expect(keys).toContain("SHARED");
+      expect(keys).toContain("CORE");
+      expect(keys.filter((k) => k === "SHARED")).toHaveLength(1);
+    });
+  });
+});

--- a/.github/actions/release-action/src/tickets/ticketExtractor.ts
+++ b/.github/actions/release-action/src/tickets/ticketExtractor.ts
@@ -1,0 +1,185 @@
+/**
+ * Ticket ID extraction utilities
+ *
+ * Extracts ticket IDs (like TEAM-123, PROJ-456) from PR titles and commit messages.
+ * Supports both generic pattern matching and specific key filtering.
+ *
+ * @example
+ * ```typescript
+ * import { extractTicketIds, extractPrNumber } from "./ticketExtractor.ts";
+ *
+ * // Extract all ticket-like patterns
+ * const tickets = extractTicketIds("feat: TEAM-123 add auth");
+ * // → ["TEAM-123"]
+ *
+ * // Extract with specific keys
+ * const filtered = extractTicketIds("TEAM-1 PROJ-2 OTHER-3", ["TEAM", "PROJ"]);
+ * // → ["TEAM-1", "PROJ-2"]
+ *
+ * // Extract PR number from squash merge
+ * const prNumber = extractPrNumber("feat: add auth (#45)");
+ * // → 45
+ * ```
+ */
+
+import type { TicketSystemEntry, TicketSystemType } from "./tickets.types.ts";
+
+/** Generic pattern matching any UPPERCASE-123 format */
+export const genericTicketPattern = /\b([A-Z][A-Z0-9]*-\d+)\b/g;
+
+/** Pattern to extract PR number from squash merge format (#123) */
+export const prNumberPattern = /\(#(\d+)\)$/;
+
+/**
+ * Build a regex pattern for specific ticket key prefixes
+ *
+ * @param keys - Array of key prefixes (e.g., ["TEAM", "PROJ"])
+ * @returns RegExp matching only those prefixes
+ *
+ * @example
+ * ```typescript
+ * const pattern = buildTicketPattern(["TEAM", "PROJ"]);
+ * "TEAM-123".match(pattern); // → ["TEAM-123"]
+ * "OTHER-456".match(pattern); // → null
+ * ```
+ */
+export function buildTicketPattern(keys: string[]): RegExp {
+  if (keys.length === 0) {
+    return genericTicketPattern;
+  }
+  const escaped = keys.map((key) => key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  return new RegExp(`\\b((?:${escaped.join("|")})-\\d+)\\b`, "g");
+}
+
+/**
+ * Extract ticket IDs from text
+ *
+ * @param text - Text to search (PR title, commit message, etc.)
+ * @param keys - Optional array of key prefixes to filter. If omitted, matches any UPPERCASE-123
+ * @returns Array of unique ticket IDs found
+ *
+ * @example
+ * ```typescript
+ * // Match any pattern
+ * extractTicketIds("feat: TEAM-123 PROJ-456 fix");
+ * // → ["TEAM-123", "PROJ-456"]
+ *
+ * // Match only specific keys
+ * extractTicketIds("TEAM-1 PROJ-2 OTHER-3", ["TEAM"]);
+ * // → ["TEAM-1"]
+ * ```
+ */
+export function extractTicketIds(text: string, keys?: string[]): string[] {
+  const pattern = keys && keys.length > 0 ? buildTicketPattern(keys) : genericTicketPattern;
+  const matches = text.match(pattern) ?? [];
+  return [...new Set(matches)];
+}
+
+/**
+ * Extract PR number from commit message (squash merge format)
+ *
+ * GitHub squash merges append (#123) to commit messages.
+ *
+ * @param commitMessage - Commit message text
+ * @returns PR number or undefined if not found
+ *
+ * @example
+ * ```typescript
+ * extractPrNumber("feat: add auth (#45)"); // → 45
+ * extractPrNumber("chore: update deps"); // → undefined
+ * ```
+ */
+export function extractPrNumber(commitMessage: string): number | undefined {
+  const match = commitMessage.trim().match(prNumberPattern);
+  const prNumber = match?.[1];
+  if (!prNumber) {
+    return undefined;
+  }
+  return Number.parseInt(prNumber, 10);
+}
+
+/**
+ * Map a ticket ID to its system based on configuration
+ *
+ * @param ticketId - Ticket ID (e.g., TEAM-123)
+ * @param systems - Array of system configurations
+ * @returns The system type that owns this ticket, or undefined if no match
+ *
+ * @example
+ * ```typescript
+ * const systems = [
+ *   { type: "linear", keys: ["TEAM"] },
+ *   { type: "jira", keys: ["JIRA", "CORE"] },
+ * ];
+ *
+ * mapTicketToSystem("TEAM-123", systems); // → "linear"
+ * mapTicketToSystem("CORE-456", systems); // → "jira"
+ * mapTicketToSystem("OTHER-789", systems); // → undefined
+ * ```
+ */
+export function mapTicketToSystem(
+  ticketId: string,
+  systems: TicketSystemEntry[]
+): TicketSystemType | undefined {
+  const [prefix] = ticketId.split("-");
+  if (!prefix) {
+    return undefined;
+  }
+
+  // Check systems with specific keys first
+  const matchingSystem = systems.find(
+    (system) => system.keys && system.keys.length > 0 && system.keys.includes(prefix)
+  );
+
+  if (matchingSystem) {
+    return matchingSystem.type;
+  }
+
+  // If only one system has no keys (generic matching), return it
+  const genericSystems = systems.filter((s) => !s.keys || s.keys.length === 0);
+  const [singleGeneric] = genericSystems;
+  if (genericSystems.length === 1 && singleGeneric) {
+    return singleGeneric.type;
+  }
+
+  // When multiple generic systems exist, prefer non-GitHub systems
+  // PREFIX-123 patterns are Linear/Jira style, not GitHub (#123)
+  if (genericSystems.length > 1) {
+    const nonGithubGeneric = genericSystems.find((s) => s.type !== "github");
+    return nonGithubGeneric?.type ?? genericSystems[0]?.type;
+  }
+
+  return undefined;
+}
+
+/**
+ * Get all unique key prefixes from system configurations
+ *
+ * @param systems - Array of system configurations
+ * @returns Array of all key prefixes, or empty if any system uses generic matching
+ *
+ * @example
+ * ```typescript
+ * getAllKeys([
+ *   { type: "linear", keys: ["TEAM", "PROJ"] },
+ *   { type: "jira", keys: ["CORE"] },
+ * ]);
+ * // → ["TEAM", "PROJ", "CORE"]
+ *
+ * getAllKeys([{ type: "linear" }]); // → [] (generic matching)
+ * ```
+ */
+export function getAllKeys(systems: TicketSystemEntry[]): string[] {
+  const hasGenericSystem = systems.some((s) => !s.keys || s.keys.length === 0);
+  if (hasGenericSystem) {
+    return [];
+  }
+
+  const keys: string[] = [];
+  for (const system of systems) {
+    if (system.keys) {
+      keys.push(...system.keys);
+    }
+  }
+  return [...new Set(keys)];
+}

--- a/.github/actions/release-action/src/tickets/tickets.test.ts
+++ b/.github/actions/release-action/src/tickets/tickets.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Tests for ticket system integration orchestrator
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  autoDetectTicketSystems,
+  extractPrDescriptions,
+  formatTicketsMarkdown,
+  parseTicketArgs,
+  releasePrTitlePattern,
+  serializePrDescriptionsToYaml,
+} from "./tickets.ts";
+import type { PullRequestInfo, TicketInfo } from "./tickets.types.ts";
+
+describe("tickets", () => {
+  describe("parseTicketArgs()", () => {
+    test("parses single system without keys", () => {
+      const result = parseTicketArgs(["--tickets=linear"]);
+
+      expect(result).toEqual([{ type: "linear" }]);
+    });
+
+    test("parses single system with keys", () => {
+      const result = parseTicketArgs(["--tickets=linear:TEAM,PROJ"]);
+
+      expect(result).toEqual([{ type: "linear", keys: ["TEAM", "PROJ"] }]);
+    });
+
+    test("parses multiple systems", () => {
+      const result = parseTicketArgs(["--tickets=linear:TEAM", "--tickets=jira:CORE,INFRA"]);
+
+      expect(result).toEqual([
+        { type: "linear", keys: ["TEAM"] },
+        { type: "jira", keys: ["CORE", "INFRA"] },
+      ]);
+    });
+
+    test("returns null when no --tickets args", () => {
+      const result = parseTicketArgs(["--other=value"]);
+
+      expect(result).toBeNull();
+    });
+
+    test("ignores non-tickets args", () => {
+      const result = parseTicketArgs(["--other=value", "--tickets=linear", "--foo"]);
+
+      expect(result).toEqual([{ type: "linear" }]);
+    });
+
+    test("handles github system", () => {
+      const result = parseTicketArgs(["--tickets=github"]);
+
+      expect(result).toEqual([{ type: "github" }]);
+    });
+
+    test("handles single key", () => {
+      const result = parseTicketArgs(["--tickets=jira:PROJ"]);
+
+      expect(result).toEqual([{ type: "jira", keys: ["PROJ"] }]);
+    });
+  });
+
+  describe("formatTicketsMarkdown()", () => {
+    test("formats Linear tickets as table with markdown links", () => {
+      const tickets: TicketInfo[] = [
+        {
+          id: "TEAM-123",
+          title: "Add authentication",
+          url: "https://linear.app/issue/TEAM-123",
+          system: "linear",
+          prNumber: 45,
+          prAuthor: "developer",
+          prUrl: "https://github.com/org/repo/pull/45",
+        },
+      ];
+
+      const result = formatTicketsMarkdown(tickets, "Linear", "org", "repo");
+
+      expect(result).toContain("## Linear");
+      expect(result).toContain("| Issue | PR | Author |");
+      expect(result).toContain("| --- | --- | --- |");
+      expect(result).toContain(
+        "| [TEAM-123: Add authentication](https://linear.app/issue/TEAM-123) | [#45](https://github.com/org/repo/pull/45) | @developer |"
+      );
+    });
+
+    test("formats GitHub Issues as table with bare refs (no title)", () => {
+      const tickets: TicketInfo[] = [
+        {
+          id: "40",
+          title: "Robust review",
+          url: "https://github.com/org/repo/issues/40",
+          system: "github",
+          prNumber: 42,
+          prAuthor: "developer",
+          prUrl: "https://github.com/org/repo/pull/42",
+        },
+      ];
+
+      const result = formatTicketsMarkdown(tickets, "GitHub Issues", "org", "repo");
+
+      expect(result).toContain("## GitHub Issues");
+      expect(result).toContain("| #40 | [#42](https://github.com/org/repo/pull/42) | @developer |");
+      // Should NOT include title (GitHub preview shows it)
+      expect(result).not.toContain("Robust review");
+    });
+
+    test("formats Linear tickets without PR info using dash cells", () => {
+      const tickets: TicketInfo[] = [
+        {
+          id: "TEAM-123",
+          title: "Add feature",
+          url: "https://linear.app/issue/TEAM-123",
+          system: "linear",
+        },
+      ];
+
+      const result = formatTicketsMarkdown(tickets, "Linear", "org", "repo");
+
+      expect(result).toContain("## Linear");
+      expect(result).toContain(
+        "| [TEAM-123: Add feature](https://linear.app/issue/TEAM-123) | — | — |"
+      );
+    });
+
+    test("formats PR as bare number when prUrl is missing", () => {
+      const tickets: TicketInfo[] = [
+        {
+          id: "TEAM-123",
+          title: "Add feature",
+          url: "https://linear.app/issue/TEAM-123",
+          system: "linear",
+          prNumber: 45,
+        },
+      ];
+
+      const result = formatTicketsMarkdown(tickets, "Linear", "org", "repo");
+
+      expect(result).toContain("| #45 |");
+      expect(result).not.toContain("[#45]");
+    });
+
+    test("returns empty string for empty tickets", () => {
+      const result = formatTicketsMarkdown([], "Linear", "org", "repo");
+
+      expect(result).toBe("");
+    });
+
+    test("formats multiple Linear tickets as table rows", () => {
+      const tickets: TicketInfo[] = [
+        {
+          id: "TEAM-1",
+          title: "First",
+          url: "url1",
+          system: "linear",
+          prNumber: 10,
+          prUrl: "pr1",
+        },
+        {
+          id: "TEAM-2",
+          title: "Second",
+          url: "url2",
+          system: "linear",
+          prNumber: 11,
+          prUrl: "pr2",
+          prAuthor: "dev",
+        },
+      ];
+
+      const result = formatTicketsMarkdown(tickets, "Linear", "org", "repo");
+      const lines = result.split("\n");
+
+      expect(lines[0]).toBe("## Linear");
+      expect(lines[2]).toBe("| Issue | PR | Author |");
+      expect(lines[3]).toBe("| --- | --- | --- |");
+      expect(lines[4]).toContain("[TEAM-1: First](url1)");
+      expect(lines[5]).toContain("[TEAM-2: Second](url2)");
+      expect(lines[5]).toContain("@dev");
+    });
+
+    test("uses correct system name", () => {
+      const tickets: TicketInfo[] = [{ id: "CORE-1", title: "Fix", url: "url", system: "jira" }];
+
+      expect(formatTicketsMarkdown(tickets, "Jira", "org", "repo")).toContain("## Jira");
+      expect(formatTicketsMarkdown(tickets, "GitHub Issues", "org", "repo")).toContain(
+        "## GitHub Issues"
+      );
+    });
+
+    test("ignores commits in table output", () => {
+      const tickets: TicketInfo[] = [
+        {
+          id: "ARCH-90",
+          title: "Release action for History service",
+          url: "https://linear.app/issue/ARCH-90",
+          system: "linear",
+          prNumber: 44,
+          prAuthor: "arturovt",
+          prUrl: "https://github.com/org/repo/pull/44",
+          commits: [
+            {
+              message: "feat(ci): add manual release workflow for history service",
+              sha: "52ff2cd",
+            },
+            { message: "fix(ci): correct workflow trigger", sha: "a1b2c3d" },
+          ],
+        },
+      ];
+
+      const result = formatTicketsMarkdown(tickets, "Linear", "org", "repo");
+
+      expect(result).toContain("## Linear");
+      expect(result).toContain(
+        "| [ARCH-90: Release action for History service](https://linear.app/issue/ARCH-90) | [#44](https://github.com/org/repo/pull/44) | @arturovt |"
+      );
+      // Commits should NOT appear in the table format
+      expect(result).not.toContain("commits");
+      expect(result).not.toContain("<details>");
+      expect(result).not.toContain("52ff2cd");
+    });
+  });
+
+  describe("autoDetectTicketSystems()", () => {
+    const originalEnv = { ...process.env };
+
+    beforeEach(() => {
+      delete process.env.LINEAR_KEYS;
+      delete process.env.JIRA_KEYS;
+    });
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    test("detects Linear when linearApiKey is set", () => {
+      const result = autoDetectTicketSystems({ linearApiKey: "lin_xxx" });
+
+      expect(result).toEqual([{ type: "linear", keys: undefined }]);
+    });
+
+    test("detects Jira when all credentials are set", () => {
+      const result = autoDetectTicketSystems({
+        jiraBaseUrl: "https://company.atlassian.net",
+        jiraEmail: "user@company.com",
+        jiraApiToken: "token",
+      });
+
+      expect(result).toEqual([{ type: "jira", keys: undefined }]);
+    });
+
+    test("does not detect Jira with partial credentials", () => {
+      const result = autoDetectTicketSystems({
+        jiraBaseUrl: "https://company.atlassian.net",
+        jiraEmail: "user@company.com",
+        // missing jiraApiToken
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    test("detects both systems when all credentials are set", () => {
+      const result = autoDetectTicketSystems({
+        linearApiKey: "lin_xxx",
+        jiraBaseUrl: "https://company.atlassian.net",
+        jiraEmail: "user@company.com",
+        jiraApiToken: "token",
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ type: "linear", keys: undefined });
+      expect(result[1]).toEqual({ type: "jira", keys: undefined });
+    });
+
+    test("returns empty array when no credentials", () => {
+      const result = autoDetectTicketSystems({});
+
+      expect(result).toEqual([]);
+    });
+
+    test("reads LINEAR_KEYS from environment", () => {
+      process.env.LINEAR_KEYS = "TEAM,PROJ";
+
+      const result = autoDetectTicketSystems({ linearApiKey: "lin_xxx" });
+
+      expect(result).toEqual([{ type: "linear", keys: ["TEAM", "PROJ"] }]);
+    });
+
+    test("reads JIRA_KEYS from environment", () => {
+      process.env.JIRA_KEYS = "CORE,INFRA";
+
+      const result = autoDetectTicketSystems({
+        jiraBaseUrl: "https://company.atlassian.net",
+        jiraEmail: "user@company.com",
+        jiraApiToken: "token",
+      });
+
+      expect(result).toEqual([{ type: "jira", keys: ["CORE", "INFRA"] }]);
+    });
+
+    test("handles empty keys string", () => {
+      process.env.LINEAR_KEYS = "";
+
+      const result = autoDetectTicketSystems({ linearApiKey: "lin_xxx" });
+
+      expect(result).toEqual([{ type: "linear", keys: undefined }]);
+    });
+
+    test("handles single key", () => {
+      process.env.LINEAR_KEYS = "TEAM";
+
+      const result = autoDetectTicketSystems({ linearApiKey: "lin_xxx" });
+
+      expect(result).toEqual([{ type: "linear", keys: ["TEAM"] }]);
+    });
+
+    test("detects GitHub when githubToken is set", () => {
+      const result = autoDetectTicketSystems({ githubToken: "ghp_xxx" });
+
+      expect(result).toEqual([{ type: "github" }]);
+    });
+
+    test("detects all systems when all credentials are set", () => {
+      const result = autoDetectTicketSystems({
+        linearApiKey: "lin_xxx",
+        jiraBaseUrl: "https://company.atlassian.net",
+        jiraEmail: "user@company.com",
+        jiraApiToken: "token",
+        githubToken: "ghp_xxx",
+      });
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({ type: "linear", keys: undefined });
+      expect(result[1]).toEqual({ type: "jira", keys: undefined });
+      expect(result[2]).toEqual({ type: "github" });
+    });
+  });
+
+  describe("release PR filtering", () => {
+    test("release PR titles are excluded from PR details map", () => {
+      expect(releasePrTitlePattern.test("Release 1.2.0")).toBe(true);
+      expect(releasePrTitlePattern.test("Release Dialog Manager 1.2.0")).toBe(true);
+      expect(releasePrTitlePattern.test("TOOLS-323: Fix ticket extraction")).toBe(false);
+      expect(releasePrTitlePattern.test("feat: add release notes")).toBe(false);
+      expect(releasePrTitlePattern.test("release 1.0.0")).toBe(false);
+    });
+
+    test("filtering removes release PRs from descriptions", () => {
+      const map = new Map<string, PullRequestInfo>();
+      map.set("sha-feature", {
+        number: 100,
+        title: "TOOLS-50: Add feature",
+        body: "Feature description",
+        url: "https://github.com/org/repo/pull/100",
+        author: "developer",
+      });
+      map.set("sha-release", {
+        number: 101,
+        title: "Release 1.2.0",
+        body: "## [1.2.0]\n\n### Features\n\n* TOOLS-50: add feature",
+        url: "https://github.com/org/repo/pull/101",
+        author: "release-bot",
+      });
+
+      const filtered = new Map([...map].filter(([, pr]) => !releasePrTitlePattern.test(pr.title)));
+
+      const descriptions = extractPrDescriptions(filtered);
+
+      expect(descriptions).toHaveLength(1);
+      expect(descriptions[0]?.prNumber).toBe(100);
+      expect(descriptions[0]?.title).toBe("TOOLS-50: Add feature");
+    });
+  });
+
+  describe("extractPrDescriptions()", () => {
+    function makePrMap(
+      ...prs: Array<Partial<PullRequestInfo> & { sha?: string }>
+    ): Map<string, PullRequestInfo> {
+      const map = new Map<string, PullRequestInfo>();
+      for (const { sha, ...pr } of prs) {
+        const full: PullRequestInfo = {
+          number: pr.number ?? 1,
+          title: pr.title ?? "PR title",
+          body: pr.body,
+          url: pr.url ?? "https://github.com/org/repo/pull/1",
+          author: pr.author ?? "dev",
+        };
+        map.set(sha ?? `sha-${full.number}`, full);
+      }
+      return map;
+    }
+
+    test("returns empty array when no PRs have bodies", () => {
+      const map = makePrMap(
+        { number: 1, body: undefined },
+        { number: 2, body: "" },
+        { number: 3, body: "   " }
+      );
+
+      expect(extractPrDescriptions(map)).toEqual([]);
+    });
+
+    test("extracts release notes section when present", () => {
+      const body = `Some description\n\n**Release notes:**\n\n- Feature A added\n- Feature B improved\n\n---\n\n**Issues:**\nCloses TOOLS-100`;
+      const map = makePrMap({ number: 54, body, title: "TOOLS-100: Add feature", author: "dev" });
+
+      const result = extractPrDescriptions(map);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.content).toBe("- Feature A added\n- Feature B improved");
+      expect(result[0]?.prNumber).toBe(54);
+    });
+
+    test("falls back to full body when no release notes section", () => {
+      const body = "This PR adds a new endpoint for auth.";
+      const map = makePrMap({ number: 10, body });
+
+      const result = extractPrDescriptions(map);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.content).toBe("This PR adds a new endpoint for auth.");
+    });
+
+    test("truncates content exceeding max length", () => {
+      const body = "x".repeat(3000);
+      const map = makePrMap({ number: 1, body });
+
+      const result = extractPrDescriptions(map);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.content).toHaveLength(2003); // 2000 + "..."
+      expect(result[0]?.content).toEndWith("...");
+    });
+
+    test("deduplicates by PR number", () => {
+      const map = new Map<string, PullRequestInfo>();
+      const pr: PullRequestInfo = {
+        number: 42,
+        title: "Feature",
+        body: "description",
+        url: "url",
+        author: "dev",
+      };
+      map.set("sha-1", pr);
+      map.set("sha-2", pr);
+
+      const result = extractPrDescriptions(map);
+
+      expect(result).toHaveLength(1);
+    });
+
+    test("handles release note singular form", () => {
+      const body = `**Release note:**\n\nSingle important change\n\n---`;
+      const map = makePrMap({ number: 1, body });
+
+      const result = extractPrDescriptions(map);
+
+      expect(result[0]?.content).toBe("Single important change");
+    });
+  });
+
+  describe("serializePrDescriptionsToYaml()", () => {
+    test("produces valid YAML with block scalars", () => {
+      const result = serializePrDescriptionsToYaml([
+        { prNumber: 54, title: "Add feature", content: "Line 1\nLine 2", author: "dev" },
+      ]);
+
+      expect(result).toContain("- prNumber: 54");
+      expect(result).toContain('  title: "Add feature"');
+      expect(result).toContain("  author: dev");
+      expect(result).toContain("  content: |");
+      expect(result).toContain("    Line 1");
+      expect(result).toContain("    Line 2");
+    });
+
+    test("escapes quotes in titles", () => {
+      const result = serializePrDescriptionsToYaml([
+        { prNumber: 1, title: 'Fix "broken" thing', content: "Fixed it", author: "dev" },
+      ]);
+
+      expect(result).toContain('  title: "Fix \\"broken\\" thing"');
+    });
+
+    test("serializes multiple descriptions", () => {
+      const result = serializePrDescriptionsToYaml([
+        { prNumber: 1, title: "First", content: "Content 1", author: "dev1" },
+        { prNumber: 2, title: "Second", content: "Content 2", author: "dev2" },
+      ]);
+
+      const entries = result.split("- prNumber:");
+      expect(entries).toHaveLength(3); // first element is empty string before first match
+    });
+  });
+});

--- a/.github/actions/release-action/src/tickets/tickets.ts
+++ b/.github/actions/release-action/src/tickets/tickets.ts
@@ -436,6 +436,20 @@ export async function generateTicketsSection(
   const warnings: string[] = [];
   const ticketsBySystem = new Map<TicketSystemType, TicketInfo[]>();
 
+  // When multiple key-pattern systems (Linear, Jira) are configured, keys are
+  // required to route each ticket to the right system — without them, a `TEAM-123`
+  // could go to either. GitHub Issues uses `#N` so it never collides.
+  const keyPatternSystems = config.systems.filter((s) => s.type !== "github");
+  if (keyPatternSystems.length > 1) {
+    const missingKeys = keyPatternSystems.filter((s) => !s.keys || s.keys.length === 0);
+    if (missingKeys.length > 0) {
+      const types = missingKeys.map((s) => s.type).join(", ");
+      warnings.push(
+        `Multiple ticket systems configured but ${types} has no keys set. Tickets may be routed to the wrong system. Set ${missingKeys.map((s) => `${s.type.toUpperCase()}_KEYS`).join(" / ")} to disambiguate.`
+      );
+    }
+  }
+
   const clients = initializeClients(config, env, warnings);
   if (clients.size === 0) {
     return { markdown: "", tickets: [], prDescriptions: [], warnings };
@@ -473,8 +487,12 @@ export async function generateTicketsSection(
 
   for (const commit of commits) {
     const pr = prDetailsBySha.get(commit.sha);
-    // Search both PR title and body for ticket references (e.g., "Resolve #34" in body)
-    const textToSearch = pr ? `${pr.title} ${pr.body ?? ""}` : commit.message;
+    // Always include the commit message so ticket IDs that appear only in the
+    // commit text (not the PR title/body) still get picked up. Concatenating
+    // is safe — extractTicketIds dedupes by id+system.
+    const textToSearch = pr
+      ? `${pr.title} ${pr.body ?? ""} ${commit.message}`
+      : commit.message;
     const prInfo = { prNumber: pr?.number, prAuthor: pr?.author, prUrl: pr?.url };
 
     const tickets = extractTicketsFromCommit(

--- a/.github/actions/release-action/src/tickets/tickets.ts
+++ b/.github/actions/release-action/src/tickets/tickets.ts
@@ -1,0 +1,605 @@
+/**
+ * Ticket system integration orchestrator
+ *
+ * Coordinates extraction of ticket IDs from commits/PRs and fetching
+ * ticket details from configured systems (Linear, Jira, GitHub Issues).
+ *
+ * @example
+ * ```typescript
+ * import { generateTicketsSection } from "./tickets.ts";
+ *
+ * const result = await generateTicketsSection({
+ *   config: {
+ *     systems: [{ type: "linear", keys: ["TEAM"] }],
+ *     owner: "org",
+ *     repo: "repo",
+ *   },
+ *   env: { githubToken: "ghp_xxx", linearApiKey: "lin_xxx" },
+ * });
+ *
+ * console.log(result.markdown);
+ * // ## Linear
+ * //
+ * // | Issue | PR | Author |
+ * // | --- | --- | --- |
+ * // | [TEAM-123: Add auth](url) | [#10](pr_url) | @author |
+ * ```
+ */
+
+import type {
+  ExtractedTicket,
+  GenerateTicketsSectionOptions,
+  GenerateTicketsSectionResult,
+  PrDescription,
+  PullRequestInfo,
+  TicketClient,
+  TicketConfig,
+  TicketEnvVars,
+  TicketInfo,
+  TicketSystemEntry,
+  TicketSystemType,
+} from "./tickets.types.ts";
+import { extractTicketIds, getAllKeys, mapTicketToSystem } from "./ticketExtractor.ts";
+import { extractGithubIssueNumbers } from "./githubIssuesClient.ts";
+import { fetchPullRequestsForCommits, getCommitsSinceLastTag } from "./githubClient.ts";
+import { createLinearClient } from "./linearClient.ts";
+import { createJiraClient } from "./jiraClient.ts";
+import { createGithubIssuesClient } from "./githubIssuesClient.ts";
+
+/**
+ * Create a ticket client for a system based on environment variables
+ *
+ * @param system - System configuration
+ * @param env - Environment variables with API keys
+ * @param config - Full ticket configuration (for GitHub Issues)
+ * @returns TicketClient or null if credentials missing
+ */
+export function createTicketClient(
+  system: TicketSystemEntry,
+  env: TicketEnvVars,
+  config: TicketConfig
+): TicketClient | null {
+  switch (system.type) {
+    case "linear": {
+      if (!env.linearApiKey) {
+        return null;
+      }
+      return createLinearClient(env.linearApiKey);
+    }
+    case "jira": {
+      if (!env.jiraBaseUrl || !env.jiraEmail || !env.jiraApiToken) {
+        return null;
+      }
+      return createJiraClient(env.jiraBaseUrl, env.jiraEmail, env.jiraApiToken);
+    }
+    case "github": {
+      if (!env.githubToken) {
+        return null;
+      }
+      return createGithubIssuesClient(config.owner, config.repo, env.githubToken);
+    }
+  }
+}
+
+/**
+ * Format tickets into a markdown table
+ *
+ * Formatting differs by system type:
+ * - Linear/Jira: Uses markdown links since GitHub doesn't auto-link these IDs
+ * - GitHub Issues: Uses bare #N since GitHub auto-links and shows preview
+ *
+ * @param tickets - Array of ticket info
+ * @param systemName - Display name for the system
+ * @param _owner - GitHub repository owner (unused, kept for API compatibility)
+ * @param _repo - GitHub repository name (unused, kept for API compatibility)
+ * @returns Formatted markdown string
+ *
+ * @example Linear/Jira
+ * ```markdown
+ * ## Linear
+ *
+ * | Issue | PR | Author |
+ * | --- | --- | --- |
+ * | [ARCH-90: Title](https://linear.app/...) | [#44](https://github.com/org/repo/pull/44) | @author |
+ * ```
+ *
+ * @example GitHub Issues
+ * ```markdown
+ * ## GitHub Issues
+ *
+ * | Issue | PR | Author |
+ * | --- | --- | --- |
+ * | #40 | [#42](https://github.com/org/repo/pull/42) | @developer |
+ * ```
+ */
+export function formatTicketsMarkdown(
+  tickets: TicketInfo[],
+  systemName: string,
+  _owner: string,
+  _repo: string
+): string {
+  if (tickets.length === 0) {
+    return "";
+  }
+
+  const lines = [`## ${systemName}`, "", "| Issue | PR | Author |", "| --- | --- | --- |"];
+
+  for (const ticket of tickets) {
+    let issueCell: string;
+
+    if (ticket.system === "github") {
+      const issueId = String(ticket.id).replace(/^#/, "");
+      issueCell = `#${issueId}`;
+    } else {
+      issueCell = `[${ticket.id}: ${ticket.title}](${ticket.url})`;
+    }
+
+    let prCell = "—";
+    if (ticket.prUrl && ticket.prNumber) {
+      prCell = `[#${ticket.prNumber}](${ticket.prUrl})`;
+    } else if (ticket.prNumber) {
+      prCell = `#${ticket.prNumber}`;
+    }
+
+    const authorCell = ticket.prAuthor ? `@${ticket.prAuthor}` : "—";
+
+    lines.push(`| ${issueCell} | ${prCell} | ${authorCell} |`);
+  }
+
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Get display name for a ticket system
+ */
+function getSystemDisplayName(systemType: TicketSystemType): string {
+  switch (systemType) {
+    case "linear":
+      return "Linear";
+    case "jira":
+      return "Jira";
+    case "github":
+      return "GitHub Issues";
+  }
+}
+
+/** Extract tickets from a single commit/PR */
+function extractTicketsFromCommit(
+  textToSearch: string,
+  systems: TicketSystemEntry[],
+  allKeys: string[],
+  hasGithubIssueSystem: boolean,
+  prInfo: { prNumber?: number; prAuthor?: string; prUrl?: string },
+  knownPrNumbers: Set<number>
+): ExtractedTicket[] {
+  const extracted: ExtractedTicket[] = [];
+
+  // Extract PREFIX-123 style tickets
+  const ticketIds = extractTicketIds(textToSearch, allKeys.length > 0 ? allKeys : undefined);
+
+  for (const ticketId of ticketIds) {
+    const system = mapTicketToSystem(ticketId, systems);
+    if (!system) continue;
+
+    extracted.push({
+      id: ticketId,
+      system,
+      prNumber: prInfo.prNumber,
+      prAuthor: prInfo.prAuthor,
+      prUrl: prInfo.prUrl,
+    });
+  }
+
+  // Extract #123 style GitHub issues
+  if (!hasGithubIssueSystem) {
+    return extracted;
+  }
+
+  const issueNumbers = extractGithubIssueNumbers(textToSearch, knownPrNumbers);
+  for (const issueNumber of issueNumbers) {
+    extracted.push({
+      id: issueNumber,
+      system: "github",
+      prNumber: prInfo.prNumber,
+      prAuthor: prInfo.prAuthor,
+      prUrl: prInfo.prUrl,
+    });
+  }
+
+  return extracted;
+}
+
+/** Fetch ticket info and add to results map */
+async function fetchAndStoreTicket(
+  extracted: ExtractedTicket,
+  commits: CommitEntry[],
+  client: TicketClient,
+  ticketsBySystem: Map<TicketSystemType, TicketInfo[]>,
+  warnings: string[]
+): Promise<void> {
+  try {
+    const ticketId = String(extracted.id);
+    const ticketInfo = await client.fetchTicket(ticketId);
+    if (!ticketInfo) return;
+
+    const enriched: TicketInfo = {
+      ...ticketInfo,
+      prNumber: extracted.prNumber,
+      prAuthor: extracted.prAuthor,
+      prUrl: extracted.prUrl,
+      commits: commits.length > 0 ? commits : undefined,
+    };
+
+    const existing = ticketsBySystem.get(extracted.system) ?? [];
+    existing.push(enriched);
+    ticketsBySystem.set(extracted.system, existing);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`Failed to fetch ${extracted.id}: ${message}`);
+  }
+}
+
+/** Initialize ticket clients for configured systems */
+function initializeClients(
+  config: TicketConfig,
+  env: TicketEnvVars,
+  warnings: string[]
+): Map<TicketSystemType, TicketClient> {
+  const clients = new Map<TicketSystemType, TicketClient>();
+
+  for (const system of config.systems) {
+    const client = createTicketClient(system, env, config);
+    if (client) {
+      clients.set(system.type, client);
+    } else {
+      warnings.push(`Missing credentials for ${getSystemDisplayName(system.type)}`);
+    }
+  }
+
+  return clients;
+}
+
+/** Commit with message and SHA */
+interface CommitEntry {
+  message: string;
+  sha: string;
+}
+
+/** Group extracted tickets by system:id key, collecting commit messages and SHAs */
+function groupTicketsByKey(
+  tickets: ExtractedTicket[]
+): Map<string, { ticket: ExtractedTicket; commits: CommitEntry[] }> {
+  const grouped = new Map<string, { ticket: ExtractedTicket; commits: CommitEntry[] }>();
+
+  for (const ticket of tickets) {
+    const key = `${ticket.system}:${ticket.id}`;
+    const existing = grouped.get(key);
+
+    if (!existing) {
+      grouped.set(key, {
+        ticket,
+        commits:
+          ticket.commitMessage && ticket.commitSha
+            ? [{ message: ticket.commitMessage, sha: ticket.commitSha }]
+            : [],
+      });
+      continue;
+    }
+
+    // Add commit if present and not already included
+    const { commitMessage, commitSha } = ticket;
+    if (!commitMessage || !commitSha) {
+      continue;
+    }
+
+    const alreadyExists = existing.commits.some((c) => c.sha === commitSha);
+    if (!alreadyExists) {
+      existing.commits.push({ message: commitMessage, sha: commitSha });
+    }
+  }
+
+  return grouped;
+}
+
+/** Collect all tickets from all systems into a flat array */
+function collectAllTickets(
+  systems: TicketSystemEntry[],
+  ticketsBySystem: Map<TicketSystemType, TicketInfo[]>
+): TicketInfo[] {
+  const allTickets: TicketInfo[] = [];
+  for (const system of systems) {
+    const tickets = ticketsBySystem.get(system.type) ?? [];
+    allTickets.push(...tickets);
+  }
+  return allTickets;
+}
+
+/** Collect all unique PR numbers from PR details map */
+function collectPrNumbers(prDetailsBySha: Map<string, PullRequestInfo>): Set<number> {
+  return new Set([...prDetailsBySha.values()].map((pr) => pr.number));
+}
+
+/** Format all systems into markdown sections */
+function formatAllSystems(
+  systems: TicketSystemEntry[],
+  ticketsBySystem: Map<TicketSystemType, TicketInfo[]>,
+  owner: string,
+  repo: string
+): string {
+  const sections: string[] = [];
+
+  for (const system of systems) {
+    const tickets = ticketsBySystem.get(system.type) ?? [];
+    const markdown = formatTicketsMarkdown(tickets, getSystemDisplayName(system.type), owner, repo);
+    if (markdown) {
+      sections.push(markdown);
+    }
+  }
+
+  return sections.join("\n");
+}
+
+/** PR titles created by release-action workflows that should be excluded from ticket extraction */
+export const releasePrTitlePattern = /^Release\s/;
+
+/** Maximum characters per PR description content */
+const maxDescriptionLength = 2000;
+
+/** Pattern to find release notes section in PR body */
+const releaseNotesPattern = /\*\*Release notes?:\*\*\s*([\s\S]*?)(?=\n---|\n\*\*[A-Z]|\n##|$)/i;
+
+/**
+ * Extract PR descriptions from fetched PR details
+ *
+ * Prefers explicit "Release notes:" sections when present.
+ * Truncates content to avoid oversized AI prompts.
+ *
+ * @param prDetailsBySha - Map of commit SHA to PR info
+ * @returns Deduplicated PR descriptions with content
+ */
+export function extractPrDescriptions(
+  prDetailsBySha: Map<string, PullRequestInfo>
+): PrDescription[] {
+  const seen = new Set<number>();
+  const descriptions: PrDescription[] = [];
+
+  for (const pr of prDetailsBySha.values()) {
+    if (seen.has(pr.number) || !pr.body?.trim()) continue;
+    seen.add(pr.number);
+
+    const releaseNotesMatch = pr.body.match(releaseNotesPattern);
+    const content = releaseNotesMatch?.[1]?.trim() ?? pr.body.trim();
+    if (!content) continue;
+
+    const truncated =
+      content.length > maxDescriptionLength
+        ? `${content.slice(0, maxDescriptionLength)}...`
+        : content;
+
+    descriptions.push({
+      prNumber: pr.number,
+      title: pr.title,
+      content: truncated,
+      author: pr.author,
+    });
+  }
+
+  return descriptions;
+}
+
+/**
+ * Serialize PR descriptions to YAML format
+ *
+ * Uses YAML block scalar (`|`) for multiline content.
+ * No library needed — the structure is flat and predictable.
+ *
+ * @param descriptions - PR descriptions to serialize
+ * @returns YAML string
+ */
+export function serializePrDescriptionsToYaml(descriptions: PrDescription[]): string {
+  return descriptions
+    .map((d) => {
+      const escapedTitle = d.title.replace(/"/g, '\\"');
+      const indentedContent = d.content
+        .split("\n")
+        .map((line) => `    ${line}`)
+        .join("\n");
+      return `- prNumber: ${d.prNumber}\n  title: "${escapedTitle}"\n  author: ${d.author}\n  content: |\n${indentedContent}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Generate tickets section for changelog
+ *
+ * @param options - Configuration and environment
+ * @returns Generated markdown and any warnings
+ *
+ * @example
+ * ```typescript
+ * const result = await generateTicketsSection({
+ *   config: {
+ *     systems: [{ type: "linear" }],
+ *     owner: "org",
+ *     repo: "repo",
+ *   },
+ *   env: { githubToken: "ghp_xxx", linearApiKey: "lin_xxx" },
+ * });
+ * ```
+ */
+export async function generateTicketsSection(
+  options: GenerateTicketsSectionOptions
+): Promise<GenerateTicketsSectionResult> {
+  const { config, env, cwd = process.cwd() } = options;
+  const warnings: string[] = [];
+  const ticketsBySystem = new Map<TicketSystemType, TicketInfo[]>();
+
+  const clients = initializeClients(config, env, warnings);
+  if (clients.size === 0) {
+    return { markdown: "", tickets: [], prDescriptions: [], warnings };
+  }
+
+  // Get commits and fetch associated PRs by commit SHA
+  // This works for all merge strategies (squash, rebase, merge commit)
+  const commits = await getCommitsSinceLastTag(cwd);
+  const commitShas = commits.map((c) => c.sha);
+
+  let prDetailsBySha = new Map<string, PullRequestInfo>();
+  if (commitShas.length > 0 && env.githubToken) {
+    prDetailsBySha = await fetchPullRequestsForCommits(
+      commitShas,
+      config.owner,
+      config.repo,
+      env.githubToken
+    );
+  }
+
+  // Filter release PRs — their bodies contain changelogs with ticket IDs
+  // that would be incorrectly re-attributed to the release PR author
+  prDetailsBySha = new Map(
+    [...prDetailsBySha].filter(([, pr]) => !releasePrTitlePattern.test(pr.title))
+  );
+
+  // Collect PR descriptions for AI release notes context
+  const prDescriptions = extractPrDescriptions(prDetailsBySha);
+
+  // Extract tickets from each commit/PR
+  const allKeys = getAllKeys(config.systems);
+  const hasGithubIssueSystem = config.systems.some((s) => s.type === "github");
+  const knownPrNumbers = collectPrNumbers(prDetailsBySha);
+  const extractedTickets: ExtractedTicket[] = [];
+
+  for (const commit of commits) {
+    const pr = prDetailsBySha.get(commit.sha);
+    // Search both PR title and body for ticket references (e.g., "Resolve #34" in body)
+    const textToSearch = pr ? `${pr.title} ${pr.body ?? ""}` : commit.message;
+    const prInfo = { prNumber: pr?.number, prAuthor: pr?.author, prUrl: pr?.url };
+
+    const tickets = extractTicketsFromCommit(
+      textToSearch,
+      config.systems,
+      allKeys,
+      hasGithubIssueSystem,
+      prInfo,
+      knownPrNumbers
+    );
+
+    // Attach commit message and SHA to each extracted ticket
+    for (const ticket of tickets) {
+      ticket.commitMessage = commit.message;
+      ticket.commitSha = commit.sha;
+    }
+
+    extractedTickets.push(...tickets);
+  }
+
+  // Group tickets by key and fetch details
+  const groupedTickets = groupTicketsByKey(extractedTickets);
+  for (const { ticket, commits } of groupedTickets.values()) {
+    const client = clients.get(ticket.system);
+    if (!client) continue;
+    await fetchAndStoreTicket(ticket, commits, client, ticketsBySystem, warnings);
+  }
+
+  return {
+    markdown: formatAllSystems(config.systems, ticketsBySystem, config.owner, config.repo),
+    tickets: collectAllTickets(config.systems, ticketsBySystem),
+    prDescriptions,
+    warnings,
+  };
+}
+
+/**
+ * Parse CLI arguments into ticket configuration
+ *
+ * @param args - CLI arguments
+ * @returns Parsed ticket system entries or null if no --tickets args
+ *
+ * @example
+ * ```typescript
+ * parseTicketArgs(["--tickets=linear", "--tickets=jira:CORE,INFRA"]);
+ * // → [{ type: "linear" }, { type: "jira", keys: ["CORE", "INFRA"] }]
+ * ```
+ */
+export function parseTicketArgs(args: string[]): TicketSystemEntry[] | null {
+  const systems: TicketSystemEntry[] = [];
+
+  for (const arg of args) {
+    if (!arg.startsWith("--tickets=")) {
+      continue;
+    }
+
+    const value = arg.slice("--tickets=".length);
+    const colonIndex = value.indexOf(":");
+
+    if (colonIndex === -1) {
+      // Format: --tickets=linear
+      systems.push({ type: value as TicketSystemType });
+    } else {
+      // Format: --tickets=linear:TEAM,PROJ
+      const systemType = value.slice(0, colonIndex) as TicketSystemType;
+      const keys = value.slice(colonIndex + 1).split(",");
+      systems.push({ type: systemType, keys });
+    }
+  }
+
+  return systems.length > 0 ? systems : null;
+}
+
+/**
+ * Load ticket environment variables
+ *
+ * @returns TicketEnvVars from process.env
+ */
+export function loadTicketEnv(): TicketEnvVars {
+  return {
+    githubToken: process.env.GH_TOKEN,
+    linearApiKey: process.env.LINEAR_API_KEY,
+    jiraBaseUrl: process.env.JIRA_BASE_URL,
+    jiraEmail: process.env.JIRA_EMAIL,
+    jiraApiToken: process.env.JIRA_API_TOKEN,
+  };
+}
+
+/**
+ * Auto-detect ticket systems from environment variables
+ *
+ * Enables ticket systems based on available credentials:
+ * - LINEAR_API_KEY → enables Linear
+ * - JIRA_BASE_URL + JIRA_EMAIL + JIRA_API_TOKEN → enables Jira
+ *
+ * Optional key filtering via environment variables:
+ * - LINEAR_KEYS=TEAM,PROJ → filter Linear tickets
+ * - JIRA_KEYS=CORE,INFRA → filter Jira tickets
+ *
+ * @param env - Environment variables with API credentials
+ * @returns Array of detected ticket system entries
+ *
+ * @example
+ * ```typescript
+ * // With LINEAR_API_KEY and LINEAR_KEYS=TEAM,PROJ set:
+ * const systems = autoDetectTicketSystems(loadTicketEnv());
+ * // → [{ type: "linear", keys: ["TEAM", "PROJ"] }]
+ * ```
+ */
+export function autoDetectTicketSystems(env: TicketEnvVars): TicketSystemEntry[] {
+  const systems: TicketSystemEntry[] = [];
+
+  if (env.linearApiKey) {
+    const keys = process.env.LINEAR_KEYS?.split(",").filter(Boolean);
+    systems.push({ type: "linear", keys: keys?.length ? keys : undefined });
+  }
+
+  if (env.jiraBaseUrl && env.jiraEmail && env.jiraApiToken) {
+    const keys = process.env.JIRA_KEYS?.split(",").filter(Boolean);
+    systems.push({ type: "jira", keys: keys?.length ? keys : undefined });
+  }
+
+  if (env.githubToken) {
+    systems.push({ type: "github" });
+  }
+
+  return systems;
+}

--- a/.github/actions/release-action/src/tickets/tickets.types.ts
+++ b/.github/actions/release-action/src/tickets/tickets.types.ts
@@ -1,0 +1,214 @@
+/**
+ * Type definitions for ticket system integration
+ *
+ * @example
+ * ```typescript
+ * import type { TicketConfig, TicketInfo } from "./tickets.types.ts";
+ *
+ * const config: TicketConfig = {
+ *   systems: [{ type: "linear", keys: ["TEAM", "PROJ"] }],
+ *   owner: "org",
+ *   repo: "repo",
+ * };
+ * ```
+ */
+
+/** Supported ticket system types */
+export type TicketSystemType = "linear" | "jira" | "github";
+
+/**
+ * Single ticket system configuration
+ *
+ * @example
+ * ```typescript
+ * // Match only TEAM-* and PROJ-* tickets in Linear
+ * const linear: TicketSystemEntry = { type: "linear", keys: ["TEAM", "PROJ"] };
+ *
+ * // Match any UPPERCASE-123 pattern in Jira
+ * const jira: TicketSystemEntry = { type: "jira" };
+ * ```
+ */
+export interface TicketSystemEntry {
+  /** Ticket system type */
+  type: TicketSystemType;
+  /** Optional key prefixes to match (e.g., ["TEAM", "PROJ"]). If omitted, matches any UPPERCASE-123 */
+  keys?: string[];
+}
+
+/**
+ * Full ticket configuration
+ *
+ * @example
+ * ```typescript
+ * const config: TicketConfig = {
+ *   systems: [
+ *     { type: "linear", keys: ["TEAM"] },
+ *     { type: "jira", keys: ["CORE"] },
+ *   ],
+ *   owner: "myorg",
+ *   repo: "myrepo",
+ * };
+ * ```
+ */
+export interface TicketConfig {
+  /** Ticket systems to use (supports multiple) */
+  systems: TicketSystemEntry[];
+  /** GitHub repository owner */
+  owner: string;
+  /** GitHub repository name */
+  repo: string;
+}
+
+/** Environment variables for ticket system authentication */
+export interface TicketEnvVars {
+  /** GitHub token for PR/commit access */
+  githubToken?: string;
+  /** Linear API key */
+  linearApiKey?: string;
+  /** Jira base URL (e.g., https://company.atlassian.net) */
+  jiraBaseUrl?: string;
+  /** Jira user email */
+  jiraEmail?: string;
+  /** Jira API token */
+  jiraApiToken?: string;
+}
+
+/**
+ * Ticket extracted from PR/commit text before API lookup
+ *
+ * @see {@link TicketInfo} for fetched ticket with title
+ */
+export interface ExtractedTicket {
+  /** Ticket ID (e.g., TEAM-123) or issue number for GitHub */
+  id: string | number;
+  /** Which system this ticket belongs to */
+  system: TicketSystemType;
+  /** Source PR number if available */
+  prNumber?: number;
+  /** PR author username */
+  prAuthor?: string;
+  /** PR URL */
+  prUrl?: string;
+  /** Original commit message */
+  commitMessage?: string;
+  /** Commit SHA */
+  commitSha?: string;
+}
+
+/**
+ * Full ticket information after API lookup
+ *
+ * @example
+ * ```typescript
+ * const ticket: TicketInfo = {
+ *   id: "TEAM-123",
+ *   title: "Add authentication",
+ *   url: "https://linear.app/team/issue/TEAM-123",
+ *   system: "linear",
+ *   prNumber: 45,
+ *   prAuthor: "developer",
+ *   prUrl: "https://github.com/org/repo/pull/45",
+ * };
+ * ```
+ */
+export interface TicketInfo {
+  /** Ticket ID (e.g., TEAM-123) */
+  id: string;
+  /** Ticket title from the system */
+  title: string;
+  /** Ticket description from the system */
+  description?: string;
+  /** Direct URL to the ticket */
+  url: string;
+  /** Which system this ticket is from */
+  system: TicketSystemType;
+  /** Source PR number if available */
+  prNumber?: number;
+  /** PR author username */
+  prAuthor?: string;
+  /** PR URL */
+  prUrl?: string;
+  /** Commits associated with this ticket */
+  commits?: Array<{ message: string; sha: string }>;
+}
+
+/**
+ * Client interface for fetching ticket details from a system
+ *
+ * @example
+ * ```typescript
+ * const client: TicketClient = createLinearClient(apiKey);
+ * const ticket = await client.fetchTicket("TEAM-123");
+ * const url = client.buildUrl("TEAM-123");
+ * ```
+ */
+export interface TicketClient {
+  /** System type this client handles */
+  systemType: TicketSystemType;
+  /** Fetch ticket details from the system */
+  fetchTicket: (ticketId: string) => Promise<TicketInfo | null>;
+  /** Build URL for a ticket ID */
+  buildUrl: (ticketId: string) => string;
+}
+
+/** Git commit information */
+export interface CommitInfo {
+  /** Commit SHA */
+  sha: string;
+  /** Commit message */
+  message: string;
+  /** Extracted PR number from message (squash merge format) */
+  prNumber?: number;
+}
+
+/** Pull request information from GitHub API */
+export interface PullRequestInfo {
+  /** PR number */
+  number: number;
+  /** PR title */
+  title: string;
+  /** PR body/description (may contain issue references like "Resolve #34") */
+  body?: string;
+  /** PR URL */
+  url: string;
+  /** Author username */
+  author: string;
+}
+
+/**
+ * Options for generating tickets section
+ *
+ * @see {@link generateTicketsSection}
+ */
+export interface GenerateTicketsSectionOptions {
+  /** Ticket configuration */
+  config: TicketConfig;
+  /** Environment variables with API keys */
+  env: TicketEnvVars;
+  /** Working directory */
+  cwd?: string;
+}
+
+/** Result of generating tickets section */
+export interface GenerateTicketsSectionResult {
+  /** Generated markdown section */
+  markdown: string;
+  /** Raw ticket data for JSON export */
+  tickets: TicketInfo[];
+  /** PR descriptions for AI release notes context */
+  prDescriptions: PrDescription[];
+  /** Warnings encountered during generation */
+  warnings: string[];
+}
+
+/** PR description content for AI release notes generation */
+export interface PrDescription {
+  /** PR number */
+  prNumber: number;
+  /** PR title */
+  title: string;
+  /** Extracted release notes section, or truncated full body */
+  content: string;
+  /** PR author */
+  author: string;
+}

--- a/.github/actions/release-action/src/updateReleaseBadge.test.ts
+++ b/.github/actions/release-action/src/updateReleaseBadge.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for release badge update utility
+ */
+import { describe, expect, test } from "bun:test";
+
+import { updateReleaseBadge } from "./updateReleaseBadge.ts";
+
+const serverUrl = "https://github.com";
+const repo = "owner/repo";
+
+describe("updateReleaseBadge", () => {
+  test("updates existing badge version in-place", () => {
+    const readme = `# My Project
+[![GitHub Release](https://img.shields.io/badge/release-v1.0.0-blue)](https://github.com/owner/repo/releases/latest)
+[![Create Release](https://img.shields.io/badge/Create-Release-blue?logo=github)](https://github.com/owner/repo/actions/workflows/release_create.yml)
+
+Some content.
+`;
+    const result = updateReleaseBadge(readme, "2.0.0", serverUrl, repo);
+
+    expect(result).toContain("release-v2.0.0-blue");
+    expect(result).not.toContain("release-v1.0.0-blue");
+    expect(result).toContain("Some content.");
+  });
+
+  test("inserts badges after first # header", () => {
+    const readme = `# My Project
+
+Some description.
+`;
+    const result = updateReleaseBadge(readme, "1.0.0", serverUrl, repo);
+
+    expect(result).toContain("# My Project\n\n[![GitHub Release]");
+    expect(result).toContain("release-v1.0.0-blue");
+    expect(result).toContain("Create-Release-blue");
+    expect(result).toContain("Some description.");
+  });
+
+  test("prepends badges when no header exists", () => {
+    const readme = "Some content without header.\n";
+
+    const result = updateReleaseBadge(readme, "1.0.0", serverUrl, repo);
+
+    expect(result).toStartWith("[![GitHub Release]");
+    expect(result).toContain("release-v1.0.0-blue");
+    expect(result).toContain("Some content without header.");
+  });
+
+  test("updates badge in content with multiple shield references", () => {
+    const readme = `# Project
+[![GitHub Release](https://img.shields.io/badge/release-v1.0.0-blue)](link)
+
+Some text with img.shields.io/badge/release-v1.0.0-blue reference.
+`;
+    const result = updateReleaseBadge(readme, "3.0.0", serverUrl, repo);
+
+    expect(result).not.toContain("release-v1.0.0-blue");
+    expect(result).toContain("release-v3.0.0-blue");
+  });
+
+  test("uses correct URLs in generated badges", () => {
+    const readme = "# Test\n";
+    const result = updateReleaseBadge(readme, "1.0.0", "https://gh.example.com", "org/my-repo");
+
+    expect(result).toContain("https://gh.example.com/org/my-repo/releases/latest");
+    expect(result).toContain(
+      "https://gh.example.com/org/my-repo/actions/workflows/release_create.yml"
+    );
+  });
+});

--- a/.github/actions/release-action/src/updateReleaseBadge.ts
+++ b/.github/actions/release-action/src/updateReleaseBadge.ts
@@ -1,0 +1,84 @@
+/**
+ * Update the release badge in README.md with the current version.
+ *
+ * Handles three cases:
+ * 1. Existing badge — updates the version number in-place
+ * 2. README with `# ` header — inserts badges after the first header
+ * 3. README without header — prepends badges to the file
+ *
+ * Exits silently if README.md does not exist.
+ *
+ * @example
+ * ```bash
+ * GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=owner/repo \
+ *   bun src/updateReleaseBadge.ts
+ * ```
+ */
+
+/**
+ * Update or insert release badge in README content.
+ *
+ * @param readme - Current README.md content
+ * @param version - Release version (e.g. "1.2.3")
+ * @param serverUrl - GitHub server URL (e.g. "https://github.com")
+ * @param repo - GitHub repository (e.g. "owner/repo")
+ * @returns Updated README content
+ */
+export function updateReleaseBadge(
+  readme: string,
+  version: string,
+  serverUrl: string,
+  repo: string
+): string {
+  const releaseBadge = `[![GitHub Release](https://img.shields.io/badge/release-v${version}-blue)](${serverUrl}/${repo}/releases/latest)`;
+  const createBadge = `[![Create Release](https://img.shields.io/badge/Create-Release-blue?logo=github)](${serverUrl}/${repo}/actions/workflows/release_create.yml)`;
+
+  // Case 1: Existing badge — update version in-place
+  if (readme.includes("img.shields.io/badge/release-v")) {
+    return readme.replace(/release-v[\d.]*-blue/g, `release-v${version}-blue`);
+  }
+
+  const lines = readme.split("\n");
+
+  // Case 2: Insert after first # header
+  const headerIndex = lines.findIndex((l) => l.startsWith("# "));
+  if (headerIndex !== -1) {
+    return [
+      ...lines.slice(0, headerIndex + 1),
+      "",
+      releaseBadge,
+      createBadge,
+      ...lines.slice(headerIndex + 1),
+    ].join("\n");
+  }
+
+  // Case 3: Prepend to file
+  return `${releaseBadge}\n${createBadge}\n\n${readme}`;
+}
+
+async function main(): Promise<void> {
+  const readmeFile = Bun.file("README.md");
+
+  if (!(await readmeFile.exists())) {
+    return;
+  }
+
+  const version = (await Bun.file("version").text()).trim();
+  const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+  const repo = process.env.GITHUB_REPOSITORY ?? "";
+
+  const readme = await readmeFile.text();
+  const updated = updateReleaseBadge(readme, version, serverUrl, repo);
+
+  if (updated !== readme) {
+    await Bun.write("README.md", updated);
+    console.log(`Updated release badge to v${version}`);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error: Error) => {
+    console.log(`::error::${error.message}`);
+    process.exit(1);
+  });
+}

--- a/.github/actions/release-action/tsconfig.json
+++ b/.github/actions/release-action/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ See the [plugin README](./claude-plugins/autopilot/README.md#installation) for s
 - [`agents-rules-sync`](./.github/actions/agents-rules-sync/README.md) — sync the stack-appropriate `rules/<stack>.md` into `CLAUDE.md` based on `package.json` `agents.rules`
 - [`contributing-check`](./.github/actions/contributing-check/README.md) — validate branch name, commit messages, and PR title against `CONTRIBUTING.md`
 - [`contributing-sync`](./.github/actions/contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, and the contributing workflow from upstream
+- [`release-action`](./.github/actions/release-action/README.md) — conventional-commit-driven release pipeline for npm packages, GitHub Actions, and Claude plugins
 
 ## Contributing
 

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,25 @@
         "typescript": "6.0.3",
       },
     },
+    ".github/actions/release-action": {
+      "name": "@code-assistants/release-action",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.92.0",
+        "@slack/web-api": "7.15.1",
+        "conventional-changelog": "7.2.0",
+        "conventional-changelog-conventionalcommits": "9.3.1",
+        "conventional-recommended-bump": "11.2.0",
+        "semver": "7.7.4",
+        "smol-toml": "1.6.1",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+        "@types/conventional-changelog": "6.0.1",
+        "@types/semver": "7.7.1",
+        "typescript": "6.0.3",
+      },
+    },
   },
   "packages": {
     "@actions/core": ["@actions/core@3.0.1", "", { "dependencies": { "@actions/exec": "^3.0.0", "@actions/http-client": "^4.0.0" } }, "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA=="],
@@ -72,15 +91,21 @@
 
     "@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
 
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.92.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@code-assistants/actions-lib": ["@code-assistants/actions-lib@workspace:.github/actions/lib"],
 
     "@code-assistants/agents-rules-sync-action": ["@code-assistants/agents-rules-sync-action@workspace:.github/actions/agents-rules-sync"],
 
     "@code-assistants/files-sync-action": ["@code-assistants/files-sync-action@workspace:.github/actions/files-sync"],
+
+    "@code-assistants/release-action": ["@code-assistants/release-action@workspace:.github/actions/release-action"],
 
     "@commitlint/cli": ["@commitlint/cli@21.0.1", "", { "dependencies": { "@commitlint/format": "^21.0.1", "@commitlint/lint": "^21.0.1", "@commitlint/load": "^21.0.1", "@commitlint/read": "^21.0.1", "@commitlint/types": "^21.0.1", "tinyexec": "^1.0.0", "yargs": "^18.0.0" }, "bin": { "commitlint": "cli.js" } }, "sha512-8vq10krmbJwBkvzXKhbs4o4JQEVscd3pqOlWuDUaDBwbeL694/P33UC29tZQFTAgPU9fVJ2+f2m3zw16yKWxHg=="],
 
@@ -144,7 +169,15 @@
 
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
 
+    "@simple-libs/hosted-git-info": ["@simple-libs/hosted-git-info@1.0.2", "", {}, "sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg=="],
+
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
+
+    "@slack/logger": ["@slack/logger@4.0.1", "", { "dependencies": { "@types/node": ">=18" } }, "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ=="],
+
+    "@slack/types": ["@slack/types@2.21.1", "", {}, "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ=="],
+
+    "@slack/web-api": ["@slack/web-api@7.15.1", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.20.1", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.15.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg=="],
 
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A=="],
 
@@ -160,7 +193,27 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/conventional-changelog": ["@types/conventional-changelog@6.0.1", "", { "dependencies": { "@types/conventional-changelog-core": "*", "@types/conventional-changelog-writer": "*", "@types/conventional-commits-parser": "*", "@types/node": "*" } }, "sha512-GLIHdve+MlJUe6ur9alLTXUBL7L2p6+/J9KFEvL/pR4iZ6ctgnpXnuNo50sCYtjj0utNkHoEQS+SBpZ+7frkvQ=="],
+
+    "@types/conventional-changelog-core": ["@types/conventional-changelog-core@8.0.1", "", { "dependencies": { "@types/conventional-changelog-writer": "*", "@types/conventional-commits-parser": "*", "@types/conventional-recommended-bump": "*", "@types/git-raw-commits": "*", "@types/node": "*", "@types/normalize-package-data": "*" } }, "sha512-oeHa/mI6bvB89CJuDo6lhPNVCyBJfuGJd/+eO4BxwheWUIc1eLObyWm8IIaeETZgo575KS8KFPlNUWWKbdHPOQ=="],
+
+    "@types/conventional-changelog-writer": ["@types/conventional-changelog-writer@4.0.11", "", { "dependencies": { "@types/conventional-commits-parser": "*", "@types/node": "*" } }, "sha512-Zxvn6OM4iYS1bwLKhYwVu7epkw2V5mfPhcUHZh+CIyMsffE4hMrJwAYC+NNp5XeXcDGF7KrsFzt/fEdovbekbg=="],
+
+    "@types/conventional-commits-parser": ["@types/conventional-commits-parser@5.0.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g=="],
+
+    "@types/conventional-recommended-bump": ["@types/conventional-recommended-bump@10.0.3", "", { "dependencies": { "conventional-recommended-bump": "*" } }, "sha512-bU0stOuSkWbhF/3hh3zHZaL5VqvfQwyHCOuxOMUc2O0kCVaoyKE/6GIb2RBz872vzmML61MMSg/Jec5/qRfOAA=="],
+
+    "@types/git-raw-commits": ["@types/git-raw-commits@5.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-sd4kgxJbuZF0RDy6cX7KlKSGiwqB1mqn8nriUbxt5e1F+MO/N4hJlhaYn0Omw4g2biClFpT5Mre07x7OkGt8tg=="],
+
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -174,9 +227,15 @@
 
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
+
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -186,21 +245,39 @@
 
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
 
     "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "conventional-changelog": ["conventional-changelog@7.2.0", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "@simple-libs/hosted-git-info": "^1.0.2", "@types/normalize-package-data": "^2.4.4", "conventional-changelog-preset-loader": "^5.0.0", "conventional-changelog-writer": "^8.3.0", "conventional-commits-parser": "^6.3.0", "fd-package-json": "^2.0.0", "meow": "^13.0.0", "normalize-package-data": "^7.0.0" }, "bin": { "conventional-changelog": "dist/cli/index.js" } }, "sha512-BEdgG+vPl53EVlTTk9sZ96aagFp0AQ5pw/ggiQMy2SClLbTo1r0l+8dSg79gkLOO5DS1Lswuhp5fWn6RwE+ivg=="],
 
     "conventional-changelog-angular": ["conventional-changelog-angular@8.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg=="],
 
     "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw=="],
 
+    "conventional-changelog-preset-loader": ["conventional-changelog-preset-loader@5.0.0", "", {}, "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA=="],
+
+    "conventional-changelog-writer": ["conventional-changelog-writer@8.4.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "conventional-commits-filter": "^5.0.0", "handlebars": "^4.7.7", "meow": "^13.0.0", "semver": "^7.5.2" }, "bin": { "conventional-changelog-writer": "dist/cli/index.js" } }, "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g=="],
+
+    "conventional-commits-filter": ["conventional-commits-filter@5.0.0", "", {}, "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q=="],
+
     "conventional-commits-parser": ["conventional-commits-parser@6.4.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "meow": "^13.0.0" }, "bin": { "conventional-commits-parser": "dist/cli/index.js" } }, "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw=="],
+
+    "conventional-recommended-bump": ["conventional-recommended-bump@11.2.0", "", { "dependencies": { "@conventional-changelog/git-client": "^2.5.1", "conventional-changelog-preset-loader": "^5.0.0", "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.1.0", "meow": "^13.0.0" }, "bin": { "conventional-recommended-bump": "dist/cli/index.js" } }, "sha512-lqIdmw330QdMBgfL0e6+6q5OMKyIpy4OZNmepit6FS3GldhkG+70drZjuZ0A5NFpze5j85dlYs3GabQXl6sMHw=="],
 
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
 
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.3.0", "", { "dependencies": { "jiti": "2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -209,6 +286,14 @@
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
 
@@ -226,15 +311,41 @@
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
+    "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "git-raw-commits": ["git-raw-commits@5.0.1", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "meow": "^13.0.0" }, "bin": { "git-raw-commits": "src/cli.js" } }, "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ=="],
 
     "global-directory": ["global-directory@5.0.0", "", { "dependencies": { "ini": "6.0.0" } }, "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hosted-git-info": ["hosted-git-info@8.1.0", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
@@ -244,6 +355,8 @@
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
+
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
@@ -252,6 +365,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -259,6 +374,8 @@
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -274,11 +391,35 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
     "meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "normalize-package-data": ["normalize-package-data@7.0.1", "", { "dependencies": { "hosted-git-info": "^8.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA=="],
+
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
@@ -290,21 +431,37 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
-    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+
+    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "spdx-correct": ["spdx-correct@3.2.0", "", { "dependencies": { "spdx-expression-parse": "^3.0.0", "spdx-license-ids": "^3.0.0" } }, "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA=="],
+
+    "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
+
+    "spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
+
+    "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
@@ -318,17 +475,27 @@
 
     "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
 
     "turbo": ["turbo@2.9.14", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.14", "@turbo/darwin-arm64": "2.9.14", "@turbo/linux-64": "2.9.14", "@turbo/linux-arm64": "2.9.14", "@turbo/windows-64": "2.9.14", "@turbo/windows-arm64": "2.9.14" }, "bin": { "turbo": "bin/turbo" } }, "sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
     "undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
+    "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
+
+    "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
@@ -346,9 +513,15 @@
 
     "@code-assistants/files-sync-action/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "@commitlint/is-ignored/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "@conventional-changelog/git-client/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
     "cli-truncate/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "conventional-changelog-writer/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "cosmiconfig/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -357,6 +530,10 @@
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "log-update/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "normalize-package-data/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "wrap-ansi/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "workspaces": [
     ".github/actions/lib",
     ".github/actions/files-sync",
-    ".github/actions/agents-rules-sync"
+    ".github/actions/agents-rules-sync",
+    ".github/actions/release-action"
   ],
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
Imports the upstream release-action as a fourth workspace member under `.github/actions/release-action`, joining `files-sync`, `agents-rules-sync`, `contributing-check`, and `contributing-sync`. The action drives conventional-commit → changelog → release-PR → tag/publish for npm packages, GitHub Actions, and Claude plugins, selecting publish artifacts based on the `release:` field in `platform.meta.yml`.

- Composite action exposes `create` (open release PR) and `publish` (tag, npm publish, GitHub Release, Slack notify) modes
- Workspace package `@code-assistants/release-action` with pinned deps (`@anthropic-ai/sdk`, `@slack/web-api`, `conventional-changelog`, `conventional-recommended-bump`, `semver`, `smol-toml`)
- All TypeScript lives in `src/`; entries (`release.ts`, `assemble-pr-body.ts`, `insert-release-notes.ts`, `slackNotify.ts`, `prepareRelease.ts`, `generateReleaseNotes.ts`, `updateReleaseBadge.ts`) sit alongside helpers (`gitTags.ts`, `platformMeta.ts`, `releaseNotesPrompt.ts`, `testHelpers.ts`) and the `tickets/` clients (Linear, Jira, GitHub Issues)
- 239 bun:test cases cover changelog generation, ticket extraction, version bumping, PR body assembly, slack notification, and badge updates
- Commits land as `github-actions[bot]`; install runs via `bun install --frozen-lockfile --filter @code-assistants/release-action` from the repo root; setup-bun pinned by SHA at `bun-version: 1.x`
- Sanitized of all upstream-org identifiers (action name, docs URLs, User-Agent strings, example tickets) and the delivery release mode

---

**Issues:**

Closes #25

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a composite `release-action` to automate conventional-commit releases for npm packages, GitHub Actions, and Claude plugins via `platform.meta.yml`. Addresses #25 with create/publish workflows, ticket-aware notes, Slack alerts, and multiple reliability fixes.

- **New Features**
  - Two modes: create (PR, bump, changelog) and publish (tag, npm/GitHub Release, major tag, Slack).
  - Picks publish targets from `release:` in `platform.meta.yml`.
  - Optional release notes using `@anthropic-ai/sdk`, with safe PR body assembly and truncation.
  - Ticket enrichment for Linear, Jira, and GitHub Issues; changelog links and PR context.
  - Slack notifications via `@slack/web-api`; updates README release badge.
  - Composite workspace package `@code-assistants/release-action` under `.github/actions/release-action`.

- **Bug Fixes**
  - Scope `pyproject.toml` version updates to the `[project]` table; match `uv.lock` workspace package by exact local source.
  - Normalize `release:` parsing by stripping quotes (action step and parser).
  - Skip `node_modules` when reading `plugin.json` for version detection.
  - Throw on non-404 responses when fetching PRs; improve ticket extraction by combining commit message with PR title/body.
  - Warn when multiple key-scoped ticket systems are configured without distinct prefixes.
  - Added tests covering these cases.

<sup>Written for commit c8690b186a383babba5191072beac516f834c089. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/29?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

