### PR TITLE
Add AI code review composite action

### DIFF
--- a/.github/actions/code-review-action/README.md
+++ b/.github/actions/code-review-action/README.md
@@ -1,0 +1,90 @@
+# Code review action
+
+Composite GitHub Action that runs AI code review on pull requests using [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Has two modes:
+
+- **`review`** — runs the `/autopilot:pr-review` skill against the PR diff and submits a structured review (approve / request changes / comment) with optional inline findings.
+- **`react`** — runs the `/autopilot:pr-answer` skill against a triggering PR comment to draft a reply, resolve threads, and optionally update the existing review.
+
+Auto-detection routes events from `pull_request`, `issue_comment`, and `pull_request_review_comment` triggers to the correct mode. Drafts, release branches, and dependabot PRs are skipped automatically.
+
+## Usage
+
+```yaml
+# .github/workflows/ai-review.yml
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: code-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  ai-review:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: awinogradov/code-assistants/.github/actions/code-review-action@v1
+        with:
+          reviewer: ${{ vars.BOT_USERNAME }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+The `if` condition prevents runner provisioning for non-PR issue comments. All other filtering (bot mentions, author checks, event validation) is handled internally.
+
+## Inputs
+
+| Input                | Required | Default                  | Description                                                                         |
+| -------------------- | -------- | ------------------------ | ----------------------------------------------------------------------------------- |
+| `reviewer`           | yes      | —                        | GitHub username added as reviewer and used for `@mention` triggering.               |
+| `bot_token`          | yes      | —                        | GitHub token for bot operations (`contents: read`, `pull-requests: write`).         |
+| `anthropic_api_key`  | no       | —                        | Anthropic API key. One of `anthropic_api_key` or `claude_oauth_token` is required.  |
+| `claude_oauth_token` | no       | —                        | Claude Code OAuth token. Alternative to `anthropic_api_key`.                        |
+| `mode`               | no       | `review`                 | Action mode: `review` or `react`. Auto-detected when `react_to_comments` is `true`. |
+| `react_to_comments`  | no       | `true`                   | Auto-detect comment events and route to `react` mode.                               |
+| `bot_username`       | no       | falls back to `reviewer` | Username for skipping CI-author PRs labeled `ci-skip-review`.                       |
+| `model`              | no       | `claude-sonnet-4-6`      | Claude model to use.                                                                |
+| `settings`           | no       | —                        | Claude Code settings JSON (e.g., env vars for MCP servers).                         |
+| `mcp_config`         | no       | —                        | Additional MCP server configuration JSON, merged with repo `.mcp.json`.             |
+| `parallel_fanout`    | no       | `false`                  | Run the PR-review sub-agents as parallel headless SDK calls. Opt-in until stable.   |
+| `preflight_checks`   | no       | `true`                   | Wait for PR checks to pass before running review (review mode only).                |
+| `poll_interval`      | no       | `10`                     | Seconds between check status polls.                                                 |
+| `checks_timeout`     | no       | `600`                    | Maximum seconds to wait for checks.                                                 |
+| `debug_logs`         | no       | `false`                  | Enable DEBUG-level Claude trace logging and always upload the execution artifact.   |
+| `pr_number`          | no       | event context            | Override auto-detected PR number.                                                   |
+| `pr_head_sha`        | no       | event context            | Override auto-detected PR head SHA.                                                 |
+| `comment_id`         | no       | event context            | Comment ID (react mode, explicit-input setups).                                     |
+| `comment_body`       | no       | event context            | Comment body (react mode, explicit-input setups).                                   |
+| `comment_path`       | no       | event context            | File path for review-thread comments.                                               |
+| `comment_line`       | no       | event context            | Line number for review-thread comments.                                             |
+
+## Skills consumed
+
+The action invokes Claude Code with the local `claude-plugins/autopilot` plugin and runs:
+
+- `/autopilot:pr-review` — review the PR diff and emit a structured verdict
+- `/autopilot:pr-answer` — reply to a PR comment thread and optionally resolve / update the existing review
+
+When `parallel_fanout: true`, the action's orchestrator fans out the `pr:review:*` sub-agents in parallel via the Agent SDK instead of letting the root model do it in-model.
+
+## Labels
+
+PRs authored by the configured `bot_username` (or `reviewer` if `bot_username` is unset) and carrying the `ci-skip-review` label are skipped — useful for automated CI updates that don't need review.
+
+## Versioning
+
+Reference the action by floating major tag:
+
+```yaml
+uses: awinogradov/code-assistants/.github/actions/code-review-action@v1
+```

--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -1,0 +1,513 @@
+name: "AI Code Review"
+description: "AI-powered code review using Claude Code"
+author: "Code Assistants"
+
+inputs:
+  pr_number:
+    description: "Pull request number (auto-detected from event context, override with explicit value)"
+    required: false
+  pr_head_sha:
+    description: "PR head commit SHA (auto-detected from event context, override with explicit value)"
+    required: false
+  mode:
+    description: "Action mode: 'review' for PR review, 'react' for comment reaction"
+    required: false
+    default: "review"
+  react_to_comments:
+    description: "Auto-detect and handle comment reactions when bot is mentioned"
+    required: false
+    default: "true"
+  comment_id:
+    description: "ID of the comment to react to (required for react mode)"
+    required: false
+  comment_body:
+    description: "Body of the triggering comment (required for react mode)"
+    required: false
+  comment_path:
+    description: "File path for review thread comments (empty for general PR comments)"
+    required: false
+  comment_line:
+    description: "Line number for review thread comments"
+    required: false
+  reviewer:
+    description: "GitHub username to add as reviewer. Required — no default."
+    required: true
+  bot_username:
+    description: "Bot username for skipping CI-author PRs. When set, PRs authored by this user with the 'ci-skip-review' label are skipped. Falls back to reviewer if omitted."
+    required: false
+  bot_token:
+    description: "GitHub token for bot operations"
+    required: true
+  anthropic_api_key:
+    description: "Anthropic API key (alternative to claude_oauth_token)"
+    required: false
+  claude_oauth_token:
+    description: "Claude Code OAuth token (alternative to anthropic_api_key)"
+    required: false
+  settings:
+    description: "Claude Code settings JSON (use env to pass API keys for MCP servers)"
+    required: false
+  mcp_config:
+    description: "Additional MCP servers configuration JSON (merged with repo .mcp.json)"
+    required: false
+  model:
+    description: "Claude model to use for AI operations"
+    required: false
+    default: "claude-sonnet-4-6"
+  debug_logs:
+    description: "Enable verbose DEBUG-level Claude trace logging and force execution artifact upload. When false, artifacts upload only on failure or when a run exceeds 5 minutes."
+    required: false
+    default: "false"
+  parallel_fanout:
+    description: "Run PR-review sub-agents as parallel headless SDK calls from the action orchestrator instead of delegating fan-out to the root model. Cuts review-phase wall time when working correctly. Opt-in until fan-out is stable."
+    required: false
+    default: "false"
+  preflight_checks:
+    description: "Wait for all PR checks to pass before running AI review (review mode only)"
+    required: false
+    default: "true"
+  poll_interval:
+    description: "Seconds between polling for check statuses (used with preflight_checks)"
+    required: false
+    default: "10"
+  checks_timeout:
+    description: "Maximum seconds to wait for checks to complete (used with preflight_checks)"
+    required: false
+    default: "600"
+
+runs:
+  using: composite
+  steps:
+    # ── Validation ──
+
+    - name: Validate tokens
+      shell: bash
+      env:
+        BOT_TOKEN: ${{ inputs.bot_token }}
+        ANTHROPIC_KEY: ${{ inputs.anthropic_api_key }}
+        CLAUDE_TOKEN: ${{ inputs.claude_oauth_token }}
+      run: |
+        echo "bot_token: ${#BOT_TOKEN} chars"
+        echo "anthropic_api_key: ${#ANTHROPIC_KEY} chars"
+        echo "claude_oauth_token: ${#CLAUDE_TOKEN} chars"
+
+        if [[ -z "$BOT_TOKEN" ]]; then
+          echo "::error::bot_token is empty"
+          exit 1
+        fi
+
+        if [[ -z "$ANTHROPIC_KEY" && -z "$CLAUDE_TOKEN" ]]; then
+          echo "::error::Either anthropic_api_key or claude_oauth_token must be provided"
+          exit 1
+        fi
+
+    # ── Context detection ──
+
+    - name: Detect context
+      id: ctx
+      shell: bash
+      env:
+        INPUT_REACT_TO_COMMENTS: ${{ inputs.react_to_comments }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        INPUT_PR_HEAD_SHA: ${{ inputs.pr_head_sha }}
+        INPUT_COMMENT_ID: ${{ inputs.comment_id }}
+        INPUT_COMMENT_BODY: ${{ inputs.comment_body }}
+        INPUT_COMMENT_PATH: ${{ inputs.comment_path }}
+        INPUT_COMMENT_LINE: ${{ inputs.comment_line }}
+        INPUT_REVIEWER: ${{ inputs.reviewer }}
+        INPUT_BOT_USERNAME: ${{ inputs.bot_username }}
+        EVENT_NAME: ${{ github.event_name }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        EVENT_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        EVENT_PR_DRAFT: ${{ github.event.pull_request.draft }}
+        EVENT_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        EVENT_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        EVENT_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+        EVENT_COMMENT_ID: ${{ github.event.comment.id }}
+        EVENT_COMMENT_PATH: ${{ github.event.comment.path }}
+        EVENT_COMMENT_LINE: ${{ github.event.comment.original_line || github.event.comment.line }}
+        EVENT_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+        EVENT_COMMENT_IN_REPLY_TO_ID: ${{ github.event.comment.in_reply_to_id }}
+        EVENT_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || 'false' }}
+        COMMENT_BODY_RAW: ${{ github.event.comment.body }}
+        EVENT_REVIEW_ID: ${{ github.event.review.id }}
+        EVENT_REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+        REVIEW_BODY_RAW: ${{ github.event.review.body }}
+        EVENT_SENDER: ${{ github.event.sender.login }}
+        GH_TOKEN: ${{ inputs.bot_token }}
+      run: |
+        # Skip draft PRs (covers pull_request and pull_request_review_comment events)
+        if [[ "$EVENT_PR_DRAFT" == "true" ]]; then
+          echo "Skipping: draft PR"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Skip draft PRs for issue_comment events (draft status not in payload)
+        if [[ "$EVENT_NAME" == "issue_comment" && "$EVENT_IS_PR_COMMENT" == "true" ]]; then
+          if [[ "$(gh pr view "$EVENT_ISSUE_NUMBER" --json isDraft --jq '.isDraft' 2>/dev/null)" == "true" ]]; then
+            echo "Skipping: draft PR"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        fi
+
+        # Skip release PRs
+        if [[ "$EVENT_NAME" == "pull_request" && "$EVENT_PR_HEAD_REF" =~ ^(release-|delivery-) ]]; then
+          echo "Skipping: release/delivery branch ($EVENT_PR_HEAD_REF)"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Skip CI-author PRs labeled ci-skip-review (bot_username input, falls back to reviewer)
+        if [[ "$EVENT_NAME" == "pull_request" && "$EVENT_PR_AUTHOR" == "${INPUT_BOT_USERNAME:-$INPUT_REVIEWER}" && ",$EVENT_PR_LABELS," == *",ci-skip-review,"* ]]; then
+          echo "Skipping: ci-skip-review PR by $EVENT_PR_AUTHOR"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Skip dependabot PRs
+        if [[ "$EVENT_NAME" == "pull_request" && "$EVENT_PR_AUTHOR" == "dependabot[bot]" ]]; then
+          echo "Skipping: dependabot PR"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # When react_to_comments is disabled, pass through explicit inputs
+        if [[ "$INPUT_REACT_TO_COMMENTS" != "true" ]]; then
+          echo "mode=${INPUT_MODE}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${INPUT_PR_NUMBER:-${EVENT_PR_NUMBER:-$EVENT_ISSUE_NUMBER}}" >> "$GITHUB_OUTPUT"
+          echo "pr_head_sha=${INPUT_PR_HEAD_SHA:-$EVENT_PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "comment_id=${INPUT_COMMENT_ID}" >> "$GITHUB_OUTPUT"
+          echo "comment_path=${INPUT_COMMENT_PATH}" >> "$GITHUB_OUTPUT"
+          echo "comment_line=${INPUT_COMMENT_LINE}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+          delimiter="$(openssl rand -hex 16)"
+          {
+            echo "comment_body<<${delimiter}"
+            echo "$INPUT_COMMENT_BODY"
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+          exit 0
+        fi
+
+        # Auto-detection: pull_request event → review mode
+        if [[ "$EVENT_NAME" == "pull_request" ]]; then
+          echo "mode=review" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${EVENT_PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "pr_head_sha=${EVENT_PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Skip events triggered by the bot itself (prevents infinite loops)
+        if [[ "$EVENT_SENDER" == "$INPUT_REVIEWER" ]]; then
+          echo "Skipping: event triggered by bot ($EVENT_SENDER)"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Skip unsupported events early
+        # Note: pull_request_review is intentionally excluded — it causes
+        # concurrency group collisions that cancel in-progress review runs.
+        # Use pull_request_review_comment for inline reply reactions instead.
+        if [[ "$EVENT_NAME" != "issue_comment" && \
+              "$EVENT_NAME" != "pull_request_review_comment" ]]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Auto-detection: comment/review events → validate and extract
+        EFFECTIVE_AUTHOR="${EVENT_COMMENT_AUTHOR:-$EVENT_REVIEW_AUTHOR}"
+        EFFECTIVE_BODY="${COMMENT_BODY_RAW:-$REVIEW_BODY_RAW}"
+        EFFECTIVE_ID="${EVENT_COMMENT_ID:-$EVENT_REVIEW_ID}"
+
+        if [[ "$EFFECTIVE_AUTHOR" == "$INPUT_REVIEWER" ]]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Bypass the @mention requirement when replying inside a review thread
+        # whose root comment was authored by the bot — no mention needed to keep
+        # the conversation going.
+        BOT_IDENTITY="${INPUT_BOT_USERNAME:-$INPUT_REVIEWER}"
+        BOT_IN_THREAD="false"
+        if [[ "$EVENT_NAME" == "pull_request_review_comment" \
+              && "$EVENT_COMMENT_IN_REPLY_TO_ID" =~ ^[0-9]+$ \
+              && "$BOT_IDENTITY" =~ ^[A-Za-z0-9_-]+$ ]]; then
+          PARENT_AUTHOR=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/comments/${EVENT_COMMENT_IN_REPLY_TO_ID}" \
+            --jq '.user.login' 2>/dev/null) || {
+            echo "::warning::Failed to fetch parent comment ${EVENT_COMMENT_IN_REPLY_TO_ID}"
+            PARENT_AUTHOR=""
+          }
+          if [[ "$PARENT_AUTHOR" == "$BOT_IDENTITY" ]]; then
+            BOT_IN_THREAD="true"
+            echo "Bot authored parent comment — bypassing mention requirement"
+          fi
+        fi
+
+        if [[ "$EFFECTIVE_BODY" != *"@${INPUT_REVIEWER}"* && "$BOT_IN_THREAD" != "true" ]]; then
+          echo "Skipping: comment does not mention ${INPUT_REVIEWER} and bot is not in thread"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "$EVENT_NAME" == "issue_comment" && "$EVENT_IS_PR_COMMENT" != "true" ]]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Atomic claim: add eyes reaction to prevent duplicate processing.
+        # GitHub returns 201 for new reactions, 200 if already exists from same user.
+        if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+          REACTION_URL="repos/${GITHUB_REPOSITORY}/issues/comments/${EFFECTIVE_ID}/reactions"
+        else
+          REACTION_URL="repos/${GITHUB_REPOSITORY}/pulls/comments/${EFFECTIVE_ID}/reactions"
+        fi
+
+        CLAIM_RAW=$(gh api "$REACTION_URL" \
+          --method POST \
+          --field content=eyes \
+          --include 2>/dev/null) || true
+        CLAIM_RESPONSE="${CLAIM_RAW%%$'\n'*}"
+
+        if [[ "$CLAIM_RESPONSE" == *"200"* ]]; then
+          echo "Skipping: comment already claimed by another workflow run"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "mode=react" >> "$GITHUB_OUTPUT"
+        echo "skip=false" >> "$GITHUB_OUTPUT"
+
+        if [[ -n "$EVENT_ISSUE_NUMBER" ]]; then
+          echo "pr_number=${EVENT_ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+        else
+          echo "pr_number=${EVENT_PR_NUMBER}" >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "comment_id=${EFFECTIVE_ID}" >> "$GITHUB_OUTPUT"
+        echo "comment_path=${EVENT_COMMENT_PATH}" >> "$GITHUB_OUTPUT"
+        echo "comment_line=${EVENT_COMMENT_LINE}" >> "$GITHUB_OUTPUT"
+
+        delimiter="$(openssl rand -hex 16)"
+        {
+          echo "comment_body<<${delimiter}"
+          echo "$EFFECTIVE_BODY"
+          echo "${delimiter}"
+        } >> "$GITHUB_OUTPUT"
+
+    # ── Shared steps ──
+
+    - name: Resolve PR head SHA
+      id: resolve-sha
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'react'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.bot_token }}
+      run: |
+        echo "sha=$(gh pr view ${{ steps.ctx.outputs.pr_number }} --json headRefOid --jq '.headRefOid')" >> "$GITHUB_OUTPUT"
+
+    - name: Checkout repository
+      if: steps.ctx.outputs.skip != 'true'
+      uses: actions/checkout@v6
+      with:
+        # Depth 20: lets sub-agent git history walks (HEAD~N) succeed without paying for a full clone.
+        fetch-depth: 20
+        ref: ${{ steps.ctx.outputs.mode == 'react' && steps.resolve-sha.outputs.sha || steps.ctx.outputs.pr_head_sha }}
+
+    - name: Setup Bun
+      if: steps.ctx.outputs.skip != 'true'
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      with:
+        bun-version: 1.x
+
+    - name: Write MCP config
+      id: mcp
+      if: steps.ctx.outputs.skip != 'true' && inputs.mcp_config != ''
+      shell: bash
+      env:
+        MCP_CONFIG: ${{ inputs.mcp_config }}
+      run: |
+        echo "$MCP_CONFIG" > "$RUNNER_TEMP/mcp-config.json"
+        echo "path=$RUNNER_TEMP/mcp-config.json" >> "$GITHUB_OUTPUT"
+
+    # ── Claude Code setup ──
+
+    - name: Install action dependencies
+      if: steps.ctx.outputs.skip != 'true'
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      run: bun install --frozen-lockfile --filter @code-assistants/code-review-action
+
+    - name: Resolve plugin directory
+      id: plugin
+      if: steps.ctx.outputs.skip != 'true'
+      shell: bash
+      run: |
+        echo "dir=${{ github.action_path }}/../../../claude-plugins/autopilot" >> "$GITHUB_OUTPUT"
+
+    # ── PR help footer ──
+
+    - name: Update PR help footer
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'review'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.bot_token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+        HELP_ID: code-review-action
+        HELP_TEXT: |
+          - `@${{ inputs.reviewer }} <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
+      run: bun run "${{ github.action_path }}/src/updatePrFooter.ts"
+
+    # ── Review mode ──
+
+    - name: Force AI reviewer
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'review'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.bot_token }}
+        REVIEWER: ${{ inputs.reviewer }}
+        PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+      run: |
+        ALREADY_REVIEWER=$(gh pr view "$PR_NUMBER" --json reviewRequests,latestReviews --jq \
+          "[(.reviewRequests[]?.login), (.latestReviews[]?.author.login)] | any(. == \"$REVIEWER\")")
+        if [[ "$ALREADY_REVIEWER" != "true" ]]; then
+          gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER" || true
+        fi
+
+    - name: Get PR author
+      id: pr
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'review'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.bot_token }}
+      run: |
+        echo "author=$(gh pr view ${{ steps.ctx.outputs.pr_number }} --json author --jq '.author.login')" >> "$GITHUB_OUTPUT"
+
+    - name: Preflight PR checks
+      id: preflight
+      if: >-
+        steps.ctx.outputs.skip != 'true'
+        && steps.ctx.outputs.mode == 'review'
+        && inputs.preflight_checks == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.bot_token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+        REVIEWER: ${{ inputs.reviewer }}
+        PR_HEAD_SHA: ${{ steps.ctx.outputs.pr_head_sha }}
+        JOB_NAME: ${{ github.job }}
+        POLL_INTERVAL: ${{ inputs.poll_interval }}
+        CHECKS_TIMEOUT: ${{ inputs.checks_timeout }}
+        PR_AUTHOR: ${{ steps.pr.outputs.author }}
+      run: bun run "${{ github.action_path }}/src/preflightChecks.ts"
+
+    - name: Code Review
+      id: review
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'review' && steps.preflight.outputs.skip_review != 'true'
+      continue-on-error: true
+      shell: bash
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_oauth_token }}
+        GH_TOKEN: ${{ inputs.bot_token }}
+        CLAUDE_PROMPT: |
+          /autopilot:pr-review REPO: ${{ github.repository }} PR_NUMBER: ${{ steps.ctx.outputs.pr_number }} REVIEWER: ${{ inputs.reviewer }} PR_AUTHOR: ${{ steps.pr.outputs.author }}
+        CLAUDE_MODEL: ${{ inputs.model }}
+        CLAUDE_ALLOWED_TOOLS: "Bash(gh:*),mcp__repomix__*,mcp__context7__*,mcp__Ref__*,mcp__exa__*,mcp__perplexity__*,Read,Glob,Grep"
+        CLAUDE_DISALLOWED_TOOLS: "Bash(gh pr review:*),Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(gh api:*)"
+        CLAUDE_JSON_SCHEMA: '{"type":"object","properties":{"verdict":{"type":"string","enum":["approve","requestChanges","comment"]},"reviewComment":{"type":"string"},"inlineComments":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"line":{"type":"integer"},"body":{"type":"string"}},"required":["path","line","body"]}}},"required":["verdict","reviewComment"]}'
+        CLAUDE_PLUGIN_DIR: ${{ steps.plugin.outputs.dir }}
+        CLAUDE_MCP_CONFIG: ${{ steps.mcp.outputs.path }}
+        CLAUDE_SETTINGS: ${{ inputs.settings }}
+        EXECUTION_OUTPUT_FILE: ${{ runner.temp }}/claude-execution-output.json
+        LOG_LEVEL: ${{ inputs.debug_logs == 'true' && 'debug' || 'info' }}
+        PARALLEL_FANOUT: ${{ inputs.parallel_fanout }}
+        PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+      run: bun run "${{ github.action_path }}/src/runClaude.ts"
+
+    - name: Submit Review
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'review' && steps.preflight.outputs.skip_review != 'true' && always() && (steps.review.outcome == 'success' || steps.review.outcome == 'failure')
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.bot_token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+        REVIEWER: ${{ inputs.reviewer }}
+        STRUCTURED_OUTPUT: ${{ steps.review.outputs.structured_output }}
+        EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
+        PR_HEAD_SHA: ${{ steps.ctx.outputs.pr_head_sha }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      run: bun run "${{ github.action_path }}/src/submitReview.ts"
+
+    - name: Upload review execution artifact
+      if: >-
+        steps.ctx.outputs.skip != 'true'
+        && steps.ctx.outputs.mode == 'review'
+        && always()
+        && (steps.review.outcome == 'failure' || inputs.debug_logs == 'true' || steps.review.outputs.long_run == 'true')
+      uses: actions/upload-artifact@v7
+      with:
+        name: claude-execution-${{ steps.ctx.outputs.pr_number }}-${{ github.run_id }}-${{ github.run_attempt }}
+        path: ${{ runner.temp }}/claude-execution-output.json
+        retention-days: 14
+        if-no-files-found: ignore
+
+    # ── React mode ──
+
+    - name: React to Comment
+      id: reaction
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'react'
+      continue-on-error: true
+      shell: bash
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_oauth_token }}
+        GH_TOKEN: ${{ inputs.bot_token }}
+        CLAUDE_PROMPT: |
+          /autopilot:pr-answer REPO: ${{ github.repository }} PR_NUMBER: ${{ steps.ctx.outputs.pr_number }} REVIEWER: ${{ inputs.reviewer }} COMMENT_BODY: ${{ steps.ctx.outputs.comment_body }} COMMENT_PATH: ${{ steps.ctx.outputs.comment_path }} COMMENT_LINE: ${{ steps.ctx.outputs.comment_line }}
+        CLAUDE_MODEL: ${{ inputs.model }}
+        CLAUDE_ALLOWED_TOOLS: "Bash(gh:*),mcp__repomix__*,mcp__context7__*,mcp__Ref__*,mcp__exa__*,mcp__perplexity__*,Read,Glob,Grep"
+        CLAUDE_DISALLOWED_TOOLS: "Bash(gh pr review:*),Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(gh api:*)"
+        CLAUDE_JSON_SCHEMA: '{"type":"object","properties":{"reply":{"type":"string"},"resolveComments":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"line":{"type":"integer"}},"required":["path","line"]}},"updatedVerdict":{"type":["string","null"],"enum":["approve","requestChanges","comment",null]},"updatedReviewComment":{"type":["string","null"]}},"required":["reply"]}'
+        CLAUDE_PLUGIN_DIR: ${{ steps.plugin.outputs.dir }}
+        CLAUDE_MCP_CONFIG: ${{ steps.mcp.outputs.path }}
+        CLAUDE_SETTINGS: ${{ inputs.settings }}
+        EXECUTION_OUTPUT_FILE: ${{ runner.temp }}/claude-reaction-output.json
+        LOG_LEVEL: ${{ inputs.debug_logs == 'true' && 'debug' || 'info' }}
+      run: bun run "${{ github.action_path }}/src/runClaude.ts"
+
+    - name: Submit Reaction
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'react' && always() && (steps.reaction.outcome == 'success' || steps.reaction.outcome == 'failure')
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.bot_token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+        REVIEWER: ${{ inputs.reviewer }}
+        COMMENT_ID: ${{ steps.ctx.outputs.comment_id }}
+        COMMENT_PATH: ${{ steps.ctx.outputs.comment_path }}
+        STRUCTURED_OUTPUT: ${{ steps.reaction.outputs.structured_output }}
+        EXECUTION_FILE: ${{ steps.reaction.outputs.execution_file }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      run: bun run "${{ github.action_path }}/src/reactToComment.ts"
+
+    - name: Upload reaction execution artifact
+      if: >-
+        steps.ctx.outputs.skip != 'true'
+        && steps.ctx.outputs.mode == 'react'
+        && always()
+        && (steps.reaction.outcome == 'failure' || inputs.debug_logs == 'true' || steps.reaction.outputs.long_run == 'true')
+      uses: actions/upload-artifact@v7
+      with:
+        name: claude-reaction-${{ steps.ctx.outputs.pr_number }}-${{ github.run_id }}-${{ github.run_attempt }}
+        path: ${{ runner.temp }}/claude-reaction-output.json
+        retention-days: 14
+        if-no-files-found: ignore

--- a/.github/actions/code-review-action/package.json
+++ b/.github/actions/code-review-action/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@code-assistants/code-review-action",
+  "version": "0.0.0",
+  "description": "Composite GitHub Action that runs AI code review on pull requests via Claude Code.",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "clean": "rm -rf node_modules .turbo"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.2.126",
+    "@octokit/rest": "22.0.1",
+    "pino": "10.3.1",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "typescript": "6.0.3"
+  }
+}

--- a/.github/actions/code-review-action/src/github/githubReview.ts
+++ b/.github/actions/code-review-action/src/github/githubReview.ts
@@ -1,0 +1,301 @@
+/**
+ * Shared GitHub review operations for PR review submission and comment reaction scripts.
+ * Provides review thread fetching, resolution, and Octokit initialization.
+ *
+ * @example
+ * import { fetchReviewThreads, resolveThread, parseRepoEnv } from "./github/githubReview.ts";
+ */
+import { Octokit } from "@octokit/rest";
+
+/** GitHub PR review event type */
+export type ReviewEvent = "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
+
+/** Flattened review thread from GraphQL response */
+export interface ReviewThread {
+  id: string;
+  path: string;
+  line: number | null;
+  isOutdated: boolean;
+  isResolved: boolean;
+  firstCommentAuthor: string | null;
+  firstCommentBody: string;
+  firstCommentReviewId: string | null;
+}
+
+/** Parsed repository environment configuration */
+export interface RepoEnv {
+  octokit: Octokit;
+  owner: string;
+  repoName: string;
+  pullNumber: number;
+  reviewer: string;
+}
+
+/** GraphQL response shape for review threads query */
+interface ReviewThreadsResponse {
+  repository: {
+    pullRequest: {
+      reviewThreads: {
+        nodes: Array<{
+          id: string;
+          path: string;
+          line: number | null;
+          isOutdated: boolean;
+          isResolved: boolean;
+          comments: {
+            nodes: Array<{
+              author: { login: string } | null;
+              body: string;
+              pullRequestReview: { id: string } | null;
+            }>;
+          };
+        }>;
+      };
+    };
+  };
+}
+
+/** Maps verdict string to GitHub review event */
+export const verdictToEvent: Record<string, ReviewEvent> = {
+  approve: "APPROVE",
+  requestChanges: "REQUEST_CHANGES",
+  comment: "COMMENT",
+};
+
+/**
+ * Parse and validate required environment variables, initialize Octokit.
+ * Throws if GH_TOKEN, REPO, PR_NUMBER, or REVIEWER are missing or invalid.
+ */
+export function parseRepoEnv(): RepoEnv {
+  const token = process.env.GH_TOKEN;
+  const repo = process.env.REPO;
+  const prNumber = process.env.PR_NUMBER;
+  const reviewer = process.env.REVIEWER;
+
+  if (!token || !repo || !prNumber || !reviewer) {
+    throw new Error("Missing required environment variables: GH_TOKEN, REPO, PR_NUMBER, REVIEWER");
+  }
+
+  const [owner, repoName] = repo.split("/");
+  if (!owner || !repoName) {
+    throw new Error(`Invalid REPO format: ${repo}. Expected owner/repo`);
+  }
+
+  return {
+    octokit: new Octokit({ auth: token }),
+    owner,
+    repoName,
+    pullNumber: Number(prNumber),
+    reviewer,
+  };
+}
+
+/**
+ * Fetch all review threads for a PR via GraphQL.
+ * Returns flattened thread objects with first comment metadata.
+ */
+export async function fetchReviewThreads(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number
+): Promise<ReviewThread[]> {
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              path
+              line
+              isOutdated
+              isResolved
+              comments(first: 1) {
+                nodes {
+                  author { login }
+                  body
+                  pullRequestReview { id }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await octokit.graphql<ReviewThreadsResponse>(query, {
+    owner,
+    repo,
+    number: pullNumber,
+  });
+
+  return result.repository.pullRequest.reviewThreads.nodes.map((node) => ({
+    id: node.id,
+    path: node.path,
+    line: node.line,
+    isOutdated: node.isOutdated,
+    isResolved: node.isResolved,
+    firstCommentAuthor: node.comments.nodes[0]?.author?.login ?? null,
+    firstCommentBody: node.comments.nodes[0]?.body ?? "",
+    firstCommentReviewId: node.comments.nodes[0]?.pullRequestReview?.id ?? null,
+  }));
+}
+
+/**
+ * Resolve a single review thread by its GraphQL node ID.
+ */
+export async function resolveThread(octokit: Octokit, threadId: string): Promise<void> {
+  await octokit.graphql(
+    `
+      mutation($threadId: ID!) {
+        resolveReviewThread(input: { threadId: $threadId }) {
+          thread { isResolved }
+        }
+      }
+    `,
+    { threadId }
+  );
+}
+
+/**
+ * Unresolve a single review thread by its GraphQL node ID.
+ * Used to reopen threads that GitHub auto-resolves on APPROVE reviews.
+ */
+export async function unresolveThread(octokit: Octokit, threadId: string): Promise<void> {
+  await octokit.graphql(
+    `
+      mutation($threadId: ID!) {
+        unresolveReviewThread(input: { threadId: $threadId }) {
+          thread { isResolved }
+        }
+      }
+    `,
+    { threadId }
+  );
+}
+
+/**
+ * Delete all pending reviews for a PR to avoid GitHub's single-pending-review limit.
+ */
+export async function deletePendingReviews(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number
+): Promise<void> {
+  const { data: reviews } = await octokit.rest.pulls.listReviews({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+
+  const pendingReviews = reviews.filter((r) => r.state === "PENDING");
+
+  for (const review of pendingReviews) {
+    console.log(`Deleting pending review ${review.id}...`);
+    await octokit.rest.pulls.deletePendingReview({
+      owner,
+      repo,
+      pull_number: pullNumber,
+      review_id: review.id,
+    });
+  }
+}
+
+/**
+ * Read Claude's plain text result from the execution output file.
+ * Falls back gracefully: returns null if file is missing, unreadable, or lacks a result message.
+ *
+ * @param filePath - Path to the execution output JSON file
+ * @see https://docs.anthropic.com/en/docs/agent-sdk/typescript - SDKResultMessage
+ */
+export async function readExecutionResult(filePath: string | undefined): Promise<string | null> {
+  if (!filePath) {
+    return null;
+  }
+
+  try {
+    const data: unknown = await Bun.file(filePath).json();
+    const messages = Array.isArray(data) ? data : [data];
+    const resultMessage = messages.findLast(
+      (m) => typeof m === "object" && m !== null && (m as Record<string, unknown>).type === "result"
+    ) as Record<string, unknown> | undefined;
+    const result = resultMessage?.result;
+    return typeof result === "string" ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if the bot already submitted a review on the current PR head commit.
+ * Detects reviews submitted during Claude's execution via MCP tools when structured output is missing.
+ *
+ * @param headSha - Current PR head commit SHA for commit-level matching
+ */
+export async function hasRecentBotReview(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  reviewer: string,
+  headSha?: string
+): Promise<boolean> {
+  const { data: reviews } = await octokit.rest.pulls.listReviews({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+
+  const lastBotReview = reviews
+    .filter((r) => r.user?.login === reviewer && r.state !== "PENDING")
+    .at(-1);
+
+  if (!lastBotReview) {
+    return false;
+  }
+
+  if (headSha) {
+    return lastBotReview.commit_id === headSha;
+  }
+
+  return true;
+}
+
+/**
+ * Check if the bot already replied to a specific comment.
+ * Detects replies submitted during Claude's execution via MCP tools when structured output is missing.
+ */
+export async function hasRecentBotReply(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  reviewer: string,
+  commentId?: string,
+  commentPath?: string
+): Promise<boolean> {
+  const since = new Date(Date.now() - 15 * 60 * 1000).toISOString();
+
+  if (commentPath && commentId) {
+    const { data: comments } = await octokit.rest.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number: pullNumber,
+      since,
+    });
+    return comments.some(
+      (c) => c.in_reply_to_id === Number(commentId) && c.user?.login === reviewer
+    );
+  }
+
+  const { data: comments } = await octokit.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: pullNumber,
+    since,
+  });
+  return comments.some((c) => c.user?.login === reviewer);
+}

--- a/.github/actions/code-review-action/src/logClaudeMessage.test.ts
+++ b/.github/actions/code-review-action/src/logClaudeMessage.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for scripts/logClaudeMessage.ts — truncation and per-message dispatch.
+ * Captures log rows via a spy logger instead of reading stdout.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { logMessage, textTruncate, toolTruncate, truncate } from "./logClaudeMessage.ts";
+
+interface LogRow {
+  level: "info" | "debug";
+  obj: Record<string, unknown>;
+  msg: string;
+}
+
+function spyLogger(): { rows: LogRow[]; log: unknown } {
+  const rows: LogRow[] = [];
+  const record = (level: LogRow["level"]) => (obj: Record<string, unknown>, msg: string) => {
+    rows.push({ level, obj, msg });
+  };
+  return {
+    rows,
+    log: { info: record("info"), debug: record("debug") },
+  };
+}
+
+describe("truncate", () => {
+  test("returns empty string for null/undefined", () => {
+    expect(truncate(null, 100)).toBe("");
+    expect(truncate(undefined, 100)).toBe("");
+  });
+
+  test("passes short strings through unchanged", () => {
+    expect(truncate("hello", 100)).toBe("hello");
+  });
+
+  test("stringifies non-string values", () => {
+    expect(truncate({ a: 1 }, 100)).toBe('{"a":1}');
+  });
+
+  test("cuts long strings with an ellipsis", () => {
+    expect(truncate("abcdef", 3)).toBe("abc…");
+  });
+
+  test("leaves strings exactly at the limit unchanged", () => {
+    expect(truncate("abc", 3)).toBe("abc");
+  });
+
+  test("exports the textTruncate and toolTruncate constants for callers", () => {
+    expect(textTruncate).toBeGreaterThan(toolTruncate);
+  });
+});
+
+describe("logMessage", () => {
+  test("system init → single session_start info row", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "system",
+        subtype: "init",
+        session_id: "sess-1",
+        model: "claude-sonnet-4-6",
+        permissionMode: "bypassPermissions",
+        cwd: "/tmp",
+        tools: ["Read", "Bash"],
+        mcp_servers: [{ name: "ctx", status: "ok" }],
+      } as never
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.level).toBe("info");
+    expect(rows[0]?.obj.event).toBe("session_start");
+    expect(rows[0]?.obj.session_id).toBe("sess-1");
+    expect(rows[0]?.obj.model).toBe("claude-sonnet-4-6");
+    expect(rows[0]?.obj.parent_tool_use_id).toBe("root");
+  });
+
+  test("assistant tool_use block → tool_use info row with ids and input", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "assistant",
+        session_id: "sess-1",
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: "tool_use", id: "toolu_1", name: "Read", input: { file_path: "/x" } }],
+          usage: null,
+          model: "claude-sonnet-4-6",
+        },
+      } as never
+    );
+
+    const toolRow = rows.find((r) => r.obj.event === "tool_use");
+    expect(toolRow?.level).toBe("info");
+    expect(toolRow?.obj.tool_name).toBe("Read");
+    expect(toolRow?.obj.tool_use_id).toBe("toolu_1");
+    expect(toolRow?.obj.parent_tool_use_id).toBe("root");
+    expect(toolRow?.obj.subagent_type).toBeUndefined();
+    expect(toolRow?.obj.input).toContain("/x");
+  });
+
+  test("Task tool_use carries subagent_type", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "assistant",
+        session_id: "sess-1",
+        parent_tool_use_id: null,
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_task",
+              name: "Task",
+              input: { subagent_type: "code-reviewer", prompt: "review" },
+            },
+          ],
+          usage: null,
+          model: "claude-sonnet-4-6",
+        },
+      } as never
+    );
+
+    const toolRow = rows.find((r) => r.obj.event === "tool_use");
+    expect(toolRow?.obj.tool_name).toBe("Task");
+    expect(toolRow?.obj.subagent_type).toBe("code-reviewer");
+  });
+
+  test("sub-agent assistant message retains parent_tool_use_id", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "assistant",
+        session_id: "sess-1",
+        parent_tool_use_id: "toolu_task",
+        message: {
+          content: [
+            { type: "tool_use", id: "toolu_child", name: "Grep", input: { pattern: "foo" } },
+          ],
+          usage: null,
+          model: "claude-sonnet-4-6",
+        },
+      } as never
+    );
+
+    const toolRow = rows.find((r) => r.obj.event === "tool_use");
+    expect(toolRow?.obj.parent_tool_use_id).toBe("toolu_task");
+    expect(toolRow?.obj.session_id).toBe("sess-1");
+  });
+
+  test("user tool_result → tool_result info row with is_error", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "user",
+        session_id: "sess-1",
+        parent_tool_use_id: "toolu_task",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_child",
+              content: "file contents",
+              is_error: false,
+            },
+          ],
+        },
+      } as never
+    );
+
+    const resultRow = rows.find((r) => r.obj.event === "tool_result");
+    expect(resultRow?.level).toBe("info");
+    expect(resultRow?.obj.tool_use_id).toBe("toolu_child");
+    expect(resultRow?.obj.is_error).toBe(false);
+    expect(resultRow?.obj.parent_tool_use_id).toBe("toolu_task");
+  });
+
+  test("result success → session_end info row with duration and cost", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "sess-1",
+        duration_ms: 12345,
+        duration_api_ms: 9999,
+        num_turns: 7,
+        total_cost_usd: 0.1234,
+        usage: { input_tokens: 100, output_tokens: 200 },
+        modelUsage: { "claude-sonnet-4-6": { input_tokens: 100 } },
+        permission_denials: [],
+        is_error: false,
+        result: "done",
+        stop_reason: "end_turn",
+      } as never
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.level).toBe("info");
+    expect(rows[0]?.obj.event).toBe("session_end");
+    expect(rows[0]?.obj.subtype).toBe("success");
+    expect(rows[0]?.obj.duration_ms).toBe(12345);
+    expect(rows[0]?.obj.total_cost_usd).toBe(0.1234);
+    expect(rows[0]?.obj.num_permission_denials).toBe(0);
+    expect(rows[0]?.obj.errors).toBeUndefined();
+  });
+
+  test("result error → session_end row with errors array", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "result",
+        subtype: "error_during_execution",
+        session_id: "sess-1",
+        duration_ms: 1000,
+        duration_api_ms: 800,
+        num_turns: 1,
+        total_cost_usd: 0,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        modelUsage: {},
+        permission_denials: [],
+        errors: ["boom"],
+        is_error: true,
+        stop_reason: null,
+      } as never
+    );
+
+    expect(rows[0]?.obj.subtype).toBe("error_during_execution");
+    expect(rows[0]?.obj.errors).toEqual(["boom"]);
+  });
+
+  test("thinking block goes to debug level", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "assistant",
+        session_id: "sess-1",
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: "thinking", thinking: "pondering", signature: "sig" }],
+          usage: null,
+          model: "claude-sonnet-4-6",
+        },
+      } as never
+    );
+
+    const thinkingRow = rows.find((r) => r.obj.event === "thinking");
+    expect(thinkingRow?.level).toBe("debug");
+    expect(thinkingRow?.obj.text).toBe("pondering");
+  });
+
+  test("assistant text block emits assistant_text debug row", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "assistant",
+        session_id: "sess-1",
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: "text", text: "hello from claude", citations: null }],
+          usage: null,
+          model: "claude-sonnet-4-6",
+        },
+      } as never
+    );
+
+    const textRow = rows.find((r) => r.obj.event === "assistant_text");
+    expect(textRow?.level).toBe("debug");
+    expect(textRow?.obj.text).toBe("hello from claude");
+    expect(textRow?.obj.parent_tool_use_id).toBe("root");
+  });
+
+  test("non-null usage emits assistant_usage debug row with model", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "assistant",
+        session_id: "sess-1",
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: "text", text: "hi", citations: null }],
+          usage: { input_tokens: 42, output_tokens: 7 },
+          model: "claude-sonnet-4-6",
+        },
+      } as never
+    );
+
+    const usageRow = rows.find((r) => r.obj.event === "assistant_usage");
+    expect(usageRow?.level).toBe("debug");
+    expect(usageRow?.obj.model).toBe("claude-sonnet-4-6");
+    expect(usageRow?.obj.usage).toEqual({ input_tokens: 42, output_tokens: 7 });
+  });
+
+  test("user message with string content emits no rows", () => {
+    const { rows, log } = spyLogger();
+    logMessage(
+      log as never,
+      {
+        type: "user",
+        session_id: "sess-1",
+        parent_tool_use_id: null,
+        message: { content: "just a plain string prompt" },
+      } as never
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  test("unknown message type falls back to a debug row", () => {
+    const { rows, log } = spyLogger();
+    logMessage(log as never, { type: "status", session_id: "sess-1" } as never);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.level).toBe("debug");
+    expect(rows[0]?.obj.event).toBe("message");
+    expect(rows[0]?.obj.type).toBe("status");
+  });
+});

--- a/.github/actions/code-review-action/src/logClaudeMessage.ts
+++ b/.github/actions/code-review-action/src/logClaudeMessage.ts
@@ -1,0 +1,223 @@
+/**
+ * Per-message structured logging for the Claude Agent SDK stream.
+ *
+ * Dispatches on `SDKMessage.type` and emits pino log rows that always carry
+ * `parent_tool_use_id` ("root" when null) and `session_id`, so trace lines
+ * from the ~12 parallel sub-agents spawned by `/autopilot:pr-review` remain
+ * filterable when the whole stream is interleaved into one GitHub step log.
+ *
+ * @example
+ * for await (const message of q) {
+ *   logMessage(log, message);
+ *   messages.push(message);
+ * }
+ *
+ * @see https://docs.anthropic.com/en/docs/agent-sdk/typescript - SDKMessage shape
+ */
+import type {
+  SDKAssistantMessage,
+  SDKMessage,
+  SDKResultMessage,
+  SDKSystemMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type pino from "pino";
+
+/** Max length for assistant text / thinking preview in debug logs. */
+export const textTruncate = 2048;
+
+/** Max length for tool input / tool result preview in info logs. */
+export const toolTruncate = 512;
+
+/**
+ * Shrink a value to a readable preview bounded by `max` characters.
+ *
+ * Strings pass through; anything else is JSON-stringified. Excess length is
+ * cut with a trailing ellipsis so consumers see the truncation unambiguously.
+ */
+export function truncate(value: unknown, max: number): string {
+  if (value === null || value === undefined) return "";
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  return str.length > max ? `${str.slice(0, max)}…` : str;
+}
+
+interface BaseContext {
+  parent_tool_use_id: string;
+  session_id: string | undefined;
+}
+
+function baseContext(message: SDKMessage): BaseContext {
+  const parent = "parent_tool_use_id" in message ? message.parent_tool_use_id : null;
+  const session = "session_id" in message ? message.session_id : undefined;
+  return {
+    parent_tool_use_id: parent ?? "root",
+    session_id: session,
+  };
+}
+
+interface BlockLike {
+  type?: string;
+}
+
+function blockType(block: unknown): string | undefined {
+  if (typeof block !== "object" || block === null) return undefined;
+  const t = (block as BlockLike).type;
+  return typeof t === "string" ? t : undefined;
+}
+
+interface ToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+interface ThinkingBlock {
+  type: "thinking";
+  thinking: string;
+}
+
+interface ToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content?: unknown;
+  is_error?: boolean;
+}
+
+function logToolUse(log: pino.Logger, ctx: BaseContext, block: ToolUseBlock): void {
+  const input =
+    typeof block.input === "object" && block.input !== null
+      ? (block.input as Record<string, unknown>)
+      : null;
+  const subagentType =
+    block.name === "Task" && input && typeof input.subagent_type === "string"
+      ? input.subagent_type
+      : undefined;
+  log.info(
+    {
+      ...ctx,
+      event: "tool_use",
+      tool_name: block.name,
+      tool_use_id: block.id,
+      subagent_type: subagentType,
+      input: truncate(block.input, toolTruncate),
+    },
+    `Tool call: ${block.name}`
+  );
+}
+
+function logAssistant(log: pino.Logger, message: SDKAssistantMessage): void {
+  const ctx = baseContext(message);
+  for (const block of message.message.content ?? []) {
+    const type = blockType(block);
+    if (type === "tool_use") {
+      logToolUse(log, ctx, block as ToolUseBlock);
+    } else if (type === "thinking") {
+      const { thinking } = block as ThinkingBlock;
+      log.debug(
+        { ...ctx, event: "thinking", text: truncate(thinking, textTruncate) },
+        "Assistant thinking."
+      );
+    } else if (type === "text") {
+      const { text } = block as TextBlock;
+      log.debug(
+        { ...ctx, event: "assistant_text", text: truncate(text, textTruncate) },
+        "Assistant text."
+      );
+    }
+  }
+  const { usage, model } = message.message;
+  if (usage) {
+    log.debug({ ...ctx, event: "assistant_usage", usage, model }, "Assistant usage.");
+  }
+}
+
+function logUser(log: pino.Logger, message: SDKUserMessage): void {
+  const ctx = baseContext(message);
+  const { content } = message.message;
+  if (typeof content === "string") return;
+  for (const block of content ?? []) {
+    if (blockType(block) !== "tool_result") continue;
+    const result = block as ToolResultBlock;
+    log.info(
+      {
+        ...ctx,
+        event: "tool_result",
+        tool_use_id: result.tool_use_id,
+        is_error: result.is_error ?? false,
+        content: truncate(result.content, toolTruncate),
+      },
+      "Tool result received."
+    );
+  }
+}
+
+function logSystemInit(log: pino.Logger, message: SDKSystemMessage): void {
+  log.info(
+    {
+      parent_tool_use_id: "root",
+      session_id: message.session_id,
+      event: "session_start",
+      model: message.model,
+      permission_mode: message.permissionMode,
+      cwd: message.cwd,
+      tool_count: message.tools.length,
+      mcp_server_count: message.mcp_servers.length,
+    },
+    "Claude session started."
+  );
+}
+
+function logResult(log: pino.Logger, message: SDKResultMessage): void {
+  const errors = message.subtype === "success" ? undefined : message.errors;
+  log.info(
+    {
+      parent_tool_use_id: "root",
+      session_id: message.session_id,
+      event: "session_end",
+      subtype: message.subtype,
+      duration_ms: message.duration_ms,
+      duration_api_ms: message.duration_api_ms,
+      num_turns: message.num_turns,
+      total_cost_usd: message.total_cost_usd,
+      usage: message.usage,
+      model_usage: message.modelUsage,
+      num_permission_denials: message.permission_denials.length,
+      errors,
+    },
+    "Claude session ended."
+  );
+}
+
+/**
+ * Dispatch a single SDK message to structured pino logs.
+ *
+ * Every emitted row carries `parent_tool_use_id` (defaulting to `"root"` when
+ * the SDK returns null) and `session_id`, so trace lines from all parallel
+ * sub-agents stay attributable when interleaved.
+ */
+export function logMessage(log: pino.Logger, message: SDKMessage): void {
+  if (message.type === "assistant") {
+    logAssistant(log, message);
+    return;
+  }
+  if (message.type === "user") {
+    logUser(log, message);
+    return;
+  }
+  if (message.type === "result") {
+    logResult(log, message);
+    return;
+  }
+  if (message.type === "system" && "subtype" in message && message.subtype === "init") {
+    logSystemInit(log, message);
+    return;
+  }
+  const ctx = baseContext(message);
+  log.debug({ ...ctx, event: "message", type: message.type }, "Stream message.");
+}

--- a/.github/actions/code-review-action/src/preflightChecks.ts
+++ b/.github/actions/code-review-action/src/preflightChecks.ts
@@ -1,0 +1,315 @@
+/**
+ * Preflight PR check status polling before AI code review.
+ * Polls GitHub Check Runs and Commit Statuses APIs until all sibling checks complete.
+ * Skips review and posts a comment if any check has failed or if polling times out.
+ *
+ * @example
+ * GH_TOKEN=xxx REPO=owner/repo PR_NUMBER=123 PR_HEAD_SHA=abc JOB_NAME=review POLL_INTERVAL=10 CHECKS_TIMEOUT=600 PR_AUTHOR=user bun run scripts/preflightChecks.ts
+ */
+import { appendFile } from "node:fs/promises";
+
+import type { Octokit } from "@octokit/rest";
+
+import { parseRepoEnv } from "./github/githubReview.ts";
+
+/** Aggregated check status result from both GitHub APIs */
+interface CheckResult {
+  allCompleted: boolean;
+  hasFailed: boolean;
+  failedNames: string[];
+  pendingNames: string[];
+}
+
+/** Outcome of the preflight polling loop */
+type PreflightOutcome =
+  | { status: "passed" }
+  | { status: "failed"; failedNames: string[] }
+  | { status: "timeout"; pendingNames: string[] };
+
+/** Preflight configuration parsed from environment */
+interface PreflightConfig {
+  octokit: Octokit;
+  owner: string;
+  repoName: string;
+  pullNumber: number;
+  reviewer: string;
+  headSha: string;
+  jobName: string;
+  pollIntervalMs: number;
+  timeoutMs: number;
+  prAuthor: string;
+}
+
+const failedConclusions = new Set(["failure", "timed_out"]);
+const failedStatuses = new Set(["failure", "error"]);
+
+/** Parse and validate preflight-specific environment variables. */
+function parsePreflightEnv(): PreflightConfig {
+  const { octokit, owner, repoName, pullNumber, reviewer } = parseRepoEnv();
+  const headSha = process.env.PR_HEAD_SHA;
+  const jobName = process.env.JOB_NAME;
+  const prAuthor = process.env.PR_AUTHOR ?? "there";
+
+  if (!headSha || !jobName) {
+    throw new Error("Missing required environment variables: PR_HEAD_SHA, JOB_NAME");
+  }
+
+  const rawInterval = Number(process.env.POLL_INTERVAL);
+  const pollIntervalMs =
+    (Number.isFinite(rawInterval) && rawInterval > 0 ? rawInterval : 10) * 1000;
+  const rawTimeout = Number(process.env.CHECKS_TIMEOUT);
+  const timeoutMs = (Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 600) * 1000;
+
+  return {
+    octokit,
+    owner,
+    repoName,
+    pullNumber,
+    reviewer,
+    headSha,
+    jobName,
+    pollIntervalMs,
+    timeoutMs,
+    prAuthor,
+  };
+}
+
+/**
+ * Normalize name for self-exclusion comparison.
+ * Strips non-alphanumeric characters so "code-review" matches "Code Review".
+ */
+function normalizeCheckName(name: string): string {
+  return name.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Deduplicate check runs by name, keeping only the most recent run per name.
+ * GitHub's Check Runs API returns all runs including superseded ones from previous pushes.
+ * Uses the auto-incrementing `id` field as the recency indicator.
+ */
+function deduplicateCheckRuns<T extends { id: number; name: string }>(runs: T[]): T[] {
+  const latestByName = new Map<string, T>();
+
+  for (const run of runs) {
+    const existing = latestByName.get(run.name);
+    if (!existing || run.id > existing.id) {
+      latestByName.set(run.name, run);
+    }
+  }
+
+  return [...latestByName.values()];
+}
+
+/**
+ * Fetch and aggregate check statuses from both Check Runs and Commit Status APIs.
+ * Excludes the current job's own check run by normalized name comparison.
+ */
+async function fetchCheckStatuses(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string,
+  jobName: string
+): Promise<CheckResult> {
+  const normalizedJobName = normalizeCheckName(jobName);
+
+  const [checkRuns, commitStatus] = await Promise.all([
+    octokit.paginate(octokit.rest.checks.listForRef, { owner, repo, ref, per_page: 100 }),
+    octokit.rest.repos.getCombinedStatusForRef({ owner, repo, ref }),
+  ]);
+
+  const allSiblingRuns = checkRuns.filter(
+    (run) => normalizeCheckName(run.name) !== normalizedJobName
+  );
+  const nonCancelledRuns = allSiblingRuns.filter((run) => run.conclusion !== "cancelled");
+  const siblingRuns = deduplicateCheckRuns(nonCancelledRuns);
+
+  const siblingNames = new Set(siblingRuns.map((run) => run.name));
+  const cancelledOnlyNames = [...new Set(allSiblingRuns.map((run) => run.name))].filter(
+    (name) => !siblingNames.has(name)
+  );
+
+  const pendingRuns = [
+    ...siblingRuns.filter((run) => run.status !== "completed").map((run) => run.name),
+    ...cancelledOnlyNames,
+  ];
+  const failedRuns = siblingRuns
+    .filter((run) => run.status === "completed" && failedConclusions.has(run.conclusion ?? ""))
+    .map((run) => run.name);
+
+  const pendingStatuses = commitStatus.data.statuses
+    .filter((s) => s.state === "pending")
+    .map((s) => s.context);
+  const failedCommitStatuses = commitStatus.data.statuses
+    .filter((s) => failedStatuses.has(s.state))
+    .map((s) => s.context);
+
+  const allPending = [...pendingRuns, ...pendingStatuses];
+  const allFailed = [...failedRuns, ...failedCommitStatuses];
+
+  return {
+    allCompleted: allPending.length === 0,
+    hasFailed: allFailed.length > 0,
+    failedNames: allFailed,
+    pendingNames: allPending,
+  };
+}
+
+/**
+ * Poll until all sibling checks complete or timeout is reached.
+ * Logs progress on each tick with pending check names and elapsed time.
+ */
+async function pollUntilComplete(config: PreflightConfig): Promise<PreflightOutcome> {
+  const { octokit, owner, repoName, headSha, jobName, pollIntervalMs, timeoutMs } = config;
+  let elapsed = 0;
+
+  while (elapsed < timeoutMs) {
+    const result = await fetchCheckStatuses(octokit, owner, repoName, headSha, jobName);
+
+    if (result.hasFailed) {
+      return { status: "failed", failedNames: result.failedNames };
+    }
+    if (result.allCompleted) {
+      return { status: "passed" };
+    }
+
+    const elapsedSec = Math.round(elapsed / 1000);
+    const timeoutSec = Math.round(timeoutMs / 1000);
+    console.log(
+      `Waiting for checks: ${result.pendingNames.join(", ")}... (${elapsedSec}s / ${timeoutSec}s)`
+    );
+
+    await Bun.sleep(pollIntervalMs);
+    elapsed += pollIntervalMs;
+  }
+
+  const finalResult = await fetchCheckStatuses(octokit, owner, repoName, headSha, jobName);
+
+  if (finalResult.hasFailed) {
+    return { status: "failed", failedNames: finalResult.failedNames };
+  }
+  if (finalResult.allCompleted) {
+    return { status: "passed" };
+  }
+
+  return { status: "timeout", pendingNames: finalResult.pendingNames };
+}
+
+/** Build sarcastic comment for failed checks. */
+function buildFailureComment(author: string, failedNames: string[]): string {
+  const list = failedNames.map((name) => `- ${name}`).join("\n");
+
+  return `@${author}, I see red flags everywhere 🚩
+
+These checks have failed:
+${list}
+
+Fix all of them before asking anybody to review. Or move your PR to draft. Do what your heart says 💅
+
+_Code Review skipped 😢_`;
+}
+
+/** Build comment for polling timeout. */
+function buildTimeoutComment(author: string, pendingNames: string[], timeoutMin: number): string {
+  const list = pendingNames.map((name) => `- ${name}`).join("\n");
+
+  return `@${author}, I've been waiting for your checks for ${timeoutMin} minutes and they still haven't finished ⏰
+
+Still pending:
+${list}
+
+I have better things to do than wait around. Fix your CI and re-request review when you're ready 💅
+
+_Code Review skipped 😢_`;
+}
+
+/** Normalize comment body for dedup comparison. */
+function normalizeBody(body: string): string {
+  return body.trim().replaceAll(/\s+/g, " ");
+}
+
+/**
+ * Post a skip comment to the PR with dedup check.
+ * Fetches recent bot comments and skips if the same comment already exists.
+ */
+async function postSkipComment(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  reviewer: string,
+  body: string
+): Promise<void> {
+  const { data: comments } = await octokit.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 5,
+    direction: "desc",
+  });
+
+  const lastBotComment = comments.find((c) => c.user?.login === reviewer);
+  if (lastBotComment && normalizeBody(lastBotComment.body ?? "") === normalizeBody(body)) {
+    console.log("✓ Skip comment already posted, skipping duplicate");
+    return;
+  }
+
+  await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body,
+  });
+  console.log("✓ Posted skip comment to PR");
+}
+
+/** Write output to GITHUB_OUTPUT file. */
+async function writeOutput(key: string, value: string): Promise<void> {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    await appendFile(outputFile, `${key}=${value}\n`);
+  }
+}
+
+// Main execution
+try {
+  const config = parsePreflightEnv();
+  console.log(
+    `Preflight: polling checks for ${config.headSha.slice(0, 7)} every ${config.pollIntervalMs / 1000}s (timeout: ${config.timeoutMs / 1000}s)`
+  );
+
+  const outcome = await pollUntilComplete(config);
+
+  if (outcome.status === "passed") {
+    console.log("✓ All checks passed, proceeding with review");
+    await writeOutput("skip_review", "false");
+  } else if (outcome.status === "failed") {
+    console.log(`✗ Failed checks: ${outcome.failedNames.join(", ")}`);
+    const comment = buildFailureComment(config.prAuthor, outcome.failedNames);
+    await postSkipComment(
+      config.octokit,
+      config.owner,
+      config.repoName,
+      config.pullNumber,
+      config.reviewer,
+      comment
+    );
+    await writeOutput("skip_review", "true");
+  } else {
+    const timeoutMin = Math.round(config.timeoutMs / 60_000);
+    console.log(`✗ Timeout after ${timeoutMin}min, pending: ${outcome.pendingNames.join(", ")}`);
+    const comment = buildTimeoutComment(config.prAuthor, outcome.pendingNames, timeoutMin);
+    await postSkipComment(
+      config.octokit,
+      config.owner,
+      config.repoName,
+      config.pullNumber,
+      config.reviewer,
+      comment
+    );
+    await writeOutput("skip_review", "true");
+  }
+} catch (error) {
+  console.error("Preflight check error (fail-open, proceeding with review):", error);
+  await writeOutput("skip_review", "false");
+}

--- a/.github/actions/code-review-action/src/reactToComment.ts
+++ b/.github/actions/code-review-action/src/reactToComment.ts
@@ -1,0 +1,215 @@
+/**
+ * Process comment reaction and update PR review state on GitHub.
+ * Handles replying to comments, resolving review threads, and updating verdict.
+ *
+ * @example
+ * GH_TOKEN=xxx REPO=owner/repo PR_NUMBER=123 COMMENT_ID=456 STRUCTURED_OUTPUT='{"reply":"..."}' bun run scripts/reactToComment.ts
+ */
+import {
+  deletePendingReviews,
+  fetchReviewThreads,
+  hasRecentBotReply,
+  parseRepoEnv,
+  readExecutionResult,
+  resolveThread,
+  verdictToEvent,
+} from "./github/githubReview.ts";
+
+/** Target for thread resolution by file location */
+interface ResolveTarget {
+  path: string;
+  line: number;
+}
+
+/** Structured output from Claude reaction */
+interface ReactionOutput {
+  reply: string;
+  resolveComments?: ResolveTarget[];
+  updatedVerdict?: "approve" | "requestChanges" | "comment" | null;
+  updatedReviewComment?: string | null;
+}
+
+/**
+ * Parse and validate structured reaction output from Claude.
+ * Returns null if output is empty, null string, or invalid JSON.
+ */
+function parseReactionOutput(rawOutput: string): ReactionOutput | null {
+  const trimmed = rawOutput.trim();
+  if (!trimmed || trimmed === "null") {
+    return null;
+  }
+
+  const parsed: unknown = JSON.parse(trimmed);
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  return {
+    reply: (obj.reply as string) ?? "",
+    resolveComments: (obj.resolveComments as ResolveTarget[]) ?? [],
+    updatedVerdict: (obj.updatedVerdict as ReactionOutput["updatedVerdict"]) ?? null,
+    updatedReviewComment: (obj.updatedReviewComment as string | null) ?? null,
+  };
+}
+
+/**
+ * Normalize body for dedup comparison.
+ * Trims whitespace and collapses internal whitespace runs.
+ */
+function normalizeBody(body: string): string {
+  return body.trim().replaceAll(/\s+/g, " ");
+}
+
+/**
+ * Resolve all unresolved bot review threads on a PR.
+ * Used when verdict changes to APPROVE — all prior bot comments are considered addressed.
+ */
+async function resolveAllBotThreads(
+  octokit: Parameters<typeof fetchReviewThreads>[0],
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  botLogin: string
+): Promise<void> {
+  const threads = await fetchReviewThreads(octokit, owner, repo, pullNumber);
+  const toResolve = threads.filter((t) => !t.isResolved && t.firstCommentAuthor === botLogin);
+
+  for (const thread of toResolve) {
+    await resolveThread(octokit, thread.id);
+  }
+
+  if (toResolve.length > 0) {
+    console.log(`✓ Resolved ${toResolve.length} review thread(s)`);
+  }
+}
+
+// Main execution
+const { octokit, owner, repoName, pullNumber, reviewer } = parseRepoEnv();
+const structuredOutput = process.env.STRUCTURED_OUTPUT ?? "";
+const commentId = process.env.COMMENT_ID;
+const commentPath = process.env.COMMENT_PATH;
+
+let output = parseReactionOutput(structuredOutput);
+
+if (!output || !output.reply) {
+  // Check if bot already replied during execution (via MCP tools)
+  const alreadyReplied = await hasRecentBotReply(
+    octokit,
+    owner,
+    repoName,
+    pullNumber,
+    reviewer,
+    commentId,
+    commentPath
+  );
+
+  if (alreadyReplied) {
+    console.log("✓ Reply already submitted during execution, no action needed");
+    process.exit(0);
+  }
+
+  // Try execution file fallback (with RUNNER_TEMP fallback path)
+  const executionFile =
+    process.env.EXECUTION_FILE ||
+    (process.env.RUNNER_TEMP ? `${process.env.RUNNER_TEMP}/claude-execution-output.json` : undefined);
+  const resultText = await readExecutionResult(executionFile);
+  if (!resultText) {
+    console.error("No structured output, no execution result, and no existing reply found");
+    process.exit(1);
+  }
+  console.log("Structured output missing, falling back to execution result as reply");
+  output = {
+    reply: resultText,
+    resolveComments: [],
+    updatedVerdict: null,
+    updatedReviewComment: null,
+  };
+}
+
+// Step 1: Reply to the comment
+if (commentPath && commentId) {
+  await octokit.rest.pulls.createReplyForReviewComment({
+    owner,
+    repo: repoName,
+    pull_number: pullNumber,
+    comment_id: Number(commentId),
+    body: output.reply,
+  });
+  console.log("✓ Replied to review thread");
+} else if (commentId) {
+  await octokit.rest.issues.createComment({
+    owner,
+    repo: repoName,
+    issue_number: pullNumber,
+    body: output.reply,
+  });
+  console.log("✓ Replied to PR comment");
+}
+
+// Step 2: Resolve specified threads
+const resolveTargets = output.resolveComments ?? [];
+
+if (resolveTargets.length > 0) {
+  const threads = await fetchReviewThreads(octokit, owner, repoName, pullNumber);
+
+  const matchingThreads = resolveTargets
+    .map((target) =>
+      threads.find(
+        (t) =>
+          t.path === target.path &&
+          t.line === target.line &&
+          !t.isResolved &&
+          t.firstCommentAuthor === reviewer
+      )
+    )
+    .filter((t): t is NonNullable<typeof t> => t !== undefined);
+
+  for (const thread of matchingThreads) {
+    await resolveThread(octokit, thread.id);
+  }
+
+  if (matchingThreads.length > 0) {
+    console.log(`✓ Resolved ${matchingThreads.length} review thread(s)`);
+  }
+}
+
+// Step 3: Update verdict if changed (with dedup check)
+if (output.updatedVerdict && output.updatedReviewComment) {
+  const event = verdictToEvent[output.updatedVerdict] ?? "COMMENT";
+
+  // Resolve all bot threads when approving (confirms issues addressed)
+  if (event === "APPROVE") {
+    await resolveAllBotThreads(octokit, owner, repoName, pullNumber, reviewer);
+  }
+
+  const { data: reviews } = await octokit.rest.pulls.listReviews({
+    owner,
+    repo: repoName,
+    pull_number: pullNumber,
+  });
+  const lastBotReview = reviews
+    .filter((r) => r.user?.login === reviewer && r.state !== "PENDING")
+    .at(-1);
+
+  if (
+    lastBotReview &&
+    normalizeBody(lastBotReview.body ?? "") === normalizeBody(output.updatedReviewComment)
+  ) {
+    console.log("✓ Review already posted, skipping duplicate verdict update");
+  } else {
+    await deletePendingReviews(octokit, owner, repoName, pullNumber);
+
+    await octokit.rest.pulls.createReview({
+      owner,
+      repo: repoName,
+      pull_number: pullNumber,
+      event,
+      body: output.updatedReviewComment,
+    });
+
+    console.log(`✓ Updated review verdict to ${event}`);
+  }
+}
+
+console.log("✓ Reaction processed successfully");

--- a/.github/actions/code-review-action/src/reviewFanout.test.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for reviewFanout.ts pure helpers.
+ *
+ * SDK-driven invocations (`runReviewFanout`, `runSubagent`) aren't covered here
+ * because mocking the Agent SDK's streaming `query()` is brittle and the logic
+ * inside those functions is a thin wrapper over the SDK. They're exercised by
+ * the end-to-end review in CI.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  buildSubagentPrompt,
+  detectStack,
+  loadReviewAgents,
+  parseAgentFrontmatter,
+  splitFrontmatter,
+} from "./reviewFanout.ts";
+
+describe("splitFrontmatter", () => {
+  test("extracts frontmatter and body", () => {
+    const content = "---\nmodel: sonnet\n---\nbody content";
+    expect(splitFrontmatter(content)).toEqual({ fm: "model: sonnet", body: "body content" });
+  });
+
+  test("returns empty frontmatter when no fence", () => {
+    expect(splitFrontmatter("plain body")).toEqual({ fm: "", body: "plain body" });
+  });
+
+  test("returns empty frontmatter when closing fence is missing", () => {
+    expect(splitFrontmatter("---\nmodel: sonnet\nno close")).toEqual({
+      fm: "",
+      body: "---\nmodel: sonnet\nno close",
+    });
+  });
+});
+
+describe("parseAgentFrontmatter", () => {
+  test("extracts scalar model", () => {
+    expect(parseAgentFrontmatter("model: sonnet")).toEqual({ model: "sonnet" });
+  });
+
+  test("strips quotes from scalar values", () => {
+    expect(parseAgentFrontmatter('model: "haiku"')).toEqual({ model: "haiku" });
+  });
+
+  test("parses inline comma-separated tools", () => {
+    expect(parseAgentFrontmatter("tools: Bash(gh *), Read")).toEqual({
+      allowedTools: ["Bash(gh *)", "Read"],
+    });
+  });
+
+  test("parses indented list tools", () => {
+    const fm = "tools:\n  - Read\n  - Grep\n  - Bash(gh:*)";
+    expect(parseAgentFrontmatter(fm)).toEqual({
+      allowedTools: ["Read", "Grep", "Bash(gh:*)"],
+    });
+  });
+
+  test("ignores unknown keys", () => {
+    const fm = "name: pr:review:correctness\ndescription: foo\nmodel: sonnet";
+    expect(parseAgentFrontmatter(fm)).toEqual({ model: "sonnet" });
+  });
+
+  test("handles frontmatter with both model and tools", () => {
+    const fm = "model: sonnet\ntools: Bash(gh *)";
+    expect(parseAgentFrontmatter(fm)).toEqual({
+      model: "sonnet",
+      allowedTools: ["Bash(gh *)"],
+    });
+  });
+});
+
+describe("buildSubagentPrompt", () => {
+  test("embeds stack and diff in a deterministic template", () => {
+    const prompt = buildSubagentPrompt("Python", "diff --git a/x b/x");
+    expect(prompt).toBe("Stack: Python\n\nDiff:\n```diff\ndiff --git a/x b/x\n```");
+  });
+});
+
+describe("detectStack", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "fanout-stack-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true });
+  });
+
+  test("reads 'rules' field from platform.meta.yml", async () => {
+    await writeFile(join(dir, "platform.meta.yml"), "language: typescript\nrules: Bun\n");
+    expect(await detectStack(dir)).toBe("Bun");
+  });
+
+  test("returns 'unknown' when file is missing", async () => {
+    expect(await detectStack(dir)).toBe("unknown");
+  });
+
+  test("returns 'unknown' when 'rules' field is absent", async () => {
+    await writeFile(join(dir, "platform.meta.yml"), "language: typescript\n");
+    expect(await detectStack(dir)).toBe("unknown");
+  });
+
+  test("strips surrounding quotes from rules value", async () => {
+    await writeFile(join(dir, "platform.meta.yml"), 'rules: "Python+SqlAlchemy"\n');
+    expect(await detectStack(dir)).toBe("Python+SqlAlchemy");
+  });
+});
+
+describe("loadReviewAgents", () => {
+  let pluginDir: string;
+
+  beforeEach(async () => {
+    pluginDir = await mkdtemp(join(tmpdir(), "fanout-agents-"));
+    await writeFile(join(pluginDir, "agents").concat("/.keep"), "").catch(() => {});
+  });
+
+  afterEach(async () => {
+    await rm(pluginDir, { recursive: true });
+  });
+
+  async function seed(filename: string, content: string): Promise<void> {
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(join(pluginDir, "agents"), { recursive: true });
+    await writeFile(join(pluginDir, "agents", filename), content);
+  }
+
+  test("loads only pr:review:* files and parses frontmatter", async () => {
+    await seed(
+      "pr:review:correctness.md",
+      "---\nname: pr:review:correctness\nmodel: sonnet\n---\ncorrectness body"
+    );
+    await seed(
+      "pr:review:surface-naming.md",
+      "---\nname: pr:review:surface-naming\nmodel: haiku\n---\nsurface body"
+    );
+    // Unrelated file must be filtered out
+    await seed("pr:review.md", "should be excluded");
+    await seed("other.md", "unrelated");
+
+    const agents = await loadReviewAgents(pluginDir);
+    const names = agents.map((a) => a.subagent_type).sort();
+
+    expect(names).toEqual(["platform:pr:review:correctness", "platform:pr:review:surface-naming"]);
+    const correctness = agents.find((a) => a.subagent_type === "platform:pr:review:correctness");
+    expect(correctness?.model).toBe("sonnet");
+    expect(correctness?.body).toBe("correctness body");
+  });
+
+  test("propagates allowed tools when declared", async () => {
+    await seed(
+      "pr:review:rfc-compliance.md",
+      "---\nname: pr:review:rfc-compliance\nmodel: sonnet\ntools: Bash(gh *)\n---\nbody"
+    );
+    const agents = await loadReviewAgents(pluginDir);
+    expect(agents[0]?.allowedTools).toEqual(["Bash(gh *)"]);
+  });
+
+  test("leaves allowedTools undefined when frontmatter omits tools", async () => {
+    await seed(
+      "pr:review:correctness.md",
+      "---\nname: pr:review:correctness\nmodel: sonnet\n---\nbody"
+    );
+    const agents = await loadReviewAgents(pluginDir);
+    expect(agents[0]?.allowedTools).toBeUndefined();
+  });
+});
+

--- a/.github/actions/code-review-action/src/reviewFanout.test.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.test.ts
@@ -92,23 +92,26 @@ describe("detectStack", () => {
     await rm(dir, { recursive: true });
   });
 
-  test("reads 'rules' field from platform.meta.yml", async () => {
-    await writeFile(join(dir, "platform.meta.yml"), "language: typescript\nrules: Bun\n");
+  test("reads agents.rules from package.json", async () => {
+    await writeFile(
+      join(dir, "package.json"),
+      JSON.stringify({ agents: { rules: "Bun", language: "typescript" } })
+    );
     expect(await detectStack(dir)).toBe("Bun");
   });
 
-  test("returns 'unknown' when file is missing", async () => {
+  test("returns 'unknown' when package.json is missing", async () => {
     expect(await detectStack(dir)).toBe("unknown");
   });
 
-  test("returns 'unknown' when 'rules' field is absent", async () => {
-    await writeFile(join(dir, "platform.meta.yml"), "language: typescript\n");
+  test("returns 'unknown' when agents.rules is absent", async () => {
+    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "pkg" }));
     expect(await detectStack(dir)).toBe("unknown");
   });
 
-  test("strips surrounding quotes from rules value", async () => {
-    await writeFile(join(dir, "platform.meta.yml"), 'rules: "Python+SqlAlchemy"\n');
-    expect(await detectStack(dir)).toBe("Python+SqlAlchemy");
+  test("returns 'unknown' when package.json is malformed", async () => {
+    await writeFile(join(dir, "package.json"), "{ not json");
+    expect(await detectStack(dir)).toBe("unknown");
   });
 });
 

--- a/.github/actions/code-review-action/src/reviewFanout.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.ts
@@ -160,13 +160,14 @@ async function fetchPrDiff(repo: string, prNumber: string): Promise<string> {
   return stdout;
 }
 
-/** Detect the stack name from `platform.meta.yml` in the checked-out repo root. */
+/** Detect the stack name from `package.json` `agents.rules` in the checked-out repo root. */
 export async function detectStack(cwd: string = process.cwd()): Promise<string> {
   try {
-    const content = await Bun.file(join(cwd, "platform.meta.yml")).text();
-    const match = content.match(/^rules:\s*(.+)$/m);
-    const value = match?.[1]?.trim();
-    return value ? stripQuotes(value) : "unknown";
+    const pkg = (await Bun.file(join(cwd, "package.json")).json()) as {
+      agents?: { rules?: unknown };
+    };
+    const value = pkg.agents?.rules;
+    return typeof value === "string" && value.length > 0 ? value : "unknown";
   } catch {
     return "unknown";
   }

--- a/.github/actions/code-review-action/src/reviewFanout.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.ts
@@ -1,0 +1,339 @@
+/**
+ * Orchestrator-side parallel fan-out for PR-review sub-agents.
+ *
+ * Reads the 12 `pr:review:*` sub-agent definitions from the installed autopilot
+ * plugin, spawns them as parallel headless `query()` calls via the Agent SDK,
+ * and returns their markdown output. The results are written to disk so the
+ * root `/autopilot:pr-review` command can consume them instead of attempting
+ * its own (unreliable) in-model fan-out.
+ *
+ * @see runClaude.ts — wires this module into review mode
+ */
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { McpServerConfig, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import type pino from "pino";
+
+import { logMessage } from "./logClaudeMessage.ts";
+
+/** Filename prefix that identifies the 12 review sub-agents in the plugin. */
+const reviewAgentPrefix = "pr:review:";
+
+/** Shared runtime context threaded into every parallel sub-agent invocation. */
+export interface FanoutContext {
+  log: pino.Logger;
+  repo: string;
+  prNumber: string;
+  pluginDir: string;
+  mcpServers: Record<string, McpServerConfig>;
+  settingSources: ("user" | "project")[];
+  pathToClaudeCodeExecutable: string | undefined;
+  fallbackModel: string;
+  /** Tools inherited from the root query — used when the agent file declares none. */
+  inheritedAllowedTools: string[];
+  inheritedDisallowedTools: string[];
+  /** Per-sub-agent timeout, independent of the 30-min root timeout. */
+  subagentTimeoutMs: number;
+}
+
+/** Result of a single sub-agent invocation, written to the shared JSON file. */
+export interface SubagentResult {
+  subagent_type: string;
+  markdown: string;
+  duration_ms: number;
+  error?: string;
+}
+
+/** In-memory representation of one loaded agent definition file. */
+interface AgentDefinition {
+  subagent_type: string;
+  filename: string;
+  body: string;
+  model: string | undefined;
+  allowedTools: string[] | undefined;
+}
+
+/**
+ * Split a markdown file with YAML frontmatter into the frontmatter text and body.
+ * Returns empty frontmatter if the file doesn't start with the `---` fence.
+ */
+export function splitFrontmatter(content: string): { fm: string; body: string } {
+  if (!content.startsWith("---\n")) return { fm: "", body: content };
+  const end = content.indexOf("\n---\n", 4);
+  if (end === -1) return { fm: "", body: content };
+  return { fm: content.slice(4, end), body: content.slice(end + 5) };
+}
+
+function parseInlineTools(value: string): string[] {
+  return value
+    .split(",")
+    .map((t) => stripQuotes(t.trim()))
+    .filter(Boolean);
+}
+
+/**
+ * Parse the tiny YAML subset used by Claude Code agent frontmatter.
+ *
+ * Handles: scalar `key: value` (quoted or unquoted) and `key:` with an
+ * indented `- item` list underneath. That's all agent frontmatter needs;
+ * pulling in a full YAML lib would be premature.
+ */
+export function parseAgentFrontmatter(fm: string): {
+  model?: string;
+  allowedTools?: string[];
+} {
+  const out: { model?: string; allowedTools?: string[] } = {};
+  const listBuffer: string[] = [];
+  let inToolsList = false;
+
+  for (const line of fm.split("\n")) {
+    const listMatch = line.match(/^\s+-\s+(.+)$/);
+    if (listMatch && inToolsList) {
+      listBuffer.push(stripQuotes((listMatch[1] ?? "").trim()));
+      continue;
+    }
+    inToolsList = false;
+
+    const kvMatch = line.match(/^([a-zA-Z_-]+):\s*(.*)$/);
+    if (!kvMatch) continue;
+    const [, key, rawValue] = kvMatch;
+    const value = (rawValue ?? "").trim();
+
+    if (key === "model" && value) out.model = stripQuotes(value);
+    if (key === "tools" && value) out.allowedTools = parseInlineTools(value);
+    if (key === "tools" && !value) inToolsList = true;
+  }
+
+  if (listBuffer.length > 0) out.allowedTools = listBuffer;
+  return out;
+}
+
+function stripQuotes(value: string): string {
+  return value.replace(/^["']|["']$/g, "");
+}
+
+/** Read all `pr:review:*.md` files from the plugin's agents directory. */
+export async function loadReviewAgents(pluginDir: string): Promise<AgentDefinition[]> {
+  const agentsDir = join(pluginDir, "agents");
+  const entries = await readdir(agentsDir);
+  const reviewFiles = entries
+    .filter((f) => f.startsWith(reviewAgentPrefix) && f.endsWith(".md"))
+    .sort();
+
+  return Promise.all(
+    reviewFiles.map(async (filename) => {
+      const content = await Bun.file(join(agentsDir, filename)).text();
+      const { fm, body } = splitFrontmatter(content);
+      const parsed = parseAgentFrontmatter(fm);
+      return {
+        subagent_type: `platform:${filename.replace(/\.md$/, "")}`,
+        filename,
+        body: body.trim(),
+        model: parsed.model,
+        allowedTools: parsed.allowedTools,
+      };
+    })
+  );
+}
+
+/** Build the `Stack: ... Diff: ...` user prompt each review sub-agent expects. */
+export function buildSubagentPrompt(stack: string, diff: string): string {
+  return `Stack: ${stack}\n\nDiff:\n\`\`\`diff\n${diff}\n\`\`\``;
+}
+
+/** Fetch the unified PR diff via the gh CLI. */
+async function fetchPrDiff(repo: string, prNumber: string): Promise<string> {
+  const proc = Bun.spawn(["gh", "pr", "diff", prNumber, "-R", repo], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  await proc.exited;
+  if (proc.exitCode !== 0) {
+    throw new Error(`gh pr diff failed (exit ${proc.exitCode}): ${stderr.trim()}`);
+  }
+  return stdout;
+}
+
+/** Detect the stack name from `platform.meta.yml` in the checked-out repo root. */
+export async function detectStack(cwd: string = process.cwd()): Promise<string> {
+  try {
+    const content = await Bun.file(join(cwd, "platform.meta.yml")).text();
+    const match = content.match(/^rules:\s*(.+)$/m);
+    const value = match?.[1]?.trim();
+    return value ? stripQuotes(value) : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+function isTextBlock(block: unknown): block is TextBlock {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
+}
+
+/**
+ * Capture the final assistant text block from an SDK message stream.
+ *
+ * The review sub-agents are instructed to emit a single structured markdown
+ * block as their last assistant message; later text wins to cover the case
+ * where the model emits intermediate narration before the final block.
+ */
+function extractFinalText(message: SDKMessage): string | undefined {
+  if (message.type !== "assistant") return undefined;
+  const content = (message as { message: { content?: unknown[] } }).message.content ?? [];
+  const texts = content.filter(isTextBlock);
+  return texts.at(-1)?.text;
+}
+
+/**
+ * Run one review sub-agent as a headless SDK query.
+ *
+ * Uses a child logger bound with `orchestrator_subagent` so the debug-log
+ * analyzer can group interleaved messages from the parallel streams.
+ */
+async function runSubagent(
+  ctx: FanoutContext,
+  agent: AgentDefinition,
+  userPrompt: string
+): Promise<SubagentResult> {
+  const childLog = ctx.log.child({ orchestrator_subagent: agent.subagent_type });
+  const start = performance.now();
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), ctx.subagentTimeoutMs);
+
+  const model = agent.model ?? ctx.fallbackModel;
+  let markdown = "";
+  let error: string | undefined;
+
+  childLog.info({ model }, "Sub-agent query starting.");
+
+  try {
+    markdown = await streamAssistantText(
+      childLog,
+      query({
+        prompt: userPrompt,
+        options: buildSubagentOptions(ctx, agent, abortController),
+      })
+    );
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+    childLog.error({ error }, "Sub-agent invocation failed.");
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const durationMs = Math.round(performance.now() - start);
+  childLog.info(
+    { duration_ms: durationMs, markdown_bytes: markdown.length, error },
+    "Sub-agent query finished."
+  );
+  return { subagent_type: agent.subagent_type, markdown, duration_ms: durationMs, error };
+}
+
+/** Stream SDK messages through the logger; return the last assistant text. */
+async function streamAssistantText(
+  log: pino.Logger,
+  stream: AsyncIterable<SDKMessage>
+): Promise<string> {
+  let markdown = "";
+  for await (const message of stream) {
+    logMessage(log, message);
+    const text = extractFinalText(message);
+    if (text !== undefined) markdown = text;
+  }
+  return markdown;
+}
+
+/** Build the SDK `query()` options for a single sub-agent. */
+function buildSubagentOptions(
+  ctx: FanoutContext,
+  agent: AgentDefinition,
+  abortController: AbortController
+): Parameters<typeof query>[0]["options"] {
+  return {
+    model: agent.model ?? ctx.fallbackModel,
+    allowedTools: agent.allowedTools ?? ctx.inheritedAllowedTools,
+    disallowedTools: ctx.inheritedDisallowedTools,
+    plugins: [{ type: "local" as const, path: ctx.pluginDir }],
+    mcpServers: ctx.mcpServers,
+    permissionMode: "bypassPermissions" as const,
+    allowDangerouslySkipPermissions: true,
+    settingSources: ctx.settingSources,
+    systemPrompt: {
+      type: "preset" as const,
+      preset: "claude_code" as const,
+      append: agent.body,
+    },
+    pathToClaudeCodeExecutable: ctx.pathToClaudeCodeExecutable,
+    abortController,
+    env: {
+      ...(process.env as Record<string, string>),
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? "",
+      CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN ?? "",
+      GH_TOKEN: process.env.GH_TOKEN ?? "",
+    },
+  };
+}
+
+/**
+ * Run all 12 `pr:review:*` sub-agents in parallel and return their markdown
+ * review blocks. Individual failures are captured in the `error` field of the
+ * corresponding result but do not abort the whole fan-out — this mirrors the
+ * current root-model behavior where a failing sub-agent is skipped.
+ */
+export async function runReviewFanout(ctx: FanoutContext): Promise<SubagentResult[]> {
+  ctx.log.info(
+    { repo: ctx.repo, pr_number: ctx.prNumber, plugin_dir: ctx.pluginDir },
+    "Parallel review fan-out starting."
+  );
+
+  const [agents, diff, stack] = await Promise.all([
+    loadReviewAgents(ctx.pluginDir),
+    fetchPrDiff(ctx.repo, ctx.prNumber),
+    detectStack(),
+  ]);
+
+  ctx.log.info(
+    { agent_count: agents.length, diff_bytes: diff.length, stack },
+    "Agent definitions and PR context loaded."
+  );
+
+  const userPrompt = buildSubagentPrompt(stack, diff);
+  const start = performance.now();
+
+  const results = await Promise.all(agents.map((agent) => runSubagent(ctx, agent, userPrompt)));
+
+  const totalMs = Math.round(performance.now() - start);
+  const maxAgentMs = results.reduce((max, r) => Math.max(max, r.duration_ms), 0);
+  const totalAgentMs = results.reduce((sum, r) => sum + r.duration_ms, 0);
+  const failed = results.filter((r) => r.error).length;
+
+  ctx.log.info(
+    {
+      total_ms: totalMs,
+      max_agent_ms: maxAgentMs,
+      // Gain vs. a hypothetical serial run: sum(agent time) / wall time.
+      parallel_speedup: totalMs > 0 ? +(totalAgentMs / totalMs).toFixed(2) : 0,
+      agent_count: results.length,
+      failed_count: failed,
+    },
+    "Parallel review fan-out complete."
+  );
+
+  return results;
+}

--- a/.github/actions/code-review-action/src/runClaude.test.ts
+++ b/.github/actions/code-review-action/src/runClaude.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for runClaude.ts utility functions.
+ * Covers config parsing, JSON safety, MCP config loading, and GitHub output formatting.
+ */
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  detectLinuxLibc,
+  loadMcpServers,
+  mcpConfigFileSchema,
+  parseConfig,
+  resolveClaudeBinary,
+  safeParseJson,
+  setOutput,
+} from "./runClaude.ts";
+
+describe("safeParseJson", () => {
+  test("returns undefined for empty string", () => {
+    expect(safeParseJson("", "test")).toBeUndefined();
+  });
+
+  test("returns undefined for undefined", () => {
+    expect(safeParseJson(undefined, "test")).toBeUndefined();
+  });
+
+  test("parses valid JSON", () => {
+    const result = safeParseJson('{"key": "value"}', "test");
+    expect(result).toEqual({ key: "value" });
+  });
+
+  test("throws on invalid JSON with descriptive message", () => {
+    expect(() => safeParseJson("{bad", "CLAUDE_JSON_SCHEMA")).toThrow(
+      "Invalid JSON in CLAUDE_JSON_SCHEMA"
+    );
+  });
+
+  test("attaches cause to thrown error", () => {
+    expect.assertions(2);
+    try {
+      safeParseJson("{bad", "test");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).cause).toBeInstanceOf(SyntaxError);
+    }
+  });
+});
+
+describe("parseConfig", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.CLAUDE_PROMPT = "test prompt";
+    process.env.CLAUDE_MODEL = "claude-sonnet-4-6";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  test("throws when CLAUDE_PROMPT is missing", () => {
+    delete process.env.CLAUDE_PROMPT;
+    expect(() => parseConfig()).toThrow("Missing required environment variable: CLAUDE_PROMPT");
+  });
+
+  test("throws when CLAUDE_MODEL is missing", () => {
+    delete process.env.CLAUDE_MODEL;
+    expect(() => parseConfig()).toThrow("Missing required environment variable: CLAUDE_MODEL");
+  });
+
+  test("parses minimal config", () => {
+    const config = parseConfig();
+    expect(config.prompt).toBe("test prompt");
+    expect(config.model).toBe("claude-sonnet-4-6");
+    expect(config.allowedTools).toEqual([]);
+    expect(config.disallowedTools).toEqual([]);
+    expect(config.jsonSchema).toBeUndefined();
+    expect(config.pluginDir).toBeUndefined();
+    expect(config.timeoutMs).toBe(30 * 60 * 1000);
+  });
+
+  test("parses comma-separated allowed tools with trimming", () => {
+    process.env.CLAUDE_ALLOWED_TOOLS = "Bash(gh:*), Read , Glob";
+    const config = parseConfig();
+    expect(config.allowedTools).toEqual(["Bash(gh:*)", "Read", "Glob"]);
+  });
+
+  test("filters empty entries from tools", () => {
+    process.env.CLAUDE_ALLOWED_TOOLS = "Read,,Glob,";
+    const config = parseConfig();
+    expect(config.allowedTools).toEqual(["Read", "Glob"]);
+  });
+
+  test("parses JSON schema from env", () => {
+    process.env.CLAUDE_JSON_SCHEMA = '{"type":"object","properties":{"verdict":{"type":"string"}}}';
+    const config = parseConfig();
+    expect(config.jsonSchema).toEqual({
+      type: "object",
+      properties: { verdict: { type: "string" } },
+    });
+  });
+
+  test("throws on malformed JSON schema", () => {
+    process.env.CLAUDE_JSON_SCHEMA = "{bad json";
+    expect(() => parseConfig()).toThrow("Invalid JSON in CLAUDE_JSON_SCHEMA");
+  });
+
+  test("uses custom timeout when provided", () => {
+    process.env.CLAUDE_TIMEOUT_MINUTES = "15";
+    const config = parseConfig();
+    expect(config.timeoutMs).toBe(15 * 60 * 1000);
+  });
+
+  test("defaults to 30 min timeout for invalid values", () => {
+    process.env.CLAUDE_TIMEOUT_MINUTES = "not-a-number";
+    const config = parseConfig();
+    expect(config.timeoutMs).toBe(30 * 60 * 1000);
+  });
+
+  test("uses EXECUTION_OUTPUT_FILE when set", () => {
+    process.env.EXECUTION_OUTPUT_FILE = "/custom/path.json";
+    const config = parseConfig();
+    expect(config.outputFilePath).toBe("/custom/path.json");
+  });
+
+  test("converts empty string pluginDir to undefined", () => {
+    process.env.CLAUDE_PLUGIN_DIR = "";
+    const config = parseConfig();
+    expect(config.pluginDir).toBeUndefined();
+  });
+});
+
+describe("mcpConfigFileSchema", () => {
+  test("validates config with mcpServers key", () => {
+    const input = { mcpServers: { server1: { command: "node", args: ["index.js"] } } };
+    const result = mcpConfigFileSchema.parse(input);
+    expect(result.mcpServers).toEqual(input.mcpServers);
+  });
+
+  test("validates flat server config (no mcpServers wrapper)", () => {
+    const input = { server1: { command: "node", args: ["index.js"] } };
+    const result = mcpConfigFileSchema.parse(input);
+    expect(result.server1).toEqual(input.server1);
+  });
+
+  test("rejects non-object input", () => {
+    expect(() => mcpConfigFileSchema.parse("string")).toThrow();
+    expect(() => mcpConfigFileSchema.parse(42)).toThrow();
+    expect(() => mcpConfigFileSchema.parse(null)).toThrow();
+  });
+});
+
+describe("loadMcpServers", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "runClaude-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true });
+  });
+
+  test("returns empty object for undefined path", async () => {
+    const result = await loadMcpServers(undefined);
+    expect(result).toEqual({});
+  });
+
+  test("loads config with mcpServers key", async () => {
+    const config = { mcpServers: { ctx: { command: "npx", args: ["-y", "ctx-mcp"] } } };
+    const filePath = join(tempDir, "mcp.json");
+    await Bun.write(filePath, JSON.stringify(config));
+
+    const result = await loadMcpServers(filePath);
+    expect(result).toEqual(config.mcpServers);
+  });
+
+  test("loads flat config without mcpServers wrapper", async () => {
+    const config = { ctx: { command: "npx", args: ["-y", "ctx-mcp"] } };
+    const filePath = join(tempDir, "mcp.json");
+    await Bun.write(filePath, JSON.stringify(config));
+
+    const result = await loadMcpServers(filePath);
+    expect(result).toEqual(config);
+  });
+
+  test("returns empty object for missing file", async () => {
+    const result = await loadMcpServers(join(tempDir, "nonexistent.json"));
+    expect(result).toEqual({});
+  });
+
+  test("returns empty object for invalid JSON", async () => {
+    const filePath = join(tempDir, "bad.json");
+    await Bun.write(filePath, "{invalid");
+
+    const result = await loadMcpServers(filePath);
+    expect(result).toEqual({});
+  });
+});
+
+describe("detectLinuxLibc", () => {
+  test("returns 'glibc' or 'musl' (string literal)", async () => {
+    const libc = await detectLinuxLibc();
+    expect(["glibc", "musl"]).toContain(libc);
+  });
+});
+
+describe("resolveClaudeBinary", () => {
+  // Resolution depends on whether the platform-specific @anthropic-ai/claude-agent-sdk-<platform>-<arch>
+  // subpackage is reachable from this file via Node resolution. Bun's workspace install keeps
+  // optional subpackages in `.bun/` cache without symlinking them into the workspace's node_modules,
+  // so this returns undefined in workspace contexts but resolves a path in standalone installs.
+  test("resolves to a claude binary path when the platform subpackage is installed", async () => {
+    const binary = await resolveClaudeBinary();
+    if (binary !== undefined) {
+      expect(binary).toMatch(/claude(?:\.exe)?$/);
+    }
+  });
+
+  test("returns undefined when no matching package is installed", async () => {
+    const binary = await resolveClaudeBinary("win32", "arm64");
+    expect(binary).toBeUndefined();
+  });
+
+  test("prefers musl binary when libc markers indicate musl (via candidate ordering)", async () => {
+    const [darwinArm64, darwinX64] = await Promise.all([
+      resolveClaudeBinary("darwin", "arm64"),
+      resolveClaudeBinary("darwin", "x64"),
+    ]);
+    for (const binary of [darwinArm64, darwinX64]) {
+      if (binary !== undefined) expect(binary).toMatch(/claude$/);
+    }
+  });
+});
+
+describe("setOutput", () => {
+  let tempDir: string;
+  let outputFile: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "runClaude-test-"));
+    outputFile = join(tempDir, "GITHUB_OUTPUT");
+    await Bun.write(outputFile, "");
+    process.env.GITHUB_OUTPUT = outputFile;
+  });
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    await rm(tempDir, { recursive: true });
+  });
+
+  test("writes output with heredoc delimiter", async () => {
+    await setOutput("test_key", "test_value");
+
+    const content = await readFile(outputFile, "utf8");
+    expect(content).toMatch(/^test_key<<EOF_[a-f0-9]+\ntest_value\nEOF_[a-f0-9]+\n$/);
+  });
+
+  test("handles multi-line values", async () => {
+    await setOutput("json", '{"key":"value",\n"nested":true}');
+
+    const content = await readFile(outputFile, "utf8");
+    expect(content).toContain('{"key":"value",\n"nested":true}');
+  });
+
+  test("does nothing without GITHUB_OUTPUT", async () => {
+    delete process.env.GITHUB_OUTPUT;
+    await setOutput("key", "value");
+    // Should not throw
+  });
+
+  test("appends multiple outputs", async () => {
+    await setOutput("key1", "val1");
+    await setOutput("key2", "val2");
+
+    const content = await readFile(outputFile, "utf8");
+    expect(content).toContain("key1<<EOF_");
+    expect(content).toContain("key2<<EOF_");
+  });
+});

--- a/.github/actions/code-review-action/src/runClaude.ts
+++ b/.github/actions/code-review-action/src/runClaude.ts
@@ -1,0 +1,451 @@
+/**
+ * Run Claude Code via Agent SDK for PR review and comment reaction.
+ * Replaces anthropics/claude-code-action with direct SDK invocation.
+ *
+ * Streams messages from the SDK query, writes an execution file,
+ * and sets GitHub Action outputs (structured_output, execution_file).
+ *
+ * @example
+ * CLAUDE_PROMPT="..." CLAUDE_MODEL="claude-sonnet-4-6" bun run scripts/runClaude.ts
+ *
+ * @see https://docs.anthropic.com/en/docs/agent-sdk/typescript - Agent SDK reference
+ */
+import { randomUUID } from "node:crypto";
+import { access, appendFile, mkdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+import type { McpServerConfig } from "@anthropic-ai/claude-agent-sdk";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import pino from "pino";
+import { z } from "zod";
+
+import { logMessage } from "./logClaudeMessage.ts";
+import { runReviewFanout, type FanoutContext } from "./reviewFanout.ts";
+
+/** Duration above which a Claude session is considered long-running (triggers artifact upload). */
+const longRunMs = 5 * 60 * 1000;
+
+/** Create pino logger configured per platform logging standard. */
+async function createLogger(): Promise<pino.Logger> {
+  const version = (await Bun.file(`${import.meta.dirname}/../version`).text()).trim();
+
+  return pino(
+    {
+      name: "runClaude",
+      level: process.env.LOG_LEVEL ?? "info",
+      timestamp: () => `,"timestamp":"${new Date().toISOString().replace(/Z$/, "000Z")}"`,
+      messageKey: "event",
+      formatters: {
+        level: (label) => ({ level: label === "warn" ? "warning" : label }),
+      },
+      base: { version },
+      mixin() {
+        // Extract callsite from stack trace (skip Error, mixin, pino internals).
+        // Named fn:  "    at parseConfig (/path/to/runClaude.ts:86:5)"  → [_, "parseConfig", "/path/to/runClaude.ts", "86"]
+        // Anonymous: "    at /path/to/runClaude.ts:160:3"                → [_, "/path/to/runClaude.ts", "160"]
+        const stack = new Error().stack ?? "";
+        const callerLine = stack.split("\n")[3] ?? "";
+        const match =
+          callerLine.match(/at (\S+) \((.+):(\d+):\d+\)/) ?? callerLine.match(/at (.+):(\d+):\d+/);
+
+        if (match?.[3]) {
+          return { func_name: match[1], filename: match[2], lineno: Number(match[3]) };
+        }
+        if (match?.[2]) {
+          return { func_name: "<anonymous>", filename: match[1], lineno: Number(match[2]) };
+        }
+        return {};
+      },
+    },
+    // Synchronous stdout so no trace lines are lost on abort / 30-min timeout.
+    pino.destination({ sync: true })
+  );
+}
+
+/** Zod schema for MCP server configuration files */
+export const mcpConfigFileSchema = z
+  .object({
+    mcpServers: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
+  })
+  .catchall(z.record(z.string(), z.unknown()));
+
+/** Configuration parsed from environment variables */
+export interface RunClaudeConfig {
+  prompt: string;
+  model: string;
+  allowedTools: string[];
+  disallowedTools: string[];
+  jsonSchema: Record<string, unknown> | undefined;
+  pluginDir: string | undefined;
+  mcpConfigPath: string | undefined;
+  settingsJson: string | undefined;
+  outputFilePath: string;
+  timeoutMs: number;
+}
+
+/**
+ * Parse JSON safely with descriptive error messages.
+ * Returns undefined if the input is empty or falsy.
+ */
+export function safeParseJson(
+  value: string | undefined,
+  label: string
+): Record<string, unknown> | undefined {
+  if (!value) return undefined;
+
+  try {
+    return JSON.parse(value) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(`Invalid JSON in ${label}`, { cause: error });
+  }
+}
+
+/** Parse and validate required environment variables. */
+export function parseConfig(): RunClaudeConfig {
+  const prompt = process.env.CLAUDE_PROMPT;
+  const model = process.env.CLAUDE_MODEL;
+  if (!prompt) {
+    throw new Error("Missing required environment variable: CLAUDE_PROMPT");
+  }
+  if (!model) {
+    throw new Error("Missing required environment variable: CLAUDE_MODEL");
+  }
+
+  const rawTimeout = Number(process.env.CLAUDE_TIMEOUT_MINUTES);
+  const timeoutMinutes = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 30;
+
+  return {
+    prompt,
+    model,
+    allowedTools:
+      process.env.CLAUDE_ALLOWED_TOOLS?.split(",")
+        .map((t) => t.trim())
+        .filter(Boolean) ?? [],
+    disallowedTools:
+      process.env.CLAUDE_DISALLOWED_TOOLS?.split(",")
+        .map((t) => t.trim())
+        .filter(Boolean) ?? [],
+    jsonSchema: safeParseJson(process.env.CLAUDE_JSON_SCHEMA, "CLAUDE_JSON_SCHEMA"),
+    pluginDir: process.env.CLAUDE_PLUGIN_DIR || undefined,
+    mcpConfigPath: process.env.CLAUDE_MCP_CONFIG || undefined,
+    settingsJson: process.env.CLAUDE_SETTINGS || undefined,
+    outputFilePath:
+      process.env.EXECUTION_OUTPUT_FILE ??
+      `${process.env.RUNNER_TEMP ?? "/tmp"}/claude-execution-output.json`,
+    timeoutMs: timeoutMinutes * 60 * 1000,
+  };
+}
+
+/**
+ * Load and validate additional MCP server configuration from a JSON file.
+ * Uses Zod to validate the external input at the system boundary.
+ */
+export async function loadMcpServers(
+  configPath: string | undefined
+): Promise<Record<string, McpServerConfig>> {
+  if (!configPath) return {};
+
+  try {
+    const raw: unknown = await Bun.file(configPath).json();
+    const parsed = mcpConfigFileSchema.parse(raw);
+    return (parsed.mcpServers ?? parsed) as Record<string, McpServerConfig>;
+  } catch (error) {
+    log?.warn({ config_path: configPath, error }, "Couldn't load MCP config.");
+    return {};
+  }
+}
+
+/**
+ * Write Claude Code settings to a temporary directory.
+ * Uses $RUNNER_TEMP to avoid polluting the runner's home directory.
+ */
+async function writeSettings(settingsJson: string | undefined): Promise<string[]> {
+  if (!settingsJson) return ["project"];
+
+  const dir = `${process.env.RUNNER_TEMP ?? "/tmp"}/.claude`;
+  await mkdir(dir, { recursive: true });
+  await Bun.write(`${dir}/settings.json`, settingsJson);
+
+  process.env.CLAUDE_CONFIG_DIR = dir;
+  return ["user", "project"];
+}
+
+/** Set a GitHub Actions output variable using heredoc delimiter for multi-line safety. */
+export async function setOutput(key: string, value: string): Promise<void> {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) return;
+
+  const delimiter = `EOF_${randomUUID().replaceAll("-", "")}`;
+  await appendFile(outputFile, `${key}<<${delimiter}\n${value}\n${delimiter}\n`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect the host libc on Linux. Uses filesystem markers because
+ * `process.report.getReport()` under Bun is unreliable (Bun itself is a
+ * statically-linked musl binary and reports no glibc version even on glibc
+ * hosts, which misleads the SDK's built-in detection).
+ */
+export async function detectLinuxLibc(): Promise<"musl" | "glibc"> {
+  const muslMarkers = [
+    "/etc/alpine-release",
+    "/lib/ld-musl-x86_64.so.1",
+    "/lib/ld-musl-aarch64.so.1",
+  ];
+  const matches = await Promise.all(muslMarkers.map(pathExists));
+  return matches.some(Boolean) ? "musl" : "glibc";
+}
+
+function linuxCandidates(arch: string, libc: "musl" | "glibc"): string[] {
+  const glibc = `@anthropic-ai/claude-agent-sdk-linux-${arch}`;
+  const musl = `${glibc}-musl`;
+  return libc === "musl" ? [musl, glibc] : [glibc, musl];
+}
+
+async function tryResolveBinary(pkg: string, binary: string): Promise<string | undefined> {
+  const require = createRequire(import.meta.url);
+  try {
+    const packageJson = require.resolve(`${pkg}/package.json`);
+    const binPath = join(packageJson, "..", binary);
+    return (await pathExists(binPath)) ? binPath : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the bundled Claude Code native binary for the current platform.
+ *
+ * The SDK's built-in resolver tries the musl variant first on Linux. On Bun +
+ * glibc hosts (e.g. GitHub Actions Ubuntu runners), Bun ignores the npm
+ * `libc` field and installs both optional platform packages, so the SDK
+ * resolves the musl binary successfully but fails to spawn it (the kernel
+ * reports ENOENT because `/lib/ld-musl-*.so.1` is absent). Explicitly picking
+ * the variant matching the host libc avoids that failure.
+ *
+ * @returns Absolute path to the `claude` binary, or `undefined` if none matches.
+ */
+export async function resolveClaudeBinary(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch
+): Promise<string | undefined> {
+  const binary = platform === "win32" ? "claude.exe" : "claude";
+  const candidates =
+    platform === "linux"
+      ? linuxCandidates(arch, await detectLinuxLibc())
+      : [`@anthropic-ai/claude-agent-sdk-${platform}-${arch}`];
+
+  for (const pkg of candidates) {
+    const binPath = await tryResolveBinary(pkg, binary);
+    if (binPath) return binPath;
+  }
+  return undefined;
+}
+
+let log: pino.Logger | undefined;
+
+/**
+ * Check whether orchestrator-side parallel fan-out should run before the root
+ * query. Requires the feature flag, review mode, and a resolvable PR context.
+ */
+function shouldRunFanout(config: RunClaudeConfig): boolean {
+  if (process.env.PARALLEL_FANOUT !== "true") return false;
+  if (!config.prompt.includes("/autopilot:pr-review ")) return false;
+  if (!config.pluginDir) return false;
+  if (!process.env.GITHUB_REPOSITORY || !process.env.PR_NUMBER) return false;
+  return true;
+}
+
+/** Spawn the 12 review sub-agents in parallel and persist their results. */
+async function runFanoutIfEnabled(
+  config: RunClaudeConfig,
+  settingSources: ("user" | "project")[],
+  mcpServers: Record<string, McpServerConfig>,
+  pathToClaudeCodeExecutable: string | undefined
+): Promise<string | undefined> {
+  if (!log || !shouldRunFanout(config)) return undefined;
+
+  const fanoutCtx: FanoutContext = {
+    log,
+    repo: process.env.GITHUB_REPOSITORY ?? "",
+    prNumber: process.env.PR_NUMBER ?? "",
+    pluginDir: config.pluginDir ?? "",
+    mcpServers,
+    settingSources,
+    pathToClaudeCodeExecutable,
+    fallbackModel: config.model,
+    inheritedAllowedTools: config.allowedTools,
+    inheritedDisallowedTools: config.disallowedTools,
+    // Give each sub-agent 10 min — rfc-compliance historically hits ~77s.
+    subagentTimeoutMs: 10 * 60 * 1000,
+  };
+
+  const results = await runReviewFanout(fanoutCtx);
+  const outputPath = `${process.env.RUNNER_TEMP ?? "/tmp"}/precomputed-reviews.json`;
+  await Bun.write(outputPath, JSON.stringify(results, null, 2));
+  log.info({ output_path: outputPath, count: results.length }, "Fan-out results written.");
+  return outputPath;
+}
+
+/** Run Claude Code and write outputs. Exported for visibility, called from main guard. */
+async function run(): Promise<void> {
+  log = await createLogger();
+  const config = parseConfig();
+  const settingSources = await writeSettings(config.settingsJson);
+  const mcpServers = await loadMcpServers(config.mcpConfigPath);
+
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), config.timeoutMs);
+
+  const pathToClaudeCodeExecutable = await resolveClaudeBinary();
+
+  log.debug(
+    {
+      model: config.model,
+      timeout_min: config.timeoutMs / 60_000,
+      claude_binary: pathToClaudeCodeExecutable,
+    },
+    "Starting Claude execution."
+  );
+
+  const precomputedReviewsPath = await runFanoutIfEnabled(
+    config,
+    settingSources as ("user" | "project")[],
+    mcpServers,
+    pathToClaudeCodeExecutable
+  );
+
+  const messages: unknown[] = [];
+
+  const q = query({
+    prompt: config.prompt,
+    options: {
+      model: config.model,
+      allowedTools: config.allowedTools,
+      // Claude has Bash(gh:*) for reading PR data but must not post reviews/comments
+      // directly — submitReview.ts / reactToComment.ts own the submission pipeline.
+      disallowedTools: config.disallowedTools,
+      outputFormat: config.jsonSchema
+        ? { type: "json_schema" as const, schema: config.jsonSchema }
+        : undefined,
+      plugins: config.pluginDir ? [{ type: "local" as const, path: config.pluginDir }] : [],
+      mcpServers,
+      permissionMode: "bypassPermissions" as const,
+      allowDangerouslySkipPermissions: true,
+      settingSources: settingSources as ("user" | "project")[],
+      systemPrompt: { type: "preset" as const, preset: "claude_code" as const },
+      pathToClaudeCodeExecutable,
+      abortController,
+      env: {
+        ...(process.env as Record<string, string>),
+        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? "",
+        CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN ?? "",
+        GH_TOKEN: process.env.GH_TOKEN ?? "",
+        PRECOMPUTED_REVIEWS_PATH: precomputedReviewsPath ?? "",
+      },
+    },
+  });
+
+  for await (const message of q) {
+    logMessage(log, message);
+    messages.push(message);
+  }
+
+  // Prevent the 30min timer from keeping the event loop alive after completion
+  clearTimeout(timeout);
+
+  await writeExecutionFile(log, config.outputFilePath, messages);
+  await emitOutputs(log, config.outputFilePath, messages);
+}
+
+/** Write the collected SDK messages to the execution output file and log the result. */
+async function writeExecutionFile(
+  log: pino.Logger,
+  outputFilePath: string,
+  messages: unknown[]
+): Promise<void> {
+  await Bun.write(outputFilePath, JSON.stringify(messages));
+  log.info(
+    { output_file_path: outputFilePath, message_count: messages.length },
+    "Execution file written."
+  );
+}
+
+/**
+ * Emit GitHub Actions outputs from the collected messages, flag long-running
+ * sessions, and exit non-zero when the final result subtype isn't "success".
+ */
+async function emitOutputs(
+  log: pino.Logger,
+  outputFilePath: string,
+  messages: unknown[]
+): Promise<void> {
+  const resultMessage = messages.findLast(
+    (m): m is Record<string, unknown> =>
+      typeof m === "object" && m !== null && (m as Record<string, unknown>).type === "result"
+  );
+
+  const structuredOutput = resultMessage?.structured_output;
+  const conclusion = (resultMessage?.subtype as string) ?? "error";
+  const durationMs = Number(resultMessage?.duration_ms ?? 0);
+
+  await setOutput("execution_file", outputFilePath);
+  if (structuredOutput !== undefined && structuredOutput !== null) {
+    await setOutput("structured_output", JSON.stringify(structuredOutput));
+  }
+  if (durationMs > longRunMs) {
+    await setOutput("long_run", "true");
+    log.info(
+      { duration_ms: durationMs, threshold_ms: longRunMs },
+      "Long-running Claude session detected."
+    );
+  }
+
+  if (conclusion !== "success") {
+    const errors = Array.isArray(resultMessage?.errors)
+      ? (resultMessage.errors as string[]).join(", ")
+      : "No result message";
+    log.error({ conclusion, errors }, "Couldn't execute Claude: non-success result.");
+    process.exit(1);
+  }
+
+  log.info("Claude execution completed.");
+}
+
+/** Write an empty execution file as fallback on fatal error. */
+async function writeEmptyExecutionFile(): Promise<void> {
+  const outputPath =
+    process.env.EXECUTION_OUTPUT_FILE ??
+    `${process.env.RUNNER_TEMP ?? "/tmp"}/claude-execution-output.json`;
+
+  await Bun.write(outputPath, "[]");
+  await setOutput("execution_file", outputPath);
+}
+
+/** Handle fatal error: log, write empty execution file, exit. */
+async function handleFatalError(error: unknown): Promise<never> {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  log?.error({ error: errorMessage }, "Couldn't run Claude: unexpected error.");
+  if (!log) console.error(`Couldn't run Claude: ${errorMessage}`);
+
+  await writeEmptyExecutionFile().catch(() => {});
+  process.exit(1);
+}
+
+// Only execute when run directly, not when imported for testing
+if (import.meta.main) {
+  try {
+    await run();
+  } catch (error) {
+    await handleFatalError(error);
+  }
+}

--- a/.github/actions/code-review-action/src/submitReview.ts
+++ b/.github/actions/code-review-action/src/submitReview.ts
@@ -1,0 +1,316 @@
+/**
+ * Submit PR review to GitHub with inline comments validation.
+ * Validates inline comments against PR diff hunks and submits review via Octokit.
+ *
+ * @example
+ * GH_TOKEN=xxx REPO=owner/repo PR_NUMBER=123 STRUCTURED_OUTPUT='{"verdict":"approve",...}' bun run scripts/submitReview.ts
+ */
+import type { Octokit } from "@octokit/rest";
+
+import type { ReviewEvent, ReviewThread } from "./github/githubReview.ts";
+import {
+  deletePendingReviews,
+  fetchReviewThreads,
+  hasRecentBotReview,
+  parseRepoEnv,
+  readExecutionResult,
+  resolveThread,
+  unresolveThread,
+  verdictToEvent,
+} from "./github/githubReview.ts";
+
+/** Inline comment on a specific file/line in the PR */
+interface InlineComment {
+  path: string;
+  line: number;
+  body: string;
+}
+
+/** Structured output from Claude review */
+interface StructuredOutput {
+  verdict: "approve" | "requestChanges" | "comment";
+  reviewComment: string;
+  inlineComments?: InlineComment[];
+}
+
+/** Valid line location in the PR diff */
+interface ValidLine {
+  path: string;
+  line: number;
+}
+
+/** Location of a comment (path and line) */
+interface CommentLocation {
+  path: string;
+  line: number;
+}
+
+/**
+ * Parse and validate structured output from Claude.
+ * Returns null if output is empty, null string, or invalid JSON.
+ */
+function parseStructuredOutput(rawOutput: string): StructuredOutput | null {
+  const trimmed = rawOutput.trim();
+  if (!trimmed || trimmed === "null") {
+    return null;
+  }
+
+  const parsed: unknown = JSON.parse(trimmed);
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  return {
+    verdict: (obj.verdict as StructuredOutput["verdict"]) ?? "comment",
+    reviewComment: (obj.reviewComment as string) ?? "Review completed.",
+    inlineComments: (obj.inlineComments as InlineComment[]) ?? [],
+  };
+}
+
+/**
+ * Extract line range from a single diff hunk match.
+ */
+function extractHunkLines(filename: string, match: RegExpMatchArray): ValidLine[] {
+  const start = Number(match[1]);
+  const count = match[2] ? Number(match[2]) : 1;
+
+  return Array.from({ length: count }, (_, i) => ({ path: filename, line: start + i }));
+}
+
+/**
+ * Extract valid line numbers from PR diff hunks.
+ * Parses unified diff format: @@ -old,count +new,count @@
+ */
+function extractValidLines(patches: Array<{ filename: string; patch?: string }>): ValidLine[] {
+  const hunkHeaderRegex = /@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/g;
+
+  return patches
+    .filter((file) => file.patch)
+    .flatMap((file) =>
+      [...file.patch!.matchAll(hunkHeaderRegex)].flatMap((m) => extractHunkLines(file.filename, m))
+    );
+}
+
+/**
+ * Check if a comment is on a valid diff line.
+ */
+function isValidComment(comment: InlineComment, validLines: ValidLine[]): boolean {
+  return validLines.some((vl) => vl.path === comment.path && vl.line === comment.line);
+}
+
+/**
+ * Check if a comment's file:line is already mentioned in the review body.
+ * Prevents duplicate content when invalid inline comments would repeat issues.
+ */
+function isAlreadyMentioned(comment: InlineComment, reviewBody: string): boolean {
+  const pattern = `${comment.path}:${comment.line}`;
+  return reviewBody.includes(pattern);
+}
+
+/**
+ * Format invalid comments for inclusion in review body.
+ * Downgrades blockers (🚧) to suggestions (🙋‍♂️) since they're supplementary.
+ */
+function formatInvalidComments(comments: InlineComment[]): string {
+  if (comments.length === 0) {
+    return "";
+  }
+
+  const formatted = comments
+    .map((c) => {
+      const body = c.body.replaceAll("🚧", "🙋‍♂️");
+      return `**\`${c.path}:${c.line}\`**\n\n${body}`;
+    })
+    .join("\n\n");
+
+  return `\n\n---\n## Additional Comments (not in diff)\n\n${formatted}`;
+}
+
+/**
+ * Normalize review body for dedup comparison.
+ * Trims whitespace and collapses internal whitespace runs.
+ */
+function normalizeBody(body: string): string {
+  return body.trim().replaceAll(/\s+/g, " ");
+}
+
+/**
+ * Cleanup bot review threads by resolving outdated ones, duplicates, and fixed blockers.
+ * Resolves threads when:
+ * - Thread is marked outdated by GitHub (code at that line changed)
+ * - A new comment will be posted on the same path:line (prevents duplicates)
+ * - Review event is APPROVE (confirms all issues addressed)
+ */
+async function cleanupBotThreads(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  botLogin: string,
+  newCommentLocations: CommentLocation[],
+  event: ReviewEvent
+): Promise<number> {
+  const threads = await fetchReviewThreads(octokit, owner, repo, pullNumber);
+
+  const toResolve = threads.filter((thread: ReviewThread) => {
+    if (thread.isResolved) return false;
+    if (thread.firstCommentAuthor !== botLogin) return false;
+
+    // Resolve if outdated (code changed)
+    if (thread.isOutdated) return true;
+
+    // Resolve all bot threads when approving (confirms issues addressed)
+    if (event === "APPROVE") return true;
+
+    // Resolve if new comment will be posted on same location (prevents duplicates)
+    if (thread.line === null) return false;
+    return newCommentLocations.some((loc) => loc.path === thread.path && loc.line === thread.line);
+  });
+
+  for (const thread of toResolve) {
+    await resolveThread(octokit, thread.id);
+  }
+
+  return toResolve.length;
+}
+
+// Main execution
+const { octokit, owner, repoName, pullNumber, reviewer } = parseRepoEnv();
+const structuredOutput = process.env.STRUCTURED_OUTPUT ?? "";
+
+// Parse structured output
+let output = parseStructuredOutput(structuredOutput);
+
+if (!output) {
+  // Check if bot already submitted a review during execution (via MCP tools)
+  const headSha = process.env.PR_HEAD_SHA;
+  const alreadyReviewed = await hasRecentBotReview(
+    octokit,
+    owner,
+    repoName,
+    pullNumber,
+    reviewer,
+    headSha
+  );
+
+  if (alreadyReviewed) {
+    console.log("✓ Review already submitted during execution, no action needed");
+    process.exit(0);
+  }
+
+  // Try execution file fallback (with RUNNER_TEMP fallback path)
+  const executionFile =
+    process.env.EXECUTION_FILE ||
+    (process.env.RUNNER_TEMP ? `${process.env.RUNNER_TEMP}/claude-execution-output.json` : undefined);
+  const resultText = await readExecutionResult(executionFile);
+  if (!resultText) {
+    console.error("No structured output, no execution result, and no existing review found");
+    process.exit(1);
+  }
+  console.log("Structured output missing, falling back to execution result as COMMENT review");
+  output = {
+    verdict: "comment",
+    reviewComment: resultText,
+    inlineComments: [],
+  };
+}
+
+const event = verdictToEvent[output.verdict] ?? "COMMENT";
+const allComments = output.inlineComments ?? [];
+
+// Fetch PR files to validate comment line numbers
+const { data: prFiles } = await octokit.rest.pulls.listFiles({
+  owner,
+  repo: repoName,
+  pull_number: pullNumber,
+});
+
+const validLines = extractValidLines(prFiles);
+
+const validComments = allComments.filter((c) => isValidComment(c, validLines));
+const invalidComments = allComments
+  .filter((c) => !isValidComment(c, validLines))
+  .filter((c) => !isAlreadyMentioned(c, output.reviewComment));
+
+const finalBody = output.reviewComment + formatInvalidComments(invalidComments);
+
+console.log(
+  `Submitting ${event} review: ${validComments.length} inline comments, ${invalidComments.length} moved to body...`
+);
+
+// Cleanup bot threads: resolve outdated, duplicates, and fixed blockers on approval
+const newCommentLocations = validComments.map((c) => ({ path: c.path, line: c.line }));
+const resolvedCount = await cleanupBotThreads(
+  octokit,
+  owner,
+  repoName,
+  pullNumber,
+  reviewer,
+  newCommentLocations,
+  event
+);
+if (resolvedCount > 0) {
+  console.log(`✓ Resolved ${resolvedCount} review thread(s)`);
+}
+
+// Skip if consecutive approval with no new findings (avoid duplicate reviews)
+const { data: reviews } = await octokit.rest.pulls.listReviews({
+  owner,
+  repo: repoName,
+  pull_number: pullNumber,
+});
+
+const botReviews = reviews.filter((r) => r.user?.login === reviewer && r.state !== "PENDING");
+const lastBotReview = botReviews.at(-1);
+
+// Skip if last bot review has identical body (prevents duplicate from concurrent posting)
+if (lastBotReview && normalizeBody(lastBotReview.body ?? "") === normalizeBody(finalBody)) {
+  console.log("✓ Review already posted, skipping duplicate");
+  process.exit(0);
+}
+
+if (
+  event === "APPROVE" &&
+  lastBotReview?.state === "APPROVED" &&
+  validComments.length === 0 &&
+  !output.reviewComment.includes("🙋‍♂️") &&
+  !output.reviewComment.includes("💡")
+) {
+  console.log("✓ Previous review already approved, no new findings - skipping duplicate");
+  process.exit(0);
+}
+
+// Delete pending reviews before submitting
+await deletePendingReviews(octokit, owner, repoName, pullNumber);
+
+// Submit the review
+const { data: submittedReview } = await octokit.rest.pulls.createReview({
+  owner,
+  repo: repoName,
+  pull_number: pullNumber,
+  event,
+  body: finalBody,
+  comments: validComments,
+});
+
+console.log("✓ Review submitted successfully");
+
+// GitHub auto-resolves threads in APPROVE reviews — unresolve ones from this review
+if (event === "APPROVE" && validComments.length > 0) {
+  const threads = await fetchReviewThreads(octokit, owner, repoName, pullNumber);
+  const autoResolvedThreads = threads.filter(
+    (t) =>
+      t.isResolved &&
+      t.firstCommentAuthor === reviewer &&
+      t.firstCommentReviewId === submittedReview.node_id
+  );
+
+  for (const thread of autoResolvedThreads) {
+    await unresolveThread(octokit, thread.id);
+  }
+
+  if (autoResolvedThreads.length > 0) {
+    console.log(`✓ Unresolved ${autoResolvedThreads.length} auto-resolved thread(s)`);
+  }
+}

--- a/.github/actions/code-review-action/src/updatePrFooter.ts
+++ b/.github/actions/code-review-action/src/updatePrFooter.ts
@@ -1,0 +1,170 @@
+/**
+ * Update PR description with an "Available commands" help section in the footer.
+ * Manages HTML-comment-bounded sections for idempotent, multi-action help text.
+ * Fails open — errors are logged but do not block the action.
+ *
+ * @example
+ * GH_TOKEN=xxx REPO=owner/repo PR_NUMBER=123 HELP_ID=code-review-action HELP_TEXT='- `@bot review` — re-run review' bun run scripts/updatePrFooter.ts
+ */
+import type { Octokit } from "@octokit/rest";
+
+import { parseRepoEnv } from "./github/githubReview.ts";
+
+/** Configuration for the PR footer update, parsed from environment */
+interface FooterConfig {
+  octokit: Octokit;
+  owner: string;
+  repoName: string;
+  pullNumber: number;
+  helpId: string;
+  helpText: string;
+}
+
+const outerOpenTag = "<!-- code-assistants-actions-help -->";
+const outerCloseTag = "<!-- /code-assistants-actions-help -->";
+const actionOpenPrefix = "<!-- action:";
+const actionClosePrefix = "<!-- /action:";
+const tagSuffix = " -->";
+
+/** Build opening HTML comment marker for an action section */
+function actionOpenTag(id: string): string {
+  return `${actionOpenPrefix}${id}${tagSuffix}`;
+}
+
+/** Build closing HTML comment marker for an action section */
+function actionCloseTag(id: string): string {
+  return `${actionClosePrefix}${id}${tagSuffix}`;
+}
+
+/**
+ * Validate that the help ID contains only safe characters.
+ * Prevents HTML comment injection via malformed IDs.
+ */
+function validateHelpId(id: string): void {
+  if (!/^[a-z0-9-]+$/i.test(id)) {
+    throw new Error(
+      `Invalid help ID: "${id}". Must contain only alphanumeric characters and hyphens.`
+    );
+  }
+}
+
+/** Parse and validate environment variables for the footer update. */
+function parseFooterEnv(): FooterConfig {
+  const { octokit, owner, repoName, pullNumber } = parseRepoEnv();
+  const helpId = process.env.HELP_ID ?? "code-review-action";
+  const helpText = process.env.HELP_TEXT;
+
+  if (!helpText) {
+    throw new Error("Missing required environment variable: HELP_TEXT");
+  }
+
+  validateHelpId(helpId);
+
+  return { octokit, owner, repoName, pullNumber, helpId, helpText: helpText.trim() };
+}
+
+/** Build the HTML-comment-bounded section for one action. */
+function buildActionSection(helpId: string, helpText: string): string {
+  return `${actionOpenTag(helpId)}\n${helpText}\n${actionCloseTag(helpId)}`;
+}
+
+/** Build the complete footer wrapper around all action sections. */
+function buildFullFooter(innerSections: string): string {
+  return [
+    outerOpenTag,
+    "---",
+    "<details>",
+    "<summary>Available commands 🤖</summary>",
+    "<br />",
+    "",
+    innerSections,
+    "",
+    "</details>",
+    outerCloseTag,
+  ].join("\n");
+}
+
+/**
+ * Extract all action sections from the footer content.
+ * Uses indexOf-based parsing to find action ID → help text pairs.
+ */
+function extractActionSections(content: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  let searchStart = 0;
+
+  while (searchStart < content.length) {
+    const openIdx = content.indexOf(actionOpenPrefix, searchStart);
+    if (openIdx === -1) break;
+
+    const suffixIdx = content.indexOf(tagSuffix, openIdx + actionOpenPrefix.length);
+    if (suffixIdx === -1) break;
+
+    const id = content.slice(openIdx + actionOpenPrefix.length, suffixIdx);
+    const closeTag = actionCloseTag(id);
+    const closeIdx = content.indexOf(closeTag, suffixIdx);
+    if (closeIdx === -1) break;
+
+    const sectionContent = content.slice(suffixIdx + tagSuffix.length, closeIdx).trim();
+    sections.set(id, sectionContent);
+    searchStart = closeIdx + closeTag.length;
+  }
+
+  return sections;
+}
+
+/**
+ * Compute the updated PR body with the help footer.
+ * Uses a "collect and rebuild" strategy for idempotent updates.
+ */
+function updateBody(currentBody: string, helpId: string, helpText: string): string {
+  const startIdx = currentBody.indexOf(outerOpenTag);
+  const endIdx = currentBody.indexOf(outerCloseTag);
+
+  let userBody: string;
+  let sections: Map<string, string>;
+
+  if (startIdx !== -1 && endIdx !== -1) {
+    userBody = currentBody.slice(0, startIdx).trimEnd();
+    const footerContent = currentBody.slice(startIdx, endIdx + outerCloseTag.length);
+    sections = extractActionSections(footerContent);
+  } else {
+    userBody = currentBody.trimEnd();
+    sections = new Map();
+  }
+
+  sections.set(helpId, helpText);
+
+  const sectionsStr = [...sections.entries()]
+    .map(([id, text]) => buildActionSection(id, text))
+    .join("\n\n");
+
+  const separator = userBody.length > 0 ? "\n\n" : "";
+  return `${userBody}${separator}${buildFullFooter(sectionsStr)}`;
+}
+
+try {
+  const config = parseFooterEnv();
+
+  const { data: pr } = await config.octokit.rest.pulls.get({
+    owner: config.owner,
+    repo: config.repoName,
+    pull_number: config.pullNumber,
+  });
+
+  const currentBody = pr.body ?? "";
+  const updatedBody = updateBody(currentBody, config.helpId, config.helpText);
+
+  if (updatedBody === currentBody) {
+    console.log("✓ Help footer already up to date, skipping update");
+  } else {
+    await config.octokit.rest.pulls.update({
+      owner: config.owner,
+      repo: config.repoName,
+      pull_number: config.pullNumber,
+      body: updatedBody,
+    });
+    console.log(`✓ Help footer updated for action: ${config.helpId}`);
+  }
+} catch (error) {
+  console.error("PR footer update error (fail-open, proceeding):", error);
+}

--- a/.github/actions/code-review-action/tsconfig.json
+++ b/.github/actions/code-review-action/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ See the [plugin README](./claude-plugins/autopilot/README.md#installation) for s
 - [`contributing-check`](./.github/actions/contributing-check/README.md) — validate branch name, commit messages, and PR title against `CONTRIBUTING.md`
 - [`contributing-sync`](./.github/actions/contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, and the contributing workflow from upstream
 - [`release-action`](./.github/actions/release-action/README.md) — conventional-commit-driven release pipeline for npm packages, GitHub Actions, and Claude plugins
+- [`code-review-action`](./.github/actions/code-review-action/README.md) — AI code review for pull requests via Claude Code, with a react mode for replying to bot mentions
 
 ## Contributing
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,20 @@
         "typescript": "6.0.3",
       },
     },
+    ".github/actions/code-review-action": {
+      "name": "@code-assistants/code-review-action",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.2.126",
+        "@octokit/rest": "22.0.1",
+        "pino": "10.3.1",
+        "zod": "4.4.3",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+        "typescript": "6.0.3",
+      },
+    },
     ".github/actions/files-sync": {
       "name": "@code-assistants/files-sync-action",
       "version": "0.0.0",
@@ -91,6 +105,24 @@
 
     "@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
 
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.126", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.126", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.126" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-4ZrVu0XUEwNG6wxvsLgppRAmSfAf3oeEMEUPhgazb0AXUUe/7W8MxwZKJWOffqSLWaNYzOt3ZCIL7NJY6toqWw=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.126", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JFlJBbeAlx7Ic5s4lGUN9SppobryXk/lIqPCvhp6KrJTQIerh3MIBzxsVIJ0MaDut7jVni/oYgsvDni7NIyqHA=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.126", "", { "os": "darwin", "cpu": "x64" }, "sha512-J8BpMj16NK9FUaG3HnHSivyp4Xww9DKWHiC8QSHT9oiT8pH5IG7nl0jxyjIq/lY79evlTY+ubgDVWlMUhUAN/g=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.126", "", { "os": "linux", "cpu": "arm64" }, "sha512-LM+mnfQsgI+1i5mYZwIPDDf14NGBu5wbhzm5U8P11dCa2p8sXmKoWpkbO16BFM2NxeW44I/RXCxE5qFsbz4zcg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.126", "", { "os": "linux", "cpu": "arm64" }, "sha512-GO0BnIUw3LQ3XAy+nipAabkN0GwQGPhHB6ITI4XLoR99fLHB3TA6WfyvTf0fnpxd25A+c/+UsAoxz4zBQaHlhA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.126", "", { "os": "linux", "cpu": "x64" }, "sha512-yaOTDcYCdscxC0LKg9w8IwSa5g+993WggFZJBTZpqvflA2+WMQeTarDnKlsFTCw9XUZkL8XZeBALYJGx0HutuA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.126", "", { "os": "linux", "cpu": "x64" }, "sha512-ByJGO0+mu7EplxSFSCIHd7QWsXdrF3qgtzQ177o/j+oSppLoqR1ot5ktf8aw5oR3CC5lFHg4tqd6TnneQpEoIg=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.126", "", { "os": "win32", "cpu": "arm64" }, "sha512-gv3MOsOBkCx3LajOOIjD7AKsOtz/qNHsS2oshGt2GVoy7JA3XbCDeCetDjM6SorV4SE+7F/IH0UJdXe5ejI/Zg=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.126", "", { "os": "win32", "cpu": "x64" }, "sha512-oRV75HwyoOd1/t5+kipAM2g62CaElpKGvSBx3Ys4lCwCiFUyOnmet/O+hRXENsY6ShDeQZEcJL2UWljr2d5NQw=="],
+
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.92.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -102,6 +134,8 @@
     "@code-assistants/actions-core": ["@code-assistants/actions-core@workspace:packages/actions-core"],
 
     "@code-assistants/agents-rules-sync-action": ["@code-assistants/agents-rules-sync-action@workspace:.github/actions/agents-rules-sync"],
+
+    "@code-assistants/code-review-action": ["@code-assistants/code-review-action@workspace:.github/actions/code-review-action"],
 
     "@code-assistants/files-sync-action": ["@code-assistants/files-sync-action@workspace:.github/actions/files-sync"],
 
@@ -143,6 +177,10 @@
 
     "@conventional-changelog/git-client": ["@conventional-changelog/git-client@2.7.0", "", { "dependencies": { "@simple-libs/child-process-utils": "^1.0.0", "@simple-libs/stream-utils": "^1.2.0", "semver": "^7.5.2" }, "peerDependencies": { "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.4.0" }, "optionalPeers": ["conventional-commits-filter", "conventional-commits-parser"] }, "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
     "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
@@ -166,6 +204,8 @@
     "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
 
@@ -213,9 +253,13 @@
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -229,13 +273,21 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -249,7 +301,9 @@
 
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
 
-    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "conventional-changelog": ["conventional-changelog@7.2.0", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "@simple-libs/hosted-git-info": "^1.0.2", "@types/normalize-package-data": "^2.4.4", "conventional-changelog-preset-loader": "^5.0.0", "conventional-changelog-writer": "^8.3.0", "conventional-commits-parser": "^6.3.0", "fd-package-json": "^2.0.0", "meow": "^13.0.0", "normalize-package-data": "^7.0.0" }, "bin": { "conventional-changelog": "dist/cli/index.js" } }, "sha512-BEdgG+vPl53EVlTTk9sZ96aagFp0AQ5pw/ggiQMy2SClLbTo1r0l+8dSg79gkLOO5DS1Lswuhp5fWn6RwE+ivg=="],
 
@@ -267,19 +321,33 @@
 
     "conventional-recommended-bump": ["conventional-recommended-bump@11.2.0", "", { "dependencies": { "@conventional-changelog/git-client": "^2.5.1", "conventional-changelog-preset-loader": "^5.0.0", "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.1.0", "meow": "^13.0.0" }, "bin": { "conventional-recommended-bump": "dist/cli/index.js" } }, "sha512-lqIdmw330QdMBgfL0e6+6q5OMKyIpy4OZNmepit6FS3GldhkG+70drZjuZ0A5NFpze5j85dlYs3GabQXl6sMHw=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
 
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.3.0", "", { "dependencies": { "jiti": "2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -299,9 +367,21 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
@@ -313,9 +393,15 @@
 
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -343,15 +429,27 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "hono": ["hono@4.12.22", "", {}, "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw=="],
+
     "hosted-git-info": ["hosted-git-info@8.1.0", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
@@ -365,9 +463,15 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -378,6 +482,8 @@
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
@@ -395,7 +501,11 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
     "meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -407,9 +517,21 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "normalize-package-data": ["normalize-package-data@7.0.1", "", { "dependencies": { "hosted-git-info": "^8.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
@@ -425,13 +547,41 @@
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -443,15 +593,41 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -463,7 +639,11 @@
 
     "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
 
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
@@ -473,13 +653,19 @@
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
+
     "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
 
     "turbo": ["turbo@2.9.14", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.14", "@turbo/darwin-arm64": "2.9.14", "@turbo/linux-64": "2.9.14", "@turbo/linux-arm64": "2.9.14", "@turbo/windows-64": "2.9.14", "@turbo/windows-arm64": "2.9.14" }, "bin": { "turbo": "bin/turbo" } }, "sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
@@ -491,13 +677,21 @@
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -509,13 +703,25 @@
 
     "zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
+
     "@code-assistants/agents-rules-sync-action/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@code-assistants/code-review-action/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@code-assistants/files-sync-action/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@commitlint/is-ignored/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "@conventional-changelog/git-client/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "cli-truncate/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
@@ -524,6 +730,8 @@
     "conventional-changelog-writer/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "cosmiconfig/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -535,8 +743,24 @@
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "wrap-ansi/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "cosmiconfig/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     ".github/actions/files-sync",
     ".github/actions/agents-rules-sync",
     ".github/actions/release-action",
+    ".github/actions/code-review-action",
     "packages/*"
   ],
   "scripts": {


### PR DESCRIPTION
Imports an AI-powered code review composite action under .github/actions/code-review-action. The action runs Claude Code against PR diffs and posts structured review verdicts, plus a react mode for replying to bot mentions in comment threads. Wired to the in-repo autopilot plugin (no external plugin clone).

- New workspace package @code-assistants/code-review-action with composite action.yml exposing review and react modes, plus ported scripts for runClaude, submitReview, reactToComment, preflightChecks, reviewFanout, logClaudeMessage, updatePrFooter, and github/githubReview
- Slash-command surface remapped to /autopilot:pr-review and /autopilot:pr-answer; plugin install step replaced by a pointer to claude-plugins/autopilot
- reviewer input is required (no default); CI-skip label is ci-skip-review; help-footer tag renamed to code-assistants-actions-help
- Workspace entry added to root package.json with bun.lock regenerated; new action linked from the root README actions table

---

**Issues:**

Closes #32

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a composite GitHub Action for AI code review powered by Claude Code that reviews PR diffs, reacts to bot mentions, and posts structured approvals, change requests, or comments. Closes #32.

- **New Features**
  - New workspace package `@code-assistants/code-review-action` with `review` and `react` modes, wired to the in-repo autopilot plugin (no external clone).
  - Auto-routes PR and comment events; skips drafts, release branches, and dependabot; preflight waits for sibling checks and aborts on failures.
  - Parallel fan-out executes 12 review sub-agents; structured logs and execution artifacts for downstream steps.
  - GitHub helpers to submit reviews, validate inline comments against hunks, resolve/unresolve threads, and update a PR footer help section.
  - Slash commands remapped to `/autopilot:pr-review` and `/autopilot:pr-answer`; reviewer input is required.
  - Label/tag updates: CI skip label is `ci-skip-review`; footer wrapper tag is `code-assistants-actions-help`. Root README links the new action.
  - Stack detection now reads `agents.rules` from `package.json` for platform-aware review fan-out.

- **Migration**
  - Add a workflow that uses `.github/actions/code-review-action` (default mode is `review`).
  - Use `/autopilot:pr-review` and `/autopilot:pr-answer` for on-demand runs.
  - Update any CI-skip automation to use the `ci-skip-review` label.
  - Pass an explicit reviewer to the action.

<sup>Written for commit d54d291bf1f7b6ce32b8a7d0f88a2bf0c220ad6e. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

