### PR TITLE
Skip confirmation prompts in /autopilot:run sub-skills

### DIFF
--- a/claude-plugins/autopilot/.claude-plugin/plugin.json
+++ b/claude-plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Autopilot: plan, implement, commit, PR, and monitor — skills and agents for AI-assisted development workflows",
   "author": {
     "name": "Tony Vi",

--- a/claude-plugins/autopilot/skills/branch:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/branch:create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: branch:create
 description: Create and checkout a git branch following repository naming conventions with GitHub issue integration. Use when creating branches, or when invoked from other skills.
-argument-hint: <ISSUE-NUMBER> [description] [--trivial | --hotfix | --maintenance | --proposal]
+argument-hint: <ISSUE-NUMBER> [description] [--trivial | --hotfix | --maintenance | --proposal] [--autopilot]
 allowed-tools:
   - Bash(git *)
   - Read
@@ -30,6 +30,7 @@ Expected forms:
 - `<ISSUE-NUMBER>` — GitHub issue number (e.g., `123` or `#123`). Used to fetch the issue and to build the branch name `issue-<number>-<slug>`.
 - `<ISSUE-NUMBER> "<description>"` — issue number plus custom branch slug description
 - `--hotfix "<description>"` / `--trivial "<description>"` / `--maintenance "<description>"` / `--proposal "<description>"` — special prefix branches without a GitHub issue
+- `--autopilot` — non-interactive mode used by `/autopilot:run`. Skips the Phase 5 confirmation prompt and creates the branch directly with the auto-generated name. Conflict resolution (Phase 4) and validation errors still surface.
 
 ## Input resolution
 
@@ -38,6 +39,7 @@ Arguments are optional. When `$ARGUMENTS` is empty OR a field is missing, resolv
 - **Issue number** — `$ARGUMENTS` → parse current branch name for `^issue-([0-9]+)` → prompt user only if none found and no special prefix flag is present.
 - **Description** — `$ARGUMENTS` → generate from GitHub issue title via Phase 3 rules → no user prompt (auto-generate always succeeds).
 - **Special prefix flags** (`--hotfix` / `--trivial` / `--maintenance` / `--proposal`) — `$ARGUMENTS` only. Never inferred. Default: none.
+- **`--autopilot`** — `$ARGUMENTS` only. Never inferred. Default: `false` (interactive mode).
 - **Repository conventions** — read `CONTRIBUTING.md` directly from the repository root.
 
 ## Phase 0: Preflight Check
@@ -47,6 +49,7 @@ Invoke `Skill(autopilot:preflight-check)` with `mode: branch` from this conversa
 ## Phase 1: Input Validation
 
 1. **Parse `$ARGUMENTS`** (shell-quoted positional tokens):
+   - Check for `--autopilot`: if present, strip it from the arguments and set `autopilotMode = true`. Otherwise `autopilotMode = false`.
    - Check for special prefix flags: `--trivial`, `--hotfix`, `--maintenance`, `--proposal`
    - If flag found: extract description from remaining arguments
    - If no flag: extract first argument as issue number, optional description
@@ -155,6 +158,8 @@ Invoke `Skill(autopilot:preflight-check)` with `mode: branch` from this conversa
    - `multiSelect`: false
 
 ## Phase 5: Verify with User
+
+**Autopilot bypass:** If `autopilotMode` is true (from Phase 1), skip this entire phase and proceed directly to Phase 6 with the resolved branch name. Do NOT call AskUserQuestion.
 
 Present branch details and confirm using **AskUserQuestion tool**.
 

--- a/claude-plugins/autopilot/skills/commits:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/commits:create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commits:create
 description: Analyze staged changes and create conventional commits with intelligent grouping. Use when creating commits, or when invoked from other skills.
-argument-hint: "[optional commit context]"
+argument-hint: "[optional commit context] [--autopilot]"
 allowed-tools:
   - Bash(git *)
   - Bash(gh *)
@@ -29,16 +29,20 @@ Expected form:
 
 - (no arguments) — auto-analyze staged changes
 - `"<context>"` — free-form context that helps generate a better commit message (e.g., `"add auth feature"`)
+- `--autopilot` — non-interactive mode used by `/autopilot:run`. Skips commit-strategy, commit-message, and PR-update prompts and commits directly using the auto-generated messages.
 
 ## Input resolution
 
 Arguments are optional. When `$ARGUMENTS` is empty:
 
 - **Commit context** — skip; rely on the diff itself (`git diff --staged`) plus recent conversation history (skill analyses, user instructions) to generate the message. Do NOT prompt.
+- **`--autopilot`** — `$ARGUMENTS` only. Never inferred. Default: `false` (interactive mode). Strip from `$ARGUMENTS` before parsing the remainder as commit context.
 - **Repository conventions** — read `CONTRIBUTING.md` directly from the repository root.
 - **Existing PR** — detect via `gh pr view --json number,url 2>/dev/null` at Phase 5. No user prompt needed.
 
 ## AskUserQuestion Contract (MANDATORY)
+
+**Autopilot bypass:** When `autopilotMode` is true (from Phase 1), this entire contract is moot — every AskUserQuestion call in Phases 3, 4, and 5 is skipped. Generate the commit message(s), commit directly, and exit without prompting.
 
 Every AskUserQuestion call that presents content for review (commit messages) MUST follow these exact rules. Simple choice dialogs (Phase 3 commit strategy, Phase 5 PR update offer) are exempt from the preview requirement.
 
@@ -110,6 +114,7 @@ Invoke `Skill(autopilot:preflight-check)` with `mode: commits` from this convers
 
 ## Phase 1: Check for Changes
 
+0. Parse `$ARGUMENTS`: if it contains `--autopilot`, strip the flag and set `autopilotMode = true`. Otherwise `autopilotMode = false`. The remainder (if any) is the commit context.
 1. Run `git status` to see current state
 2. If there are unstaged changes:
    - Show the list of modified/untracked files
@@ -131,6 +136,8 @@ Use the Agent tool with:
 After the agent completes, store the structured results (categories, file lists, strategy recommendation, recent commit style).
 
 ## Phase 3: Choose Commit Strategy
+
+**Autopilot bypass:** If `autopilotMode` is true, do NOT call AskUserQuestion. Use single commit flow when `singleCommitRecommended: true`; otherwise use grouped commit flow. Proceed to Phase 4.
 
 Use the agent's analysis to decide the commit flow:
 
@@ -162,6 +169,9 @@ Use the agent's analysis to decide the commit flow:
 3. Generate commit message following the format below — the title must name the specific thing that changed, and the body must list the concrete modifications
 4. **WHAT-not-WHY validation**: Check the generated title against the WHY signal words and vague signal words listed in the WHAT-not-WHY Rule section below. If the title contains any of those words followed by abstract goals (not technical specifics), or contains the words "review", "feedback", "comments", or "suggestions", regenerate the title using only concrete technical details from the diff. Repeat up to 3 times. If the title still fails, present it to the user with a note that it may need manual rewording.
 5. Verify the title is at most 72 characters: run `printf '%s' "<title>" | wc -m`. If the count exceeds 72, regenerate a shorter title and re-run the check. Do not present a title to the user that exceeds 72 characters.
+
+**Autopilot bypass:** If `autopilotMode` is true, skip steps 6–9 below. Run `git commit -m "<message>"` directly with the generated message and continue to Phase 5.
+
 6. Present using **AskUserQuestion tool** with preview:
 
    **Preview content rules:**
@@ -215,6 +225,8 @@ For each category that has files:
 After analyzing all categories, `git reset HEAD` to unstage everything.
 
 #### Step 2: Present all commits in one dialog
+
+**Autopilot bypass:** If `autopilotMode` is true, skip this step entirely. Skip to Step 3 and execute each commit directly with its generated message.
 
 Use a **single AskUserQuestion** with multiple questions (one per commit), each with preview.
 
@@ -339,6 +351,8 @@ The title must "contain the answer" — a reader should understand what changed 
 **Vague signal words to avoid in titles:** "update", "fix stuff", "changes", "improvements", "tweaks", "adjustments", "various", "some", "misc", "review updates", "address feedback", "resolve issue", "close gaps", "cover edge cases", "ensure compliance", "improve handling", "address concerns", "satisfy requirements"
 
 ## Phase 5: Offer PR Update
+
+**Autopilot bypass:** If `autopilotMode` is true, skip this entire phase — the calling skill (`/autopilot:run`) creates or updates the PR itself in its next step.
 
 After all commits are created successfully:
 

--- a/claude-plugins/autopilot/skills/pr:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr:create
 description: Create a pull request with validated title and description following repository conventions. Use when creating PRs, or when invoked from other skills.
-argument-hint: "[--draft] [--release-notes] [--closes #N,#M] [--related #X,#Y]"
+argument-hint: "[--draft] [--release-notes] [--closes #N,#M] [--related #X,#Y] [--autopilot]"
 allowed-tools:
   - Bash(git *)
   - Bash(gh *)
@@ -30,6 +30,7 @@ Expected flags (all optional, any order):
 - `--release-notes` — include a release notes section in the body (auto-enabled on breaking changes)
 - `--closes #N,#M` — additional issue numbers to close on merge (comma-separated, GitHub issue numbers)
 - `--related #X,#Y` — related issues to link without closing (comma-separated, GitHub issue numbers)
+- `--autopilot` — non-interactive mode used by `/autopilot:run`. Skips the Phase 5 confirmation prompt and creates the PR directly with the generated title and body. When meaningful changes are detected (Phase 2), release notes are auto-added.
 
 ## Input resolution
 
@@ -39,6 +40,7 @@ Arguments are optional. Resolve each field in this order:
 - **`--release-notes`** — `$ARGUMENTS` → auto-enable when Phase 2 detects breaking changes → default `false`. Do NOT prompt (user gets an "Add release notes" option in Phase 5 preview).
 - **`--closes`** — `$ARGUMENTS` → branch-name-derived issue number is already added automatically in Phase 4. No prompt; treat absence as intentional.
 - **`--related`** — `$ARGUMENTS` → no inference. No prompt; treat absence as intentional.
+- **`--autopilot`** — `$ARGUMENTS` only. Never inferred. Default: `false` (interactive mode).
 - **Branch + base + issue number** — from `git branch --show-current` and the branch-name pattern `^issue-([0-9]+)-`. Special prefix branches (`hotfix-`, `trivial-`, `maintenance-`, `proposal-`) have no issue number. No prompt.
 - **Repository conventions** — read `CONTRIBUTING.md` directly from the repository root.
 
@@ -49,6 +51,8 @@ This workflow is not complete until Phase 6 executes `gh pr create` and outputs 
 Do not call any skill not listed in `allowed-tools` above. The title and description rules in Phases 3-4 are the validation — there is no separate validation step.
 
 ## AskUserQuestion Contract (MANDATORY)
+
+**Autopilot bypass:** When `autopilotMode` is true (from Phase 1), this contract is moot — the Phase 5 confirmation prompt is skipped. Generate the title and body, then proceed directly to Phase 6.
 
 Every AskUserQuestion call that presents content for review (PR previews in Phase 5) MUST follow these exact rules. Simple choice dialogs (Phase 1 uncommitted changes) are exempt from the preview requirement.
 
@@ -109,6 +113,7 @@ Invoke `Skill(autopilot:preflight-check)` with `mode: pr` from this conversation
 
 Uncommitted-change handling is done in Phase 0 by `preflight-check` — do not repeat it here.
 
+0. Parse `$ARGUMENTS`: if it contains `--autopilot`, set `autopilotMode = true` and remove the flag before further parsing. Otherwise `autopilotMode = false`.
 1. Get current branch name with `git branch --show-current`
 2. Validate branch name follows convention:
    - Standard: `issue-<number>-<short-description>` (e.g., `issue-123-add-feature`)
@@ -267,6 +272,11 @@ Closes #<issue-from-branch>
 ```
 
 ## Phase 5: Verify with User
+
+**Autopilot bypass:** If `autopilotMode` is true, skip the AskUserQuestion confirmation below. Before proceeding to Phase 6:
+
+- If meaningful changes are detected (Phase 2 step 7) AND neither `--release-notes` nor breaking changes triggered the release notes section, auto-generate the `**Release notes:**` section using the rules in Phase 4 and insert it between the description and the `**Issues:**` section (with `---` separators).
+- Then proceed directly to Phase 6 with the resulting title and body.
 
 Present PR details using **AskUserQuestion tool** with preview.
 

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -260,7 +260,7 @@ Use this body for the `## Pre-Implementation` section:
 ```
 ## Pre-Implementation
 
-Invoke `Skill(autopilot:branch-create)` with the resolved issue number (e.g., `42` for `#42`). The branch-create skill fetches the issue, generates an `issue-<number>-<slug>` branch name, and prompts the user to confirm before creation. Do NOT present a Hotfix/Trivial/Maintenance prefix prompt — issue inputs always use the `issue-<number>-<slug>` convention so the PR can link back via `Closes #<number>`.
+Invoke `Skill(autopilot:branch-create)` with arguments `<issue-number> --autopilot` (e.g., `42 --autopilot` for `#42`). The branch-create skill fetches the issue, generates an `issue-<number>-<slug>` branch name, and creates the branch directly without a confirmation prompt (the `--autopilot` flag suppresses Phase 5). Do NOT present a Hotfix/Trivial/Maintenance prefix prompt — issue inputs always use the `issue-<number>-<slug>` convention so the PR can link back via `Closes #<number>`. Conflict resolution still surfaces if the branch already exists.
 ```
 
 ##### Input type is `plain description`
@@ -270,7 +270,7 @@ Use this body for the `## Pre-Implementation` section:
 ```
 ## Pre-Implementation
 
-Choose a branch type for this change using AskUserQuestion:
+Choose a branch type for this change using AskUserQuestion (this is the one prompt autopilot keeps — picking a special-prefix type cannot be inferred from a free-form description):
 
 Tool parameters:
 - `question`: "Choose a branch type for this change."
@@ -282,7 +282,7 @@ Tool parameters:
   ]
 - `multiSelect`: false
 
-Then invoke `/autopilot:branch-create --<chosen-prefix> "<description>"` using the Skill tool, where `<description>` is a short summary derived from the user description. The branch name MUST be approved by the user via AskUserQuestion before creation — do not skip approval or create the branch directly with git commands.
+Then invoke `Skill(autopilot:branch-create)` with arguments `--<chosen-prefix> "<description>" --autopilot`, where `<description>` is a short summary derived from the user description. The `--autopilot` flag suppresses the Phase 5 confirmation so the branch is created directly with the generated name. Conflict resolution still surfaces if the branch already exists.
 ```
 
 #### Otherwise (not on `main` AND (`isWorktree` is false OR `worktreeNeedsBranch` is false))
@@ -300,12 +300,7 @@ After all implementation steps and verification are complete, execute the follow
 
 ### Step 1: Auto-Commit
 
-Invoke `Skill(autopilot:commits-create)`. Follow the skill's full workflow — do NOT run `git commit` directly.
-
-**Autopilot override:** This is autopilot mode — the user has pre-authorized automatic approval of commit messages. When the commits:create skill presents commit options via AskUserQuestion:
-- For commit strategy: auto-select "Single commit (Recommended)" unless the skill strongly recommends splitting
-- For commit message confirmation: auto-select "Commit" — do NOT select "Edit" or "Cancel"
-- Skip the "Offer PR Update" step (Phase 5 in commits:create) — the PR will be created in Step 2
+Invoke `Skill(autopilot:commits-create)` with arguments `--autopilot`. The `--autopilot` flag suppresses commits:create's commit-strategy prompt (Phase 3), commit-message confirmation (Phase 4), and PR-update offer (Phase 5). Follow the skill's full workflow — do NOT run `git commit` directly.
 
 If the commit fails due to a pre-commit hook, check `git status` for modified files (hook may have auto-formatted), re-stage with `git add -u`, and retry the commit once. If still fails, report the error and stop.
 
@@ -316,16 +311,11 @@ After committing, push: `git push -u origin <branch>`
 **CRITICAL — direct `gh pr create` and `gh pr edit` are FORBIDDEN in autopilot.** ALL PR creation and updates MUST go through `Skill(autopilot:pr-create)` and `Skill(autopilot:pr-update)`. Direct CLI calls produce PRs in the incorrect format. If a skill call fails or times out, report the error and stop — do NOT fall back to direct CLI commands.
 
 1. Check if PR already exists: `gh pr view --json number,url`
-   - If exit code 0 (PR exists): invoke `Skill(autopilot:pr-update)` — NEVER run `gh pr edit` directly. Proceed to format check below.
+   - If exit code 0 (PR exists): invoke `Skill(autopilot:pr-update)` — NEVER run `gh pr edit` directly. (pr:update has no user-facing confirmation prompt in the autopilot flow today, so no flag is needed.) Proceed to format check below.
    - If exit code 1 (no PR): proceed with creation below
    - If other error (network/auth): report error and stop
 
-2. Invoke `Skill(autopilot:pr-create)`. NEVER run `gh pr create` directly — even if the skill fails or times out. If the skill errors, report the failure and stop. Do NOT fall back to direct CLI.
-
-**Autopilot override:** This is autopilot mode — the user has pre-authorized automatic approval of PR content. When the pr:create skill presents PR options via AskUserQuestion:
-- For uncommitted changes check: auto-select "Continue anyway" (changes were already committed in Step 1)
-- For PR confirmation: auto-select "Create PR" — do NOT select "Edit content" or "Cancel"
-- If "Add release notes" option appears and the implementation includes user-facing changes (feat: or fix: commits), auto-select "Add release notes" first, then "Create PR"
+2. Invoke `Skill(autopilot:pr-create)` with arguments `--autopilot` (append `--release-notes` when the branch's commits include `feat:` or `fix:` types so user-facing notes are included). The `--autopilot` flag suppresses pr:create's Phase 5 confirmation. Release notes are added automatically for breaking changes regardless of the flag. NEVER run `gh pr create` directly — even if the skill fails or times out. If the skill errors, report the failure and stop. Do NOT fall back to direct CLI.
 
 Output the PR URL after creation.
 


### PR DESCRIPTION
The /autopilot:run skill promised hands-off execution but still triggered AskUserQuestion confirmations during branch creation, commit creation, and PR creation. Users had to click through dialogs for steps they had already authorized by choosing run instead of plan, and the prior workaround relied on the model reliably picking the recommended option each turn.

This change introduces an explicit `--autopilot` flag that `branch:create`, `commits:create`, and `pr:create` honor by skipping their content-confirmation prompts. The run skill now passes the flag on every sub-skill invocation, replacing the fragile "model auto-selects the recommended option" workaround.

- Add `--autopilot` argument to `branch:create`, `commits:create`, and `pr:create` that bypasses Phase 5 confirmation (branch name), Phase 3/4 prompts (commit strategy and message), and Phase 5 PR-update offer
- Update `run/SKILL.md` to pass `--autopilot` to each sub-skill and drop the "Autopilot override" instruction blocks
- Bump autopilot plugin version from 0.3.0 to 0.4.0
- Destructive-action guards (branch-name conflict resolution, no-staged-changes check) remain interactive
- The `plan` skill keeps invoking sub-skills without the flag, preserving today's interactive behavior

---

**Release notes:**

- `/autopilot:run` now creates branches, commits, and PRs without prompting for confirmation at each step
- New `--autopilot` flag on `branch:create`, `commits:create`, and `pr:create` enables non-interactive mode for skills that orchestrate them

---

**Issues:**

Closes #37