### PR TITLE
Declare agents field on workspace modules

### DIFF
--- a/.github/actions/agents-rules-sync/package.json
+++ b/.github/actions/agents-rules-sync/package.json
@@ -8,6 +8,10 @@
   "release": {
     "type": "github-action"
   },
+  "agents": {
+    "rules": "Bun",
+    "language": "typescript"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test",

--- a/.github/actions/code-review-action/package.json
+++ b/.github/actions/code-review-action/package.json
@@ -8,6 +8,10 @@
   "release": {
     "type": "github-action"
   },
+  "agents": {
+    "rules": "Bun",
+    "language": "typescript"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test",

--- a/.github/actions/files-sync/package.json
+++ b/.github/actions/files-sync/package.json
@@ -8,6 +8,10 @@
   "release": {
     "type": "github-action"
   },
+  "agents": {
+    "rules": "Bun",
+    "language": "typescript"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test",

--- a/.github/actions/release-action/package.json
+++ b/.github/actions/release-action/package.json
@@ -8,6 +8,10 @@
   "release": {
     "type": "github-action"
   },
+  "agents": {
+    "rules": "Bun",
+    "language": "typescript"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test",

--- a/docs/agents-field.md
+++ b/docs/agents-field.md
@@ -8,7 +8,7 @@ Several Autopilot skills behave differently per stack — `/plan` delegates to a
 
 ## Location
 
-A single object under the top-level key `agents` in the repository-root `package.json`:
+An object under the top-level key `agents` in a `package.json`:
 
 ```json
 {
@@ -21,6 +21,16 @@ A single object under the top-level key `agents` in the repository-root `package
 ```
 
 The field coexists with normal npm metadata. It is not consumed by npm, Bun, or any package manager — only by Autopilot skills.
+
+### Workspaces
+
+Consuming skills always read the **repository-root** `package.json` to detect stack and language; workspace members are not walked. Members may declare their own `agents` field anyway, and this repository does so on every workspace member to keep stack metadata visible at every module boundary — consistent with the per-member `docs/`, `CLAUDE.md`, and `AGENTS.md` convention recorded in `docs/workspace-structure.md`.
+
+Rules for member declarations:
+
+- The value should match the root unless the member genuinely uses a different stack or language.
+- Members do not override the root for skill detection today; if a future consumer reads the nearest `package.json` instead, the member declaration takes effect automatically.
+- A member may omit the field; nothing breaks because root still drives detection.
 
 ## Spec
 

--- a/packages/actions-core/package.json
+++ b/packages/actions-core/package.json
@@ -5,6 +5,10 @@
   "private": true,
   "type": "module",
   "license": "MIT",
+  "agents": {
+    "rules": "Bun",
+    "language": "typescript"
+  },
   "exports": {
     "./fetchRawContent": "./src/fetchRawContent.ts"
   },


### PR DESCRIPTION
Declares the `agents` field on every workspace member's `package.json` and updates the spec to document the convention. Resolves option B from the issue: each member declares its own field, root remains authoritative for skill detection today.

- Added `agents: { rules: "Bun", language: "typescript" }` to four `.github/actions/*` package.json files and `packages/actions-core/package.json`
- Generalized the Location section in `docs/agents-field.md` and added a Workspaces subsection describing when members should mirror the root

---

**Issues:**

Closes #43

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an `agents` field to each workspace member and document the workspace convention; the root `package.json` remains the source of truth for detection. Implements option B from #43.

- **New Features**
  - Added `agents: { rules: "Bun", language: "typescript" }` to `.github/actions/{agents-rules-sync,code-review-action,files-sync,release-action}` and `packages/actions-core`.
  - Updated `docs/agents-field.md` to allow `agents` in any `package.json` and documented Workspaces rules (members mirror root unless different; members don’t override root today).

<sup>Written for commit eff5e19c3cb47e004484d2b1f42b04abbd3a1d85. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/44?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

