### PR TITLE
Add monorepo support to release-action

### DIFF
--- a/.github/actions/release-action/README.md
+++ b/.github/actions/release-action/README.md
@@ -165,6 +165,78 @@ Store the token as a secret (e.g. `GH_TOKEN`) and pass it via `github_token: ${{
 
 The Configure Git step inside the action commits as `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`.
 
+## Monorepo mode
+
+When the repository root declares either `release.members` or a `workspaces` array, `release-action` switches to **monorepo mode** and runs the create/publish flow once per release-eligible workspace member.
+
+### Discovery
+
+| Source                                          | Effect                                                                                                                         |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Root `release.members: string[]`                | Explicit allow-list of workspace paths. Preferred when not every workspace member should release.                              |
+| Root `workspaces: string[]`                     | Fallback when `release.members` is absent. Each glob is expanded and every member with a `release` field is included.          |
+| Member without its own `release` field          | Skipped (internal-only).                                                                                                       |
+| No eligible members AND root has `release.type` | Standalone fallback — the legacy single-artifact pipeline runs against the repo root, identical to the pre-monorepo behaviour. |
+
+### Per-member behaviour
+
+| Concern            | Standalone                   | Monorepo (per member)                                                                                   |
+| ------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Last tag           | `v*`                         | `<name>@v*` (e.g. `release-action@v1.2.0`)                                                              |
+| Floating major tag | `v1` (`github-action` only)  | `<name>@v1` (`github-action` only)                                                                      |
+| Changelog file     | `CHANGELOG.md`               | `<member>/CHANGELOG.md`                                                                                 |
+| Release notes file | `.release_notes/<v>.md`      | `<member>/.release_notes/<v>.md`                                                                        |
+| Branch             | `release-<v>` (configurable) | `release-<name>-<v>` (template `release-{member}-{version}`)                                            |
+| PR label           | `release-action`             | `release-<name>` (auto-created per member)                                                              |
+| Slack channel      | Root `release.slack`         | Each member's own `release.slack`                                                                       |
+| Migrations         | n/a                          | `<member>/MIGRATING.md` is appended on major bumps with notes extracted from `BREAKING CHANGE:` footers |
+
+A member with no commits touching its path since its last tag is skipped silently. When a member's release ships and another member declares a workspace dependency on it, the dependent picks up at least a `patch` bump and a `chore(deps)` entry in its changelog.
+
+### Tag-ref ergonomics
+
+Composite-action consumers reference the action by ref: `uses: owner/repo/.github/actions/<name>@<ref>`. With `<name>@v<version>` tags, the ref contains a literal `@`, e.g.:
+
+```yaml
+uses: awinogradov/code-assistants/.github/actions/release-action@release-action@v1
+```
+
+GitHub accepts this form. SHA pins (`@<commit>`) are also fine.
+
+### Publish workflow
+
+A single shared `publish` workflow handles every member — the action reads the merged PR's changed files and resolves the unique `<member>/.release_notes/<version>.md` path to determine which member to publish:
+
+```yaml
+name: Publish
+
+on:
+  pull_request_target:
+    types: [closed]
+    paths:
+      - "**/.release_notes/**"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: awinogradov/code-assistants/.github/actions/release-action@v1
+        with:
+          mode: publish
+          github_token: ${{ secrets.GH_TOKEN }}
+          npm_token: ${{ secrets.NPM_TOKEN }}
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+        env:
+          PR_CHANGED_FILES: ${{ steps.changed.outputs.files }}
+```
+
+`PR_CHANGED_FILES` is a newline-separated list of paths supplied by an upstream step (e.g., `gh pr view <N> --json files --jq '.files[].path'`). When the env variable is unset, the action falls back to `GITHUB_EVENT_PATH` and accepts a single-member PR shape.
+
 ## Versioning
 
 Reference the action by tag, for example:

--- a/.github/actions/release-action/action.yml
+++ b/.github/actions/release-action/action.yml
@@ -72,14 +72,17 @@ inputs:
 
 outputs:
   version:
-    description: "Released version number"
+    description: "Released version number (standalone mode only)"
     value: ${{ steps.version.outputs.version }}
   release-type:
-    description: "Detected release type from package.json `release` field"
+    description: "Detected release type from package.json `release` field (standalone) or `monorepo`"
     value: ${{ steps.detect-type.outputs.type }}
   pr-url:
-    description: "URL of the created or updated release PR"
+    description: "URL of the created or updated release PR (standalone mode only)"
     value: ${{ steps.release-pr.outputs.pr-url }}
+  mode:
+    description: "Detected workflow mode: `standalone` or `monorepo`"
+    value: ${{ steps.detect-type.outputs.mode }}
 
 runs:
   using: composite
@@ -107,15 +110,35 @@ runs:
       shell: bash
       run: bun "${{ github.action_path }}/src/detectReleaseType.ts"
 
-    # ── Mode: create ──
+    # ── Monorepo path (handled entirely in TypeScript) ──
+
+    - name: Run monorepo release
+      if: steps.detect-type.outputs.mode == 'monorepo'
+      shell: bash
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        GH_TOKEN: ${{ inputs.github_token }}
+        LINEAR_API_KEY: ${{ inputs.linear_api_key }}
+        LINEAR_KEYS: ${{ inputs.linear_keys }}
+        JIRA_BASE_URL: ${{ inputs.jira_base_url }}
+        JIRA_EMAIL: ${{ inputs.jira_email }}
+        JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+        JIRA_KEYS: ${{ inputs.jira_keys }}
+        NPM_TOKEN: ${{ inputs.npm_token }}
+        SLACK_TOKEN: ${{ inputs.slack_token }}
+        INPUT_BRANCH: ${{ inputs.branch }}
+        INPUT_NAME: ${{ inputs.name }}
+      run: bun "${{ github.action_path }}/src/run.ts" --mode=${{ inputs.mode }}
+
+    # ── Mode: create (standalone) ──
 
     - name: Ensure .gitignore excludes .release_bot
-      if: inputs.mode == 'create'
+      if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       run: bun "${{ github.action_path }}/src/prepareRelease.ts" --ensure-gitignore
 
     - name: Generate Changelog
-      if: inputs.mode == 'create'
+      if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       env:
         LINEAR_API_KEY: ${{ inputs.linear_api_key }}
@@ -128,17 +151,17 @@ runs:
       run: bun "${{ github.action_path }}/src/release.ts"
 
     - name: Update Version Files
-      if: inputs.mode == 'create'
+      if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       run: bun "${{ github.action_path }}/src/prepareRelease.ts" --update-version "$(cat version)"
 
     - name: Update Release Badge
-      if: inputs.mode == 'create'
+      if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       run: bun "${{ github.action_path }}/src/updateReleaseBadge.ts"
 
     - name: Generate Release Notes
-      if: inputs.mode == 'create'
+      if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone'
       continue-on-error: true
       shell: bash
       env:
@@ -146,21 +169,21 @@ runs:
       run: bun "${{ github.action_path }}/src/generateReleaseNotes.ts"
 
     - name: Update Release Notes File
-      if: inputs.mode == 'create'
+      if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       run: |
         VERSION=$(cat version)
         bun "${{ github.action_path }}/src/insert-release-notes.ts" "$VERSION"
 
     - name: Assemble PR Body
-      if: inputs.mode == 'create'
+      if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       env:
         INPUT_BRANCH: ${{ inputs.branch }}
       run: bun "${{ github.action_path }}/src/assemble-pr-body.ts"
 
     - name: Commit and Push Release
-      if: inputs.mode == 'create'
+      if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       env:
         INPUT_BRANCH: ${{ inputs.branch }}
@@ -175,7 +198,7 @@ runs:
 
     - name: Create Pull Request
       id: release-pr
-      if: inputs.mode == 'create'
+      if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
@@ -210,6 +233,7 @@ runs:
 
     - name: Output version
       id: version
+      if: steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       env:
         MODE: ${{ inputs.mode }}
@@ -230,7 +254,7 @@ runs:
 
     - name: Determine Version
       id: determine-version
-      if: inputs.mode == 'publish'
+      if: inputs.mode == 'publish' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       run: |
         VERSION=$(cat version | tr -d '[:space:]')
@@ -239,12 +263,12 @@ runs:
         echo "Determined version: ${VERSION} (tag: v${VERSION})"
 
     - name: Setup packages
-      if: inputs.mode == 'publish' && (steps.detect-type.outputs.type == 'lib-nodejs' || steps.detect-type.outputs.type == 'lib-bun')
+      if: inputs.mode == 'publish' && steps.detect-type.outputs.mode == 'standalone' && (steps.detect-type.outputs.type == 'lib-nodejs' || steps.detect-type.outputs.type == 'lib-bun')
       shell: bash
       run: bun install
 
     - name: Publish to NPM
-      if: inputs.mode == 'publish' && (steps.detect-type.outputs.type == 'lib-nodejs' || steps.detect-type.outputs.type == 'lib-bun')
+      if: inputs.mode == 'publish' && steps.detect-type.outputs.mode == 'standalone' && (steps.detect-type.outputs.type == 'lib-nodejs' || steps.detect-type.outputs.type == 'lib-bun')
       shell: bash
       env:
         NPM_TOKEN: ${{ inputs.npm_token }}
@@ -253,7 +277,7 @@ runs:
         npm publish
 
     - name: Release Tag
-      if: inputs.mode == 'publish'
+      if: inputs.mode == 'publish' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       run: |
         TAG="${{ steps.determine-version.outputs.tag }}"
@@ -262,7 +286,7 @@ runs:
         echo "Created and pushed tag $TAG"
 
     - name: Major Version Tag
-      if: inputs.mode == 'publish' && steps.detect-type.outputs.type == 'github-action'
+      if: inputs.mode == 'publish' && steps.detect-type.outputs.mode == 'standalone' && steps.detect-type.outputs.type == 'github-action'
       shell: bash
       run: |
         VERSION="$(cat version)"
@@ -272,7 +296,7 @@ runs:
         echo "Updated major version tag $MAJOR"
 
     - name: GitHub Release
-      if: inputs.mode == 'publish'
+      if: inputs.mode == 'publish' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
@@ -285,7 +309,7 @@ runs:
         echo "Created GitHub release Release ${VERSION} (${TAG})"
 
     - name: Slack Release Notification
-      if: inputs.mode == 'publish' && inputs.slack_token != ''
+      if: inputs.mode == 'publish' && steps.detect-type.outputs.mode == 'standalone' && inputs.slack_token != ''
       continue-on-error: true
       shell: bash
       env:

--- a/.github/actions/release-action/src/assemble-pr-body.test.ts
+++ b/.github/actions/release-action/src/assemble-pr-body.test.ts
@@ -15,7 +15,7 @@ import { withTempDir } from "./testHelpers.ts";
 /** Base env stripped of GitHub CI variables that affect URL generation */
 const ciVarKeys = ["GITHUB_SERVER_URL", "GITHUB_REPOSITORY", "INPUT_BRANCH"];
 const cleanEnv = Object.fromEntries(
-  Object.entries(process.env).filter(([key]) => !ciVarKeys.includes(key))
+  Object.entries(process.env).filter(([key]) => !ciVarKeys.includes(key)),
 ) as Record<string, string>;
 
 /** GitHub env vars for tests that verify absolute URL generation */
@@ -27,7 +27,7 @@ const githubEnv = {
 /** Run the assemble-pr-body script in a temp directory */
 async function runAssemblePrBody(
   cwd: string,
-  extraEnv?: Record<string, string>
+  extraEnv?: Record<string, string>,
 ): Promise<{ exitCode: number; output: string }> {
   const scriptPath = join(import.meta.dirname, "assemble-pr-body.ts");
   const result = await $`bun ${scriptPath}`
@@ -67,7 +67,7 @@ describe("assemble-pr-body", () => {
       withTempDir(async (dir) => {
         await createBody(
           dir,
-          "![release:minor](badge)\n\n## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| [TOOLS-1: Fix](url) | [#10](pr) | @dev |\n\n### Features\n\n* feat A"
+          "![release:minor](badge)\n\n## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| [TOOLS-1: Fix](url) | [#10](pr) | @dev |\n\n### Features\n\n* feat A",
         );
         await createReleaseNotes(dir, "Some AI release notes");
         await Bun.write(join(dir, "version"), "1.0.0");
@@ -142,7 +142,7 @@ describe("assemble-pr-body", () => {
 
         const enhanced = await readEnhanced(dir);
         expect(enhanced).toContain(
-          "📋 [Detailed changelog](https://github.com/test-owner/test-repo/blob/release-2.0.0/CHANGELOG.md)"
+          "📋 [Detailed changelog](https://github.com/test-owner/test-repo/blob/release-2.0.0/CHANGELOG.md)",
         );
       }));
 
@@ -200,7 +200,7 @@ describe("assemble-pr-body", () => {
         const enhanced = await readEnhanced(dir);
         expect(enhanced.length).toBeLessThanOrEqual(65536);
         expect(enhanced).toContain(
-          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-1.5.0/.release_notes/1.5.0.md)"
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-1.5.0/.release_notes/1.5.0.md)",
         );
       }));
 
@@ -208,7 +208,7 @@ describe("assemble-pr-body", () => {
       withTempDir(async (dir) => {
         await createBody(
           dir,
-          `![release:major](badge)\n\n## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| [TOOLS-321: Fix](url) | [#10](pr) | @dev |\n\n### Features\n\n* feat`
+          `![release:major](badge)\n\n## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| [TOOLS-321: Fix](url) | [#10](pr) | @dev |\n\n### Features\n\n* feat`,
         );
         await createReleaseNotes(dir, generateLargeContent(70000));
         await Bun.write(join(dir, "version"), "10.0.0");
@@ -220,7 +220,7 @@ describe("assemble-pr-body", () => {
         expect(enhanced).toContain("<h2>Linear</h2>");
         expect(enhanced).toContain("TOOLS-321");
         expect(enhanced).toContain(
-          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-10.0.0/.release_notes/10.0.0.md)"
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-10.0.0/.release_notes/10.0.0.md)",
         );
       }));
 
@@ -246,7 +246,7 @@ describe("assemble-pr-body", () => {
 
         const enhanced = await readEnhanced(dir);
         expect(enhanced).toContain(
-          "See [full release notes](https://github.com/test-owner/test-repo/blob/rel/3.1.0/.release_notes/3.1.0.md)"
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/rel/3.1.0/.release_notes/3.1.0.md)",
         );
       }));
 
@@ -254,7 +254,7 @@ describe("assemble-pr-body", () => {
       withTempDir(async (dir) => {
         await createBody(
           dir,
-          `![badge](url)\n\n## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| [TOOLS-99: Fix](url) | [#5](pr) | @dev |\n\n## GitHub Issues\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| #42 | [#6](pr) | @dev |\n\n### Features\n\n* feat`
+          `![badge](url)\n\n## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| [TOOLS-99: Fix](url) | [#5](pr) | @dev |\n\n## GitHub Issues\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| #42 | [#6](pr) | @dev |\n\n### Features\n\n* feat`,
         );
         await createReleaseNotes(dir, generateLargeContent(70000));
         await Bun.write(join(dir, "version"), "7.0.0");
@@ -276,7 +276,7 @@ describe("assemble-pr-body", () => {
         const hugeTickets = `## Linear\n\n| Issue | PR | Author |\n| --- | --- | --- |\n${generateLargeContent(70000)}`;
         await createBody(
           dir,
-          `![release:major](badge)\n\n${hugeTickets}\n\n### Features\n\n* feat`
+          `![release:major](badge)\n\n${hugeTickets}\n\n### Features\n\n* feat`,
         );
         await createReleaseNotes(dir, "Small release notes");
         await Bun.write(join(dir, "version"), "25.0.0");
@@ -290,7 +290,7 @@ describe("assemble-pr-body", () => {
         expect(enhanced).toContain("![release:major](badge)");
         expect(enhanced).not.toContain("<h2>Linear</h2>");
         expect(enhanced).toContain(
-          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-25.0.0/.release_notes/25.0.0.md)"
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-25.0.0/.release_notes/25.0.0.md)",
         );
       }));
 
@@ -309,10 +309,10 @@ describe("assemble-pr-body", () => {
         expect(enhanced.length).toBeLessThanOrEqual(65536);
         expect(enhanced.startsWith("![release:major](badge)")).toBe(true);
         expect(enhanced).toContain(
-          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-9.0.0/.release_notes/9.0.0.md)"
+          "See [full release notes](https://github.com/test-owner/test-repo/blob/release-9.0.0/.release_notes/9.0.0.md)",
         );
         expect(enhanced).toContain(
-          "📋 [Detailed changelog](https://github.com/test-owner/test-repo/blob/release-9.0.0/CHANGELOG.md)"
+          "📋 [Detailed changelog](https://github.com/test-owner/test-repo/blob/release-9.0.0/CHANGELOG.md)",
         );
       }));
   });

--- a/.github/actions/release-action/src/assemble-pr-body.test.ts
+++ b/.github/actions/release-action/src/assemble-pr-body.test.ts
@@ -157,6 +157,33 @@ describe("assemble-pr-body", () => {
         const enhanced = await readEnhanced(dir);
         expect(enhanced).toContain("📋 [Detailed changelog](CHANGELOG.md)");
       }));
+
+    test("monorepo: blob URLs are prefixed with the member rel-path", () =>
+      withTempDir(async (dir) => {
+        await createBody(dir, "![badge](url)\n\n### Features\n\n* feat M");
+        await createReleaseNotes(dir, "Notes");
+        await Bun.write(join(dir, "version"), "1.0.0");
+
+        const { assemblePrBody } = await import("./assemble-pr-body.ts");
+        process.env.GITHUB_SERVER_URL = githubEnv.GITHUB_SERVER_URL;
+        process.env.GITHUB_REPOSITORY = githubEnv.GITHUB_REPOSITORY;
+        process.env.INPUT_BRANCH = "release-mylib-1.0.0";
+        try {
+          await assemblePrBody({
+            cwd: dir,
+            memberRelPath: "packages/mylib",
+          });
+        } finally {
+          delete process.env.GITHUB_SERVER_URL;
+          delete process.env.GITHUB_REPOSITORY;
+          delete process.env.INPUT_BRANCH;
+        }
+
+        const enhanced = await readEnhanced(dir);
+        expect(enhanced).toContain(
+          "📋 [Detailed changelog](https://github.com/test-owner/test-repo/blob/release-mylib-1.0.0/packages/mylib/CHANGELOG.md)",
+        );
+      }));
   });
 
   describe("truncation", () => {

--- a/.github/actions/release-action/src/assemble-pr-body.ts
+++ b/.github/actions/release-action/src/assemble-pr-body.ts
@@ -1,65 +1,37 @@
 /**
  * Assemble enhanced PR body with AI-generated release notes
  *
- * Reads release notes from `.release_bot/release_notes.md` and the raw changelog
- * from `.release_bot/body`, then combines them into an enhanced PR body.
- * Replaces inline conventional changelog with a link to the CHANGELOG file.
- * Truncates the body when it exceeds GitHub's 65536 character PR body limit:
- * first replaces release notes with a link, then drops the tickets section if
- * still too long, and hard-truncates as a last resort.
+ * Reads release notes from `<cwd>/.release_bot/release_notes.md` and the raw
+ * changelog from `<cwd>/.release_bot/body`, then combines them into an enhanced
+ * PR body. Replaces inline conventional changelog with a link to the per-member
+ * `CHANGELOG.md`. Truncates the body when it exceeds GitHub's 65536 character
+ * PR body limit: first replaces release notes with a link, then drops the
+ * tickets section if still too long, and hard-truncates as a last resort.
+ *
+ * Per-member usage: pass `cwd` pointing at the member directory so all relative
+ * paths resolve inside that member's tree. Standalone mode uses `process.cwd()`.
  *
  * @example
  * ```bash
  * bun src/assemble-pr-body.ts
  * ```
  */
-
-export {};
+import { join } from "node:path";
 
 /** GitHub's maximum character limit for PR body */
 const githubBodyMaxLength = 65536;
 
-const releaseNotesFile = Bun.file(".release_bot/release_notes.md");
-const releaseNotes = (await releaseNotesFile.exists())
-  ? (await releaseNotesFile.text()).trim()
-  : "";
-
-const rawBody = await Bun.file(".release_bot/body").text();
-const lines = rawBody.split("\n");
-
-// Find ticket sections (## Linear, ## Jira, ## GitHub Issues) - these stay visible
-const ticketStartIndex = lines.findIndex(
-  (line) =>
-    line.startsWith("## Linear") ||
-    line.startsWith("## Jira") ||
-    line.startsWith("## GitHub Issues")
-);
-
-// Find conventional changelog sections (### Features, ### Bug Fixes, etc.) - replaced with link
-const changelogStartIndex = lines.findIndex((line) => line.startsWith("### "));
-
-// Determine where summary ends
-function getSummaryEndIndex(): number {
-  if (ticketStartIndex > 0) return ticketStartIndex;
-  if (changelogStartIndex > 0) return changelogStartIndex;
-  return lines.length;
+/** Options accepted by {@link assemblePrBody}. */
+export interface AssemblePrBodyOptions {
+  /** Member directory; defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Branch template (e.g. `release-{version}`). Defaults to `INPUT_BRANCH` env or `release-{version}`. */
+  branchTemplate?: string;
+  /** Path within the member where the per-version release-notes file lives. Defaults to `.release_notes`. */
+  releaseNotesDir?: string;
+  /** Path within the member where the CHANGELOG.md lives. Defaults to `CHANGELOG.md`. */
+  changelogFileName?: string;
 }
-
-const summarySection = lines.slice(0, getSummaryEndIndex()).join("\n");
-
-// Extract ticket section (between ## tickets and ### changelog)
-function getTicketSection(): string {
-  if (ticketStartIndex <= 0) return "";
-  if (changelogStartIndex > ticketStartIndex) {
-    return lines.slice(ticketStartIndex, changelogStartIndex).join("\n");
-  }
-  return lines.slice(ticketStartIndex).join("\n");
-}
-
-const ticketSection = getTicketSection();
-
-// Safety net: strip any leading markdown headers AI may generate despite instructions
-const cleanedNotes = releaseNotes.replace(/^(#+\s+.*\n+)+/, "");
 
 /** Release notes file path and the branch it will be committed to */
 interface ReleaseNotesTarget {
@@ -67,32 +39,24 @@ interface ReleaseNotesTarget {
   branch: string;
 }
 
-/**
- * Detect the release notes file path and branch for linking.
- *
- * Reads the `version` file and resolves the branch from the `INPUT_BRANCH` template.
- */
-async function getReleaseNotesTarget(): Promise<ReleaseNotesTarget | undefined> {
-  const versionFile = Bun.file("version");
+async function getReleaseNotesTarget(
+  cwd: string,
+  branchTemplate: string,
+  releaseNotesDir: string,
+): Promise<ReleaseNotesTarget | undefined> {
+  const versionFile = Bun.file(join(cwd, "version"));
   if (await versionFile.exists()) {
     const version = (await versionFile.text()).trim();
     if (version) {
-      const template = process.env.INPUT_BRANCH ?? "release-{version}";
       return {
-        path: `.release_notes/${version}.md`,
-        branch: template.replace("{version}", version),
+        path: `${releaseNotesDir}/${version}.md`,
+        branch: branchTemplate.replace("{version}", version),
       };
     }
   }
-
   return undefined;
 }
 
-/**
- * Build an absolute blob URL for a file on the release branch.
- *
- * Falls back to the relative path when GitHub environment variables are not available.
- */
 function buildBlobUrl(branch: string, filePath: string): string {
   const serverUrl = process.env.GITHUB_SERVER_URL;
   const repository = process.env.GITHUB_REPOSITORY;
@@ -100,17 +64,14 @@ function buildBlobUrl(branch: string, filePath: string): string {
     return `${serverUrl}/${repository}/blob/${branch}/${filePath}`;
   }
   console.log(
-    "::warning::GITHUB_SERVER_URL or GITHUB_REPOSITORY not set. Using relative path for link."
+    "::warning::GITHUB_SERVER_URL or GITHUB_REPOSITORY not set. Using relative path for link.",
   );
   return filePath;
 }
 
-/** Wrap each ticket section heading in a collapsible `<details>` block */
 function wrapTicketsInDetails(tickets: string): string {
   if (!tickets.trim()) return "";
-
   const parts = tickets.split(/^(?=## (?:Linear|Jira|GitHub Issues))/m);
-
   return parts
     .filter((part) => part.trim())
     .map((part) => {
@@ -121,69 +82,22 @@ function wrapTicketsInDetails(tickets: string): string {
     .join("\n\n");
 }
 
-// Resolve target once — reused for both changelog link and truncation
-const releaseTarget = await getReleaseNotesTarget();
-
-// Build changelog link and final body
-const changelogLink = releaseTarget
-  ? `📋 [Detailed changelog](${buildBlobUrl(releaseTarget.branch, "CHANGELOG.md")})`
-  : "📋 Detailed changelog";
-
-// Build final body: Badges → Release Notes → Tickets → Changelog Link
-const wrappedTickets = wrapTicketsInDetails(ticketSection);
-const ticketBlock = wrappedTickets ? `${wrappedTickets}\n\n` : "";
-
-const enhanced = `${summarySection.trimEnd()}
-
-## Release Notes
-
-${cleanedNotes}
-
-${ticketBlock}${changelogLink}
-`;
-
-/**
- * Build a truncated PR body that fits within GitHub's limit.
- *
- * Replaces release notes with a link to the release notes file.
- * Keeps tickets and changelog link.
- *
- * @param summary - Badge/summary section from the raw body
- * @param ticketsBlock - Pre-formatted ticket section block (may be empty)
- * @param changelogLinkLine - Pre-formatted changelog link line
- * @param target - Resolved release notes target (avoids redundant file I/O)
- */
 function truncateBody(
   summary: string,
   ticketsBlock: string,
   changelogLinkLine: string,
-  target: ReleaseNotesTarget | undefined
+  target: ReleaseNotesTarget | undefined,
 ): string {
   const linkText = target
     ? `See [full release notes](${buildBlobUrl(target.branch, target.path)}) for detailed changes.`
     : "See release notes file for detailed changes.";
-
-  return `${summary.trimEnd()}
-
-## Release Notes
-
-${linkText}
-
-${ticketsBlock}${changelogLinkLine}
-`;
+  return `${summary.trimEnd()}\n\n## Release Notes\n\n${linkText}\n\n${ticketsBlock}${changelogLinkLine}\n`;
 }
 
-/**
- * Build a hard-truncated PR body that preserves the release notes and
- * changelog links by trimming the summary to whatever budget remains.
- *
- * Only reached when even the tickets-dropped body exceeds the limit —
- * typically means the summary itself is enormous.
- */
 function hardTruncateBody(
   summary: string,
   changelogLinkLine: string,
-  target: ReleaseNotesTarget | undefined
+  target: ReleaseNotesTarget | undefined,
 ): string {
   const shell = truncateBody("", "", changelogLinkLine, target);
   const budget = githubBodyMaxLength - shell.length;
@@ -191,47 +105,99 @@ function hardTruncateBody(
   return truncateBody(summary.slice(0, budget), "", changelogLinkLine, target);
 }
 
-/**
- * Pick a body variant that fits within GitHub's PR body limit.
- *
- * Cascades: full → release notes replaced with link → tickets also dropped
- * → hard-truncated as last resort. Each step falls through only when the
- * previous variant still exceeds the limit.
- */
 function pickBodyWithinLimit(
   full: string,
   summary: string,
   ticketsBlock: string,
   changelogLinkLine: string,
-  target: ReleaseNotesTarget | undefined
+  target: ReleaseNotesTarget | undefined,
 ): string {
   if (full.length <= githubBodyMaxLength) return full;
-
   console.log(
-    `::warning::PR body exceeds GitHub limit (${full.length}/${githubBodyMaxLength} chars). Truncating release notes.`
+    `::warning::PR body exceeds GitHub limit (${full.length}/${githubBodyMaxLength} chars). Truncating release notes.`,
   );
   const withoutNotes = truncateBody(summary, ticketsBlock, changelogLinkLine, target);
   if (withoutNotes.length <= githubBodyMaxLength) return withoutNotes;
-
   console.log(
-    `::warning::Truncated body still exceeds GitHub limit (${withoutNotes.length}/${githubBodyMaxLength} chars). Dropping tickets section.`
+    `::warning::Truncated body still exceeds GitHub limit (${withoutNotes.length}/${githubBodyMaxLength} chars). Dropping tickets section.`,
   );
   const withoutTickets = truncateBody(summary, "", changelogLinkLine, target);
   if (withoutTickets.length <= githubBodyMaxLength) return withoutTickets;
-
   console.log(
-    `::warning::Body still exceeds GitHub limit (${withoutTickets.length}/${githubBodyMaxLength} chars). Hard-truncating.`
+    `::warning::Body still exceeds GitHub limit (${withoutTickets.length}/${githubBodyMaxLength} chars). Hard-truncating.`,
   );
   return hardTruncateBody(summary, changelogLinkLine, target);
 }
 
-const finalBody = pickBodyWithinLimit(
-  enhanced,
-  summarySection,
-  ticketBlock,
-  changelogLink,
-  releaseTarget
-);
-await Bun.write(".release_bot/body_enhanced", finalBody);
+/**
+ * Assemble the enhanced PR body for a member (or the repo root in standalone mode).
+ *
+ * Writes the result to `<cwd>/.release_bot/body_enhanced`.
+ */
+export async function assemblePrBody(options: AssemblePrBodyOptions = {}): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const branchTemplate =
+    options.branchTemplate ?? process.env.INPUT_BRANCH ?? "release-{version}";
+  const releaseNotesDir = options.releaseNotesDir ?? ".release_notes";
+  const changelogFileName = options.changelogFileName ?? "CHANGELOG.md";
 
-console.log("Enhanced PR body written to .release_bot/body_enhanced");
+  const releaseNotesFile = Bun.file(join(cwd, ".release_bot/release_notes.md"));
+  const releaseNotes = (await releaseNotesFile.exists())
+    ? (await releaseNotesFile.text()).trim()
+    : "";
+
+  const rawBody = await Bun.file(join(cwd, ".release_bot/body")).text();
+  const lines = rawBody.split("\n");
+
+  const ticketStartIndex = lines.findIndex(
+    (line) =>
+      line.startsWith("## Linear") ||
+      line.startsWith("## Jira") ||
+      line.startsWith("## GitHub Issues"),
+  );
+  const changelogStartIndex = lines.findIndex((line) => line.startsWith("### "));
+
+  const summaryEnd = (() => {
+    if (ticketStartIndex > 0) return ticketStartIndex;
+    if (changelogStartIndex > 0) return changelogStartIndex;
+    return lines.length;
+  })();
+  const summarySection = lines.slice(0, summaryEnd).join("\n");
+
+  const ticketSection = (() => {
+    if (ticketStartIndex <= 0) return "";
+    if (changelogStartIndex > ticketStartIndex) {
+      return lines.slice(ticketStartIndex, changelogStartIndex).join("\n");
+    }
+    return lines.slice(ticketStartIndex).join("\n");
+  })();
+
+  // Safety net: strip any leading markdown headers AI may generate
+  const cleanedNotes = releaseNotes.replace(/^(#+\s+.*\n+)+/, "");
+
+  const releaseTarget = await getReleaseNotesTarget(cwd, branchTemplate, releaseNotesDir);
+
+  const changelogLink = releaseTarget
+    ? `📋 [Detailed changelog](${buildBlobUrl(releaseTarget.branch, changelogFileName)})`
+    : "📋 Detailed changelog";
+
+  const wrappedTickets = wrapTicketsInDetails(ticketSection);
+  const ticketBlock = wrappedTickets ? `${wrappedTickets}\n\n` : "";
+
+  const enhanced =
+    `${summarySection.trimEnd()}\n\n## Release Notes\n\n${cleanedNotes}\n\n${ticketBlock}${changelogLink}\n`;
+
+  const finalBody = pickBodyWithinLimit(
+    enhanced,
+    summarySection,
+    ticketBlock,
+    changelogLink,
+    releaseTarget,
+  );
+  await Bun.write(join(cwd, ".release_bot/body_enhanced"), finalBody);
+  console.log("Enhanced PR body written to .release_bot/body_enhanced");
+}
+
+if (import.meta.main) {
+  await assemblePrBody();
+}

--- a/.github/actions/release-action/src/assemble-pr-body.ts
+++ b/.github/actions/release-action/src/assemble-pr-body.ts
@@ -150,8 +150,7 @@ function pickBodyWithinLimit(
  */
 export async function assemblePrBody(options: AssemblePrBodyOptions = {}): Promise<void> {
   const cwd = options.cwd ?? process.cwd();
-  const branchTemplate =
-    options.branchTemplate ?? process.env.INPUT_BRANCH ?? "release-{version}";
+  const branchTemplate = options.branchTemplate ?? process.env.INPUT_BRANCH ?? "release-{version}";
   const releaseNotesDir = options.releaseNotesDir ?? ".release_notes";
   const changelogFileName = options.changelogFileName ?? "CHANGELOG.md";
 
@@ -204,8 +203,7 @@ export async function assemblePrBody(options: AssemblePrBodyOptions = {}): Promi
   const wrappedTickets = wrapTicketsInDetails(ticketSection);
   const ticketBlock = wrappedTickets ? `${wrappedTickets}\n\n` : "";
 
-  const enhanced =
-    `${summarySection.trimEnd()}\n\n## Release Notes\n\n${cleanedNotes}\n\n${ticketBlock}${changelogLink}\n`;
+  const enhanced = `${summarySection.trimEnd()}\n\n## Release Notes\n\n${cleanedNotes}\n\n${ticketBlock}${changelogLink}\n`;
 
   const finalBody = pickBodyWithinLimit(
     enhanced,

--- a/.github/actions/release-action/src/assemble-pr-body.ts
+++ b/.github/actions/release-action/src/assemble-pr-body.ts
@@ -31,6 +31,13 @@ export interface AssemblePrBodyOptions {
   releaseNotesDir?: string;
   /** Path within the member where the CHANGELOG.md lives. Defaults to `CHANGELOG.md`. */
   changelogFileName?: string;
+  /**
+   * Member path relative to the repository root (e.g. `.github/actions/release-action`).
+   * When set, the blob URLs for the changelog and release-notes links are
+   * prefixed with this path so they resolve from the repo root instead of the
+   * member subtree. Omit for standalone repos.
+   */
+  memberRelPath?: string;
 }
 
 /** Release notes file path and the branch it will be committed to */
@@ -39,17 +46,24 @@ interface ReleaseNotesTarget {
   branch: string;
 }
 
+function joinRelPath(prefix: string | undefined, suffix: string): string {
+  if (!prefix) return suffix;
+  const normalized = prefix.replace(/^\/+|\/+$/g, "");
+  return normalized.length === 0 ? suffix : `${normalized}/${suffix}`;
+}
+
 async function getReleaseNotesTarget(
   cwd: string,
   branchTemplate: string,
   releaseNotesDir: string,
+  memberRelPath: string | undefined,
 ): Promise<ReleaseNotesTarget | undefined> {
   const versionFile = Bun.file(join(cwd, "version"));
   if (await versionFile.exists()) {
     const version = (await versionFile.text()).trim();
     if (version) {
       return {
-        path: `${releaseNotesDir}/${version}.md`,
+        path: joinRelPath(memberRelPath, `${releaseNotesDir}/${version}.md`),
         branch: branchTemplate.replace("{version}", version),
       };
     }
@@ -175,10 +189,16 @@ export async function assemblePrBody(options: AssemblePrBodyOptions = {}): Promi
   // Safety net: strip any leading markdown headers AI may generate
   const cleanedNotes = releaseNotes.replace(/^(#+\s+.*\n+)+/, "");
 
-  const releaseTarget = await getReleaseNotesTarget(cwd, branchTemplate, releaseNotesDir);
+  const releaseTarget = await getReleaseNotesTarget(
+    cwd,
+    branchTemplate,
+    releaseNotesDir,
+    options.memberRelPath,
+  );
 
+  const changelogPath = joinRelPath(options.memberRelPath, changelogFileName);
   const changelogLink = releaseTarget
-    ? `📋 [Detailed changelog](${buildBlobUrl(releaseTarget.branch, changelogFileName)})`
+    ? `📋 [Detailed changelog](${buildBlobUrl(releaseTarget.branch, changelogPath)})`
     : "📋 Detailed changelog";
 
   const wrappedTickets = wrapTicketsInDetails(ticketSection);

--- a/.github/actions/release-action/src/detectReleaseType.ts
+++ b/.github/actions/release-action/src/detectReleaseType.ts
@@ -15,6 +15,7 @@
  */
 import { appendFile } from "node:fs/promises";
 
+import { discoverMembers } from "./monorepo/discoverMembers.ts";
 import { readReleaseField } from "./releaseField.ts";
 
 const DOCS_LINK = "docs/release-field.md";
@@ -51,9 +52,20 @@ async function writeGithubOutput(line: string): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  const discovery = await discoverMembers(process.cwd());
+
+  if (discovery.mode === "monorepo") {
+    await writeGithubOutput("mode=monorepo");
+    await writeGithubOutput(`type=monorepo`);
+    console.log(`Detected monorepo with ${discovery.members.length} member(s)`);
+    return;
+  }
+
+  // Standalone fallback — preserve the pre-monorepo contract by emitting the
+  // release.type so action.yml's existing publish steps continue to work.
   const pkg = await readPackageJson();
   const { type } = readReleaseField(pkg);
-
+  await writeGithubOutput("mode=standalone");
   await writeGithubOutput(`type=${type}`);
   console.log(`Detected release type: ${type}`);
 }

--- a/.github/actions/release-action/src/detectReleaseType.ts
+++ b/.github/actions/release-action/src/detectReleaseType.ts
@@ -25,19 +25,16 @@ async function readPackageJson(): Promise<unknown> {
   const file = Bun.file(PACKAGE_JSON);
 
   if (!(await file.exists())) {
-    throw new Error(
-      `${PACKAGE_JSON} not found in the working directory. See ${DOCS_LINK}.`,
-    );
+    throw new Error(`${PACKAGE_JSON} not found in the working directory. See ${DOCS_LINK}.`);
   }
 
   try {
     return await file.json();
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Failed to parse ${PACKAGE_JSON}: ${detail}. See ${DOCS_LINK}.`,
-      { cause: error },
-    );
+    throw new Error(`Failed to parse ${PACKAGE_JSON}: ${detail}. See ${DOCS_LINK}.`, {
+      cause: error,
+    });
   }
 }
 

--- a/.github/actions/release-action/src/insert-release-notes.ts
+++ b/.github/actions/release-action/src/insert-release-notes.ts
@@ -1,101 +1,103 @@
 /**
- * Insert AI release notes into CHANGELOG.md and .release_notes/<version>.md
+ * Insert AI release notes into a member's `CHANGELOG.md` and
+ * `.release_notes/<version>.md`.
  *
- * Reads AI-generated notes from `.release_bot/release_notes.md` and inserts them
- * as a "## Release Notes" section after the version header in both files.
- * Uses string matching (not regex) to avoid issues with markdown metacharacters.
+ * Reads AI-generated notes from `<cwd>/.release_bot/release_notes.md` and
+ * inserts them as a "## Release Notes" section after the version header in
+ * both files. Uses string matching (not regex) to avoid issues with markdown
+ * metacharacters.
  *
  * @example
  * ```bash
  * bun src/insert-release-notes.ts 1.2.0
  * ```
  */
+import { join } from "node:path";
 
-export {};
-
-const [, , version] = process.argv;
-
-if (!version?.trim()) {
-  console.error("Usage: bun src/insert-release-notes.ts <version>");
-  process.exit(1);
+/** Options accepted by {@link insertReleaseNotes}. */
+export interface InsertReleaseNotesOptions {
+  /** Version string locating the version header. */
+  version: string;
+  /** Member directory; defaults to `process.cwd()`. */
+  cwd?: string;
 }
 
-const notesFile = Bun.file(".release_bot/release_notes.md");
-
-if (!(await notesFile.exists())) {
-  console.log("No .release_bot/release_notes.md found, skipping release notes insertion");
-  process.exit(0);
-}
-
-const notes = (await notesFile.text()).trim();
-
-if (!notes) {
-  console.log("Release notes file is empty, skipping insertion");
-  process.exit(0);
-}
-
-const releaseNotesSection = `## Release Notes\n\n${notes}\n`;
-
-/**
- * Insert a release notes section after the version header in markdown content
- *
- * Finds the first line containing `## ` followed by the version string,
- * then inserts the release notes block after the header and its trailing blank line.
- *
- * @param content - Markdown file content
- * @param ver - Version string to locate (e.g. "1.2.0")
- * @param notesBlock - Formatted release notes block to insert
- * @returns Updated content, or original if version header not found
- */
 function insertAfterVersionHeader(content: string, ver: string, notesBlock: string): string {
   const lines = content.split("\n");
   const headerIndex = lines.findIndex((line) => line.startsWith("## ") && line.includes(ver));
+  if (headerIndex === -1) return content;
 
-  if (headerIndex === -1) {
-    return content;
-  }
-
-  // Find the blank line after the header
   let insertAt = headerIndex + 1;
   if (insertAt < lines.length && lines[insertAt]?.trim() === "") {
     insertAt += 1;
   }
-
   lines.splice(insertAt, 0, notesBlock, "");
   return lines.join("\n");
 }
 
-async function insertIntoChangelog(ver: string, notesBlock: string): Promise<void> {
-  const changelogFile = Bun.file("CHANGELOG.md");
+async function insertIntoChangelog(
+  cwd: string,
+  ver: string,
+  notesBlock: string,
+): Promise<void> {
+  const changelogPath = join(cwd, "CHANGELOG.md");
+  const changelogFile = Bun.file(changelogPath);
   if (!(await changelogFile.exists())) return;
 
   const changelog = await changelogFile.text();
   const updated = insertAfterVersionHeader(changelog, ver, notesBlock);
-
   if (updated !== changelog) {
-    await Bun.write("CHANGELOG.md", updated);
+    await Bun.write(changelogPath, updated);
     console.log("Inserted release notes into CHANGELOG.md");
   } else {
     console.log(`Version header for ${ver} not found in CHANGELOG.md, skipping`);
   }
 }
 
-// Insert into CHANGELOG.md
-await insertIntoChangelog(version, releaseNotesSection);
+/**
+ * Insert AI release notes into the member's CHANGELOG and per-version
+ * release-notes file. No-ops silently when the source notes file is missing.
+ */
+export async function insertReleaseNotes(options: InsertReleaseNotesOptions): Promise<void> {
+  const { version } = options;
+  const cwd = options.cwd ?? process.cwd();
 
-// Insert into .release_notes/<version>.md
-const releaseNotePath = `.release_notes/${version}.md`;
-const releaseNoteFile = Bun.file(releaseNotePath);
-if (await releaseNoteFile.exists()) {
-  const releaseNote = await releaseNoteFile.text();
-  const updated = insertAfterVersionHeader(releaseNote, version, releaseNotesSection);
-
-  if (updated !== releaseNote) {
-    await Bun.write(releaseNotePath, updated);
-    console.log(`Inserted release notes into ${releaseNotePath}`);
-  } else {
-    // Version header may not be present in .release_notes file — prepend instead
-    await Bun.write(releaseNotePath, `${releaseNotesSection}\n${releaseNote}`);
-    console.log(`Prepended release notes to ${releaseNotePath}`);
+  const notesFile = Bun.file(join(cwd, ".release_bot/release_notes.md"));
+  if (!(await notesFile.exists())) {
+    console.log("No .release_bot/release_notes.md found, skipping release notes insertion");
+    return;
   }
+
+  const notes = (await notesFile.text()).trim();
+  if (!notes) {
+    console.log("Release notes file is empty, skipping insertion");
+    return;
+  }
+
+  const releaseNotesSection = `## Release Notes\n\n${notes}\n`;
+
+  await insertIntoChangelog(cwd, version, releaseNotesSection);
+
+  const releaseNotePath = join(cwd, ".release_notes", `${version}.md`);
+  const releaseNoteFile = Bun.file(releaseNotePath);
+  if (await releaseNoteFile.exists()) {
+    const releaseNote = await releaseNoteFile.text();
+    const updated = insertAfterVersionHeader(releaseNote, version, releaseNotesSection);
+    if (updated !== releaseNote) {
+      await Bun.write(releaseNotePath, updated);
+      console.log(`Inserted release notes into .release_notes/${version}.md`);
+    } else {
+      await Bun.write(releaseNotePath, `${releaseNotesSection}\n${releaseNote}`);
+      console.log(`Prepended release notes to .release_notes/${version}.md`);
+    }
+  }
+}
+
+if (import.meta.main) {
+  const [, , version] = process.argv;
+  if (!version?.trim()) {
+    console.error("Usage: bun src/insert-release-notes.ts <version>");
+    process.exit(1);
+  }
+  await insertReleaseNotes({ version });
 }

--- a/.github/actions/release-action/src/insert-release-notes.ts
+++ b/.github/actions/release-action/src/insert-release-notes.ts
@@ -35,11 +35,7 @@ function insertAfterVersionHeader(content: string, ver: string, notesBlock: stri
   return lines.join("\n");
 }
 
-async function insertIntoChangelog(
-  cwd: string,
-  ver: string,
-  notesBlock: string,
-): Promise<void> {
+async function insertIntoChangelog(cwd: string, ver: string, notesBlock: string): Promise<void> {
   const changelogPath = join(cwd, "CHANGELOG.md");
   const changelogFile = Bun.file(changelogPath);
   if (!(await changelogFile.exists())) return;

--- a/.github/actions/release-action/src/migrations/migratingAppend.test.ts
+++ b/.github/actions/release-action/src/migrations/migratingAppend.test.ts
@@ -81,7 +81,12 @@ describe("appendMigratingSection", () => {
 });
 
 describe("readBreakingNotes", () => {
-  async function commit(repo: string, relPath: string, file: string, message: string): Promise<void> {
+  async function commit(
+    repo: string,
+    relPath: string,
+    file: string,
+    message: string,
+  ): Promise<void> {
     await mkdir(join(repo, relPath), { recursive: true });
     await Bun.write(join(repo, relPath, file), `${Date.now()}\n`);
     await $`git add ${join(relPath, file)}`.cwd(repo).quiet();

--- a/.github/actions/release-action/src/migrations/migratingAppend.test.ts
+++ b/.github/actions/release-action/src/migrations/migratingAppend.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for MIGRATING.md section rendering and append.
+ */
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { $ } from "bun";
+
+import { withTempDir, withTempRepo } from "../testHelpers.ts";
+import {
+  appendMigratingSection,
+  readBreakingNotes,
+  renderMigratingSection,
+} from "./migratingAppend.ts";
+
+describe("renderMigratingSection", () => {
+  test("renders from->to heading and breaking notes", () => {
+    const section = renderMigratingSection({
+      memberPath: "/x",
+      previousVersion: "1.4.0",
+      newVersion: "2.0.0",
+      breakingNotes: ["release.type renamed to release.kind"],
+    });
+    expect(section).toContain("## From 1.4.0 to 2.0.0");
+    expect(section).toContain("### Breaking changes");
+    expect(section).toContain("- release.type renamed to release.kind");
+  });
+
+  test("falls back to a placeholder bullet when no breaking notes are present", () => {
+    const section = renderMigratingSection({
+      memberPath: "/x",
+      previousVersion: "1.0.0",
+      newVersion: "2.0.0",
+      breakingNotes: [],
+    });
+    expect(section).toContain("- _Document migration steps here._");
+  });
+
+  test("uses a bare version heading when there is no previous release", () => {
+    const section = renderMigratingSection({
+      memberPath: "/x",
+      previousVersion: null,
+      newVersion: "1.0.0",
+      breakingNotes: [],
+    });
+    expect(section).toMatch(/^## 1\.0\.0/);
+  });
+});
+
+describe("appendMigratingSection", () => {
+  test("creates the file with a top-level header when missing", () =>
+    withTempDir(async (dir) => {
+      await appendMigratingSection({
+        memberPath: dir,
+        previousVersion: "0.9.0",
+        newVersion: "1.0.0",
+        breakingNotes: ["renamed `foo` to `bar`"],
+      });
+      const text = await Bun.file(join(dir, "MIGRATING.md")).text();
+      expect(text.startsWith("# MIGRATING\n\n")).toBe(true);
+      expect(text).toContain("## From 0.9.0 to 1.0.0");
+    }));
+
+  test("appends with exactly one blank line between sections", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, "MIGRATING.md"), "# MIGRATING\n\n## From 0.1.0 to 0.2.0\n\n");
+      await appendMigratingSection({
+        memberPath: dir,
+        previousVersion: "0.2.0",
+        newVersion: "1.0.0",
+        breakingNotes: ["dropped Node 18 support"],
+      });
+      const text = await Bun.file(join(dir, "MIGRATING.md")).text();
+      const sections = text.match(/^## /gm) ?? [];
+      expect(sections.length).toBe(2);
+      expect(text).toContain("## From 0.2.0 to 1.0.0");
+      expect(text).not.toMatch(/\n\n\n+/);
+    }));
+});
+
+describe("readBreakingNotes", () => {
+  async function commit(repo: string, relPath: string, file: string, message: string): Promise<void> {
+    await mkdir(join(repo, relPath), { recursive: true });
+    await Bun.write(join(repo, relPath, file), `${Date.now()}\n`);
+    await $`git add ${join(relPath, file)}`.cwd(repo).quiet();
+    await $`git commit -m ${message}`.cwd(repo).quiet();
+  }
+
+  test("extracts BREAKING CHANGE footer from a commit touching the member path", () =>
+    withTempRepo(async (repo) => {
+      await commit(
+        repo,
+        "packages/lib",
+        "f.txt",
+        "feat(lib): rework api\n\nBREAKING CHANGE: dropped legacy callback form.",
+      );
+      const notes = await readBreakingNotes({
+        cwd: repo,
+        path: "packages/lib",
+        since: null,
+      });
+      expect(notes).toEqual(["dropped legacy callback form."]);
+    }));
+
+  test("ignores commits that did not touch the member path", () =>
+    withTempRepo(async (repo) => {
+      await commit(
+        repo,
+        "packages/other",
+        "f.txt",
+        "feat(other): boom\n\nBREAKING CHANGE: unrelated.",
+      );
+      const notes = await readBreakingNotes({
+        cwd: repo,
+        path: "packages/lib",
+        since: null,
+      });
+      expect(notes).toEqual([]);
+    }));
+});

--- a/.github/actions/release-action/src/migrations/migratingAppend.ts
+++ b/.github/actions/release-action/src/migrations/migratingAppend.ts
@@ -110,7 +110,9 @@ export async function readBreakingNotes(options: {
 
   const notes: string[] = [];
   for (const message of messages) {
-    const matches = message.matchAll(/^BREAKING[ -]CHANGE:\s*(.+?)(?=\n\n|\n[A-Z][A-Za-z-]+:|\n*$)/gms);
+    const matches = message.matchAll(
+      /^BREAKING[ -]CHANGE:\s*(.+?)(?=\n\n|\n[A-Z][A-Za-z-]+:|\n*$)/gms,
+    );
     for (const match of matches) {
       const note = match[1]?.replace(/\s+/g, " ").trim();
       if (note) notes.push(note);

--- a/.github/actions/release-action/src/migrations/migratingAppend.ts
+++ b/.github/actions/release-action/src/migrations/migratingAppend.ts
@@ -1,0 +1,115 @@
+/**
+ * Append a "From <prev> to <new>" section to a member's `MIGRATING.md` on a
+ * major bump. The body is composed from `BREAKING CHANGE:` footers found in
+ * the member-scoped commit range — when no breaking notes are present we
+ * still write the heading skeleton so contributors have a place to fill in
+ * the migration prose later.
+ *
+ * @example
+ * ```typescript
+ * await appendMigratingSection({
+ *   memberPath: "/abs/.github/actions/release-action",
+ *   previousVersion: "1.4.0",
+ *   newVersion: "2.0.0",
+ *   breakingNotes: ["release.type renamed to release.kind"],
+ * });
+ * ```
+ */
+import { join } from "node:path";
+
+import { $ } from "bun";
+
+/** Inputs describing a single major-bump migration section. */
+export interface AppendMigratingOptions {
+  /** Absolute path to the member directory. */
+  memberPath: string;
+  /** Previous version (`null` when the member has no prior release). */
+  previousVersion: string | null;
+  /** Newly-released version. */
+  newVersion: string;
+  /** Breaking-change notes (typically scraped from commit `BREAKING CHANGE:` footers). */
+  breakingNotes: readonly string[];
+}
+
+/** Render the section body for a single major release. */
+export function renderMigratingSection(options: AppendMigratingOptions): string {
+  const { previousVersion, newVersion, breakingNotes } = options;
+  const heading = previousVersion
+    ? `## From ${previousVersion} to ${newVersion}`
+    : `## ${newVersion}`;
+
+  const lines: string[] = [heading, ""];
+  if (breakingNotes.length === 0) {
+    lines.push("### Breaking changes", "", "- _Document migration steps here._", "");
+  } else {
+    lines.push("### Breaking changes", "");
+    for (const note of breakingNotes) {
+      lines.push(`- ${note.trim()}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Append the rendered section to `<memberPath>/MIGRATING.md`. When the file
+ * does not exist, it is created with a top-level `# MIGRATING` header so the
+ * Markdown structure stays consistent with hand-authored migration docs.
+ */
+export async function appendMigratingSection(options: AppendMigratingOptions): Promise<void> {
+  const section = renderMigratingSection(options);
+  const path = join(options.memberPath, "MIGRATING.md");
+  const file = Bun.file(path);
+
+  if (!(await file.exists())) {
+    await Bun.write(path, `# MIGRATING\n\n${section}`);
+    return;
+  }
+
+  const existing = await file.text();
+  const trimmed = existing.replace(/\n+$/, "");
+  await Bun.write(path, `${trimmed}\n\n${section}`);
+}
+
+/**
+ * Read `BREAKING CHANGE:` / `BREAKING-CHANGE:` footers from the member's
+ * path-scoped commit range. Returns one trimmed note per occurrence in the
+ * order produced by `git log` (newest first).
+ *
+ * @param options.cwd - Repository root.
+ * @param options.path - Path relative to the repo root that scopes the log.
+ * @param options.since - Lower bound for the range (e.g. last release tag).
+ *   `null` lists all commits reachable from HEAD that touched the path.
+ */
+export async function readBreakingNotes(options: {
+  cwd: string;
+  path: string;
+  since: string | null;
+}): Promise<string[]> {
+  const { cwd, path, since } = options;
+  const range = since ? `${since}..HEAD` : "HEAD";
+  // %B = full commit body (subject + body) with footers preserved.
+  // The literal sentinel between commits lets us safely split the stream.
+  const sentinel = "<<<COMMIT-END>>>";
+  const result = await $`git log ${range} --pretty=format:%B${sentinel} -- ${path}`
+    .cwd(cwd)
+    .quiet()
+    .nothrow();
+  if (result.exitCode !== 0) return [];
+
+  const stream = result.stdout.toString();
+  const messages = stream
+    .split(sentinel)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  const notes: string[] = [];
+  for (const message of messages) {
+    const matches = message.matchAll(/^BREAKING[ -]CHANGE:\s*(.+?)(?=\n\n|\n[A-Z][A-Za-z-]+:|\n*$)/gms);
+    for (const match of matches) {
+      const note = match[1]?.replace(/\s+/g, " ").trim();
+      if (note) notes.push(note);
+    }
+  }
+  return notes;
+}

--- a/.github/actions/release-action/src/migrations/migratingAppend.ts
+++ b/.github/actions/release-action/src/migrations/migratingAppend.ts
@@ -95,7 +95,12 @@ export async function readBreakingNotes(options: {
     .cwd(cwd)
     .quiet()
     .nothrow();
-  if (result.exitCode !== 0) return [];
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr.toString().trim();
+    throw new Error(
+      `git log failed for ${path} (range ${range}): ${stderr || `exit ${result.exitCode}`}`,
+    );
+  }
 
   const stream = result.stdout.toString();
   const messages = stream

--- a/.github/actions/release-action/src/monorepo/dependentsGraph.test.ts
+++ b/.github/actions/release-action/src/monorepo/dependentsGraph.test.ts
@@ -152,7 +152,10 @@ describe("propagateBumps", () => {
   });
 
   test("returns a new map without mutating the input", () => {
-    const graph = new Map<string, Set<string>>([["a", new Set(["b"])], ["b", new Set()]]);
+    const graph = new Map<string, Set<string>>([
+      ["a", new Set(["b"])],
+      ["b", new Set()],
+    ]);
     const natural = new Map([["a", "patch" as const]]);
     const result = propagateBumps(graph, natural);
     expect(result).not.toBe(natural);

--- a/.github/actions/release-action/src/monorepo/dependentsGraph.test.ts
+++ b/.github/actions/release-action/src/monorepo/dependentsGraph.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the workspace dependents graph and bump propagation.
+ */
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { withTempDir } from "../testHelpers.ts";
+import {
+  buildDependentsGraph,
+  maxBump,
+  propagateBumps,
+  type MemberManifest,
+} from "./dependentsGraph.ts";
+
+async function setupMember(
+  root: string,
+  relPath: string,
+  pkg: Record<string, unknown>,
+): Promise<MemberManifest> {
+  const abs = join(root, relPath);
+  await mkdir(abs, { recursive: true });
+  await Bun.write(join(abs, "package.json"), `${JSON.stringify(pkg, null, 2)}\n`);
+  return {
+    name: (pkg.shortName as string) ?? (pkg.name as string),
+    path: abs,
+    packageName: pkg.name as string,
+  };
+}
+
+describe("maxBump", () => {
+  test("returns the more-severe of two bump levels", () => {
+    expect(maxBump("patch", "patch")).toBe("patch");
+    expect(maxBump("patch", "minor")).toBe("minor");
+    expect(maxBump("minor", "patch")).toBe("minor");
+    expect(maxBump("minor", "major")).toBe("major");
+    expect(maxBump("major", "patch")).toBe("major");
+  });
+});
+
+describe("buildDependentsGraph", () => {
+  test("creates reverse edges for workspace dependencies", () =>
+    withTempDir(async (dir) => {
+      const core = await setupMember(dir, "packages/core", {
+        name: "@scope/core",
+        shortName: "core",
+      });
+      const consumer = await setupMember(dir, "packages/consumer", {
+        name: "@scope/consumer",
+        shortName: "consumer",
+        dependencies: { "@scope/core": "workspace:*" },
+      });
+
+      const graph = await buildDependentsGraph([core, consumer]);
+      expect(Array.from(graph.get("core") ?? [])).toEqual(["consumer"]);
+      expect(Array.from(graph.get("consumer") ?? [])).toEqual([]);
+    }));
+
+  test("ignores dependencies on non-member packages", () =>
+    withTempDir(async (dir) => {
+      const lib = await setupMember(dir, "packages/lib", {
+        name: "@scope/lib",
+        shortName: "lib",
+        dependencies: { "external-pkg": "1.0.0" },
+      });
+      const graph = await buildDependentsGraph([lib]);
+      expect(Array.from(graph.get("lib") ?? [])).toEqual([]);
+    }));
+
+  test("does not add a self-edge when a member declares itself", () =>
+    withTempDir(async (dir) => {
+      const lib = await setupMember(dir, "packages/lib", {
+        name: "@scope/lib",
+        shortName: "lib",
+        dependencies: { "@scope/lib": "workspace:*" },
+      });
+      const graph = await buildDependentsGraph([lib]);
+      expect(Array.from(graph.get("lib") ?? [])).toEqual([]);
+    }));
+
+  test("aggregates dependencies, devDependencies, and peerDependencies", () =>
+    withTempDir(async (dir) => {
+      const core = await setupMember(dir, "packages/core", {
+        name: "@scope/core",
+        shortName: "core",
+      });
+      const consumer = await setupMember(dir, "packages/consumer", {
+        name: "@scope/consumer",
+        shortName: "consumer",
+        devDependencies: { "@scope/core": "workspace:*" },
+      });
+
+      const graph = await buildDependentsGraph([core, consumer]);
+      expect(Array.from(graph.get("core") ?? [])).toEqual(["consumer"]);
+    }));
+});
+
+describe("propagateBumps", () => {
+  test("propagates patch bumps to transitive dependents", () => {
+    const graph = new Map<string, Set<string>>([
+      ["core", new Set(["mid"])],
+      ["mid", new Set(["leaf"])],
+      ["leaf", new Set()],
+    ]);
+    const natural = new Map([["core", "minor" as const]]);
+    const result = propagateBumps(graph, natural);
+    expect(result.get("core")).toBe("minor");
+    expect(result.get("mid")).toBe("patch");
+    expect(result.get("leaf")).toBe("patch");
+  });
+
+  test("never lowers a stronger natural bump", () => {
+    const graph = new Map<string, Set<string>>([
+      ["core", new Set(["leaf"])],
+      ["leaf", new Set()],
+    ]);
+    const natural = new Map([
+      ["core", "patch" as const],
+      ["leaf", "major" as const],
+    ]);
+    const result = propagateBumps(graph, natural);
+    expect(result.get("leaf")).toBe("major");
+  });
+
+  test("does not bump unrelated members", () => {
+    const graph = new Map<string, Set<string>>([
+      ["a", new Set(["b"])],
+      ["b", new Set()],
+      ["c", new Set()],
+    ]);
+    const natural = new Map([["a", "patch" as const]]);
+    const result = propagateBumps(graph, natural);
+    expect(result.has("c")).toBe(false);
+  });
+
+  test("returns a new map without mutating the input", () => {
+    const graph = new Map<string, Set<string>>([["a", new Set(["b"])], ["b", new Set()]]);
+    const natural = new Map([["a", "patch" as const]]);
+    const result = propagateBumps(graph, natural);
+    expect(result).not.toBe(natural);
+    expect(natural.has("b")).toBe(false);
+  });
+});

--- a/.github/actions/release-action/src/monorepo/dependentsGraph.test.ts
+++ b/.github/actions/release-action/src/monorepo/dependentsGraph.test.ts
@@ -68,6 +68,23 @@ describe("buildDependentsGraph", () => {
       expect(Array.from(graph.get("lib") ?? [])).toEqual([]);
     }));
 
+  test("ignores a member-named dependency that is not declared as workspace:*", () =>
+    withTempDir(async (dir) => {
+      const core = await setupMember(dir, "packages/core", {
+        name: "@scope/core",
+        shortName: "core",
+      });
+      const consumer = await setupMember(dir, "packages/consumer", {
+        name: "@scope/consumer",
+        shortName: "consumer",
+        // pinned to a registry version, not workspace:* — must not create an edge
+        dependencies: { "@scope/core": "1.0.0" },
+      });
+
+      const graph = await buildDependentsGraph([core, consumer]);
+      expect(Array.from(graph.get("core") ?? [])).toEqual([]);
+    }));
+
   test("does not add a self-edge when a member declares itself", () =>
     withTempDir(async (dir) => {
       const lib = await setupMember(dir, "packages/lib", {

--- a/.github/actions/release-action/src/monorepo/dependentsGraph.ts
+++ b/.github/actions/release-action/src/monorepo/dependentsGraph.ts
@@ -52,12 +52,21 @@ async function readManifest(memberPath: string): Promise<Record<string, unknown>
   return json;
 }
 
-function collectDeclaredDeps(pkg: Record<string, unknown>): Set<string> {
+/**
+ * Collect dependency names that point at another workspace member.
+ *
+ * Only entries whose version specifier starts with `workspace:` count — npm
+ * packages that happen to share a name with a workspace member must not pull
+ * a release through the graph. The check matches Bun's `workspace:*` /
+ * `workspace:^` / `workspace:<range>` forms.
+ */
+function collectWorkspaceDeps(pkg: Record<string, unknown>): Set<string> {
   const out = new Set<string>();
   for (const key of ["dependencies", "devDependencies", "peerDependencies"] as const) {
     const value = pkg[key];
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      for (const dep of Object.keys(value as Record<string, unknown>)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    for (const [dep, specifier] of Object.entries(value as Record<string, unknown>)) {
+      if (typeof specifier === "string" && specifier.startsWith("workspace:")) {
         out.add(dep);
       }
     }
@@ -90,7 +99,7 @@ export async function buildDependentsGraph(
   for (const consumer of members) {
     const pkg = await readManifest(consumer.path);
     if (!pkg) continue;
-    const declared = collectDeclaredDeps(pkg);
+    const declared = collectWorkspaceDeps(pkg);
     for (const dep of declared) {
       const depMemberName = byPackageName.get(dep);
       if (!depMemberName || depMemberName === consumer.name) continue;

--- a/.github/actions/release-action/src/monorepo/dependentsGraph.ts
+++ b/.github/actions/release-action/src/monorepo/dependentsGraph.ts
@@ -1,0 +1,141 @@
+/**
+ * Workspace dependents graph and bump propagation.
+ *
+ * A member's release should bring along its workspace dependents — e.g. when
+ * `@code-assistants/actions-core` ships a new version, every action that
+ * imports it via `workspace:*` needs at least a patch bump so the new tag
+ * doesn't ship with a stale dependency declaration.
+ *
+ * The graph is direction-flipped on purpose: edges go from a *dependency* to
+ * its dependents, so {@link propagateBumps} can do a single BFS from each
+ * naturally-bumped member outward.
+ *
+ * @example
+ * ```typescript
+ * const graph = buildDependentsGraph(members);
+ * const final = propagateBumps(graph, naturalBumps);
+ * // dependents that did not bump on their own pick up a `patch`.
+ * ```
+ */
+import { join } from "node:path";
+
+/** Subset of `package.json` we need to walk dependencies. */
+export interface MemberManifest {
+  /** Unscoped member name (matches `Member.name`). */
+  name: string;
+  /** Absolute path to the member directory. */
+  path: string;
+  /** Package name as it appears in `dependencies`/`devDependencies` of other members. */
+  packageName: string;
+}
+
+/** Possible semver bump levels, in increasing severity. */
+export type BumpLevel = "patch" | "minor" | "major";
+
+const bumpRank: Record<BumpLevel, number> = { patch: 0, minor: 1, major: 2 };
+
+/** Pick the more-severe of two bump levels. */
+export function maxBump(a: BumpLevel, b: BumpLevel): BumpLevel {
+  return bumpRank[a] >= bumpRank[b] ? a : b;
+}
+
+/**
+ * Reverse adjacency: key = member name, value = set of member names that depend on it.
+ * Only members present in `members` appear as nodes.
+ */
+export type DependentsGraph = Map<string, Set<string>>;
+
+async function readManifest(memberPath: string): Promise<Record<string, unknown> | undefined> {
+  const file = Bun.file(join(memberPath, "package.json"));
+  if (!(await file.exists())) return undefined;
+  const json = (await file.json()) as Record<string, unknown>;
+  return json;
+}
+
+function collectDeclaredDeps(pkg: Record<string, unknown>): Set<string> {
+  const out = new Set<string>();
+  for (const key of ["dependencies", "devDependencies", "peerDependencies"] as const) {
+    const value = pkg[key];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const dep of Object.keys(value as Record<string, unknown>)) {
+        out.add(dep);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the reverse dependency graph from a set of workspace members.
+ *
+ * Reads each member's `package.json` and adds an edge from every dependency
+ * (when that dependency is itself a known member) to the consuming member.
+ *
+ * @param members - Members to consider. Each must carry `name`, `path`, and
+ *   `packageName` (the scoped name that appears in other members' deps).
+ */
+export async function buildDependentsGraph(
+  members: readonly MemberManifest[],
+): Promise<DependentsGraph> {
+  const byPackageName = new Map<string, string>();
+  for (const member of members) {
+    byPackageName.set(member.packageName, member.name);
+  }
+
+  const graph: DependentsGraph = new Map();
+  for (const member of members) {
+    graph.set(member.name, new Set());
+  }
+
+  for (const consumer of members) {
+    const pkg = await readManifest(consumer.path);
+    if (!pkg) continue;
+    const declared = collectDeclaredDeps(pkg);
+    for (const dep of declared) {
+      const depMemberName = byPackageName.get(dep);
+      if (!depMemberName || depMemberName === consumer.name) continue;
+      graph.get(depMemberName)!.add(consumer.name);
+    }
+  }
+
+  return graph;
+}
+
+/**
+ * Walk the dependents graph from each naturally-bumped member and force at
+ * least `patch` on every transitive dependent that did not bump on its own.
+ *
+ * Members that already have a stronger bump from their own commits are left
+ * untouched; the returned map represents the final per-member bump level
+ * after propagation.
+ *
+ * @param graph - Reverse adjacency from {@link buildDependentsGraph}.
+ * @param naturalBumps - Bumps determined from each member's own commit log.
+ * @returns Final bump map keyed by member name. The returned map is a new
+ *   object; the input is not mutated.
+ */
+export function propagateBumps(
+  graph: DependentsGraph,
+  naturalBumps: ReadonlyMap<string, BumpLevel>,
+): Map<string, BumpLevel> {
+  const final = new Map(naturalBumps);
+  const queue: string[] = [...naturalBumps.keys()];
+  const seen = new Set<string>(queue);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const dependents = graph.get(current);
+    if (!dependents) continue;
+    for (const dependent of dependents) {
+      const existing = final.get(dependent);
+      if (existing) continue;
+      final.set(dependent, "patch");
+      if (!seen.has(dependent)) {
+        seen.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return final;
+}

--- a/.github/actions/release-action/src/monorepo/discoverMembers.test.ts
+++ b/.github/actions/release-action/src/monorepo/discoverMembers.test.ts
@@ -124,6 +124,23 @@ describe("discoverMembers", () => {
     });
   });
 
+  test("deduplicates members matched by overlapping workspace globs", () =>
+    withTempDir(async (dir) => {
+      await writePkg(dir, {
+        name: "monorepo",
+        workspaces: ["packages/*", "packages/lib"],
+      });
+      await mkdir(join(dir, "packages", "lib"), { recursive: true });
+      await writePkg(join(dir, "packages", "lib"), {
+        name: "@scope/lib",
+        release: { type: "lib-nodejs" },
+      });
+
+      const result = await discoverMembers(dir);
+      expect(result.members.length).toBe(1);
+      expect(result.members[0]?.name).toBe("lib");
+    }));
+
   test("falls back to standalone when workspaces yield zero eligible members but root has release.type", async () => {
     await withTempDir(async (dir) => {
       await writePkg(dir, {

--- a/.github/actions/release-action/src/monorepo/discoverMembers.test.ts
+++ b/.github/actions/release-action/src/monorepo/discoverMembers.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for workspace member discovery.
+ */
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { withTempDir } from "../testHelpers.ts";
+import { deriveMemberName, discoverMembers } from "./discoverMembers.ts";
+
+async function writePkg(dir: string, contents: Record<string, unknown>): Promise<void> {
+  await Bun.write(join(dir, "package.json"), `${JSON.stringify(contents, null, 2)}\n`);
+}
+
+describe("deriveMemberName", () => {
+  test("strips a leading @scope/", () => {
+    expect(deriveMemberName("@code-assistants/release-action")).toBe("release-action");
+  });
+
+  test("returns the name unchanged when unscoped", () => {
+    expect(deriveMemberName("autopilot")).toBe("autopilot");
+  });
+});
+
+describe("discoverMembers", () => {
+  test("returns unknown when there is no package.json", async () => {
+    await withTempDir(async (dir) => {
+      const result = await discoverMembers(dir);
+      expect(result.mode).toBe("unknown");
+      expect(result.members).toEqual([]);
+    });
+  });
+
+  test("returns standalone when root has a release.type and no workspaces", async () => {
+    await withTempDir(async (dir) => {
+      await writePkg(dir, { name: "lib", release: { type: "lib-nodejs" } });
+      const result = await discoverMembers(dir);
+      expect(result.mode).toBe("standalone");
+      expect(result.rootReleaseType).toBe("lib-nodejs");
+      expect(result.members).toEqual([]);
+    });
+  });
+
+  test("returns standalone with slack when root declares it", async () => {
+    await withTempDir(async (dir) => {
+      await writePkg(dir, {
+        name: "lib",
+        release: { type: "lib-nodejs", slack: "#releases" },
+      });
+      const result = await discoverMembers(dir);
+      expect(result.mode).toBe("standalone");
+      expect(result.rootSlack).toBe("#releases");
+    });
+  });
+
+  test("discovers members from explicit release.members list", async () => {
+    await withTempDir(async (dir) => {
+      await writePkg(dir, {
+        name: "monorepo",
+        release: { members: ["packages/lib-a", "packages/lib-b"] },
+      });
+      await mkdir(join(dir, "packages", "lib-a"), { recursive: true });
+      await mkdir(join(dir, "packages", "lib-b"), { recursive: true });
+      await writePkg(join(dir, "packages", "lib-a"), {
+        name: "@scope/lib-a",
+        release: { type: "lib-nodejs" },
+      });
+      await writePkg(join(dir, "packages", "lib-b"), {
+        name: "@scope/lib-b",
+        release: { type: "lib-bun", slack: "#libs" },
+      });
+
+      const result = await discoverMembers(dir);
+      expect(result.mode).toBe("monorepo");
+      expect(result.members.map((m) => m.name).sort()).toEqual(["lib-a", "lib-b"]);
+      const libB = result.members.find((m) => m.name === "lib-b");
+      expect(libB?.releaseType).toBe("lib-bun");
+      expect(libB?.slack).toBe("#libs");
+    });
+  });
+
+  test("expands workspaces globs and skips members without a release field", async () => {
+    await withTempDir(async (dir) => {
+      await writePkg(dir, {
+        name: "monorepo",
+        workspaces: ["packages/*"],
+      });
+      await mkdir(join(dir, "packages", "released"), { recursive: true });
+      await mkdir(join(dir, "packages", "internal"), { recursive: true });
+      await writePkg(join(dir, "packages", "released"), {
+        name: "@scope/released",
+        release: { type: "lib-nodejs" },
+      });
+      await writePkg(join(dir, "packages", "internal"), {
+        name: "@scope/internal",
+      });
+
+      const result = await discoverMembers(dir);
+      expect(result.mode).toBe("monorepo");
+      expect(result.members.map((m) => m.name)).toEqual(["released"]);
+    });
+  });
+
+  test("ignores node_modules when expanding globs", async () => {
+    await withTempDir(async (dir) => {
+      await writePkg(dir, {
+        name: "monorepo",
+        workspaces: ["packages/*"],
+      });
+      await mkdir(join(dir, "node_modules", "packages", "leak"), { recursive: true });
+      await writePkg(join(dir, "node_modules", "packages", "leak"), {
+        name: "@evil/leak",
+        release: { type: "lib-nodejs" },
+      });
+      await mkdir(join(dir, "packages", "real"), { recursive: true });
+      await writePkg(join(dir, "packages", "real"), {
+        name: "@scope/real",
+        release: { type: "lib-nodejs" },
+      });
+
+      const result = await discoverMembers(dir);
+      expect(result.members.map((m) => m.name)).toEqual(["real"]);
+    });
+  });
+
+  test("falls back to standalone when workspaces yield zero eligible members but root has release.type", async () => {
+    await withTempDir(async (dir) => {
+      await writePkg(dir, {
+        name: "monorepo",
+        workspaces: ["packages/*"],
+        release: { type: "lib-nodejs" },
+      });
+      await mkdir(join(dir, "packages", "internal"), { recursive: true });
+      await writePkg(join(dir, "packages", "internal"), { name: "@scope/internal" });
+
+      const result = await discoverMembers(dir);
+      expect(result.mode).toBe("standalone");
+      expect(result.rootReleaseType).toBe("lib-nodejs");
+    });
+  });
+});

--- a/.github/actions/release-action/src/monorepo/discoverMembers.ts
+++ b/.github/actions/release-action/src/monorepo/discoverMembers.ts
@@ -81,6 +81,10 @@ async function expandWorkspaceGlobs(
   globs: readonly string[],
   cwd: string,
 ): Promise<string[]> {
+  // Overlapping globs (e.g. `packages/*` plus `packages/lib-a`) can yield the
+  // same member directory twice. Deduplicate by path so a member never gets
+  // released more than once per run.
+  const seen = new Set<string>();
   const out: string[] = [];
   for (const pattern of globs) {
     // Bun's `Glob` matches files; workspaces are directories, so look for a
@@ -89,6 +93,8 @@ async function expandWorkspaceGlobs(
     for await (const match of glob.scan({ cwd, dot: true, absolute: false })) {
       if (match.includes("node_modules")) continue;
       const dir = match.slice(0, -"/package.json".length);
+      if (seen.has(dir)) continue;
+      seen.add(dir);
       out.push(dir);
     }
   }

--- a/.github/actions/release-action/src/monorepo/discoverMembers.ts
+++ b/.github/actions/release-action/src/monorepo/discoverMembers.ts
@@ -1,0 +1,202 @@
+/**
+ * Discover release-eligible workspace members from a repository root.
+ *
+ * Resolution order:
+ * 1. Root `package.json` `release.members` (explicit allow-list).
+ * 2. Otherwise expand root `package.json` `workspaces` globs.
+ * 3. For each candidate path, read `<path>/package.json` and keep it only when
+ *    it declares its own `release` object (members without a `release` field
+ *    are internal-only and are skipped).
+ *
+ * When no eligible members are found and the root itself carries a `release.type`,
+ * the caller should fall back to standalone mode — discovery returns an empty
+ * array in that case; the {@link detectMode} helper signals the mode.
+ *
+ * @see ../../../../docs/release-field.md
+ */
+import { join, relative } from "node:path";
+
+import { Glob } from "bun";
+
+import { readReleaseField, readRootRelease, type ReleaseType } from "../releaseField.ts";
+
+/** Workspace member eligible for an independent release. */
+export interface Member {
+  /** Unscoped package name used in tags and labels (e.g. `release-action`). */
+  name: string;
+  /** Absolute path to the member directory. */
+  path: string;
+  /** Path relative to the repository root (e.g. `.github/actions/release-action`). */
+  relPath: string;
+  /** Release type declared on the member's `package.json`. */
+  releaseType: ReleaseType;
+  /** Optional Slack channel declared on the member's `package.json`. */
+  slack?: string;
+}
+
+/** Mode resolved from the repository root configuration. */
+export type Mode = "monorepo" | "standalone" | "unknown";
+
+/** Result of root-level discovery. */
+export interface DiscoveryResult {
+  mode: Mode;
+  members: Member[];
+  /** Set when standalone mode applies (root has a `release.type`). */
+  rootReleaseType?: ReleaseType;
+  /** Set when standalone mode applies and root declared a Slack channel. */
+  rootSlack?: string;
+}
+
+/**
+ * Strip an `@scope/` prefix and an optional `-action` suffix from a package name
+ * to derive the tag/label-friendly member name. Returns the original name when
+ * neither prefix nor suffix is present.
+ *
+ * @param packageName - The value of `package.json` `name` for the member.
+ * @returns The unscoped, suffix-trimmed member name.
+ *
+ * @example
+ * ```typescript
+ * deriveMemberName("@code-assistants/release-action"); // "release-action"
+ * deriveMemberName("autopilot");                       // "autopilot"
+ * deriveMemberName("@scope/lib");                      // "lib"
+ * ```
+ */
+export function deriveMemberName(packageName: string): string {
+  const unscoped = packageName.startsWith("@")
+    ? packageName.slice(packageName.indexOf("/") + 1)
+    : packageName;
+  return unscoped;
+}
+
+async function readJsonIfExists(path: string): Promise<unknown> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    return undefined;
+  }
+  return file.json();
+}
+
+async function expandWorkspaceGlobs(
+  globs: readonly string[],
+  cwd: string,
+): Promise<string[]> {
+  const out: string[] = [];
+  for (const pattern of globs) {
+    // Bun's `Glob` matches files; workspaces are directories, so look for a
+    // `package.json` inside each candidate then strip it back.
+    const glob = new Glob(`${pattern}/package.json`);
+    for await (const match of glob.scan({ cwd, dot: true, absolute: false })) {
+      if (match.includes("node_modules")) continue;
+      const dir = match.slice(0, -"/package.json".length);
+      out.push(dir);
+    }
+  }
+  return out;
+}
+
+async function readWorkspaceList(rootPkg: unknown): Promise<readonly string[] | undefined> {
+  if (typeof rootPkg !== "object" || rootPkg === null) return undefined;
+  const value: unknown = (rootPkg as Record<string, unknown>).workspaces;
+  if (!Array.isArray(value)) return undefined;
+  const entries: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string" && entry.length > 0) {
+      entries.push(entry);
+    }
+  }
+  return entries.length > 0 ? entries : undefined;
+}
+
+async function buildMember(memberPath: string, cwd: string): Promise<Member | undefined> {
+  const absPath = join(cwd, memberPath);
+  const pkg = await readJsonIfExists(join(absPath, "package.json"));
+  if (!pkg || typeof pkg !== "object") return undefined;
+
+  const pkgRecord = pkg as Record<string, unknown>;
+  if (!("release" in pkgRecord)) return undefined;
+
+  const config = readReleaseField(pkg);
+  const rawName = typeof pkgRecord.name === "string" ? pkgRecord.name : undefined;
+  if (!rawName) return undefined;
+
+  const member: Member = {
+    name: deriveMemberName(rawName),
+    path: absPath,
+    relPath: relative(cwd, absPath),
+    releaseType: config.type,
+  };
+  if (config.slack !== undefined) {
+    member.slack = config.slack;
+  }
+  return member;
+}
+
+/**
+ * Discover release-eligible workspace members.
+ *
+ * @param cwd - Repository root absolute path. Defaults to `process.cwd()`.
+ * @returns A {@link DiscoveryResult} describing the mode and the eligible
+ *   members. When `mode` is `standalone`, callers should run the legacy
+ *   single-artifact pipeline against `cwd`.
+ *
+ * @example
+ * ```typescript
+ * const result = await discoverMembers(process.cwd());
+ * if (result.mode === "monorepo") {
+ *   for (const member of result.members) {
+ *     // release member
+ *   }
+ * }
+ * ```
+ */
+export async function discoverMembers(cwd = process.cwd()): Promise<DiscoveryResult> {
+  const rootPkg = await readJsonIfExists(join(cwd, "package.json"));
+  if (!rootPkg) {
+    return { mode: "unknown", members: [] };
+  }
+
+  const root = readRootRelease(rootPkg);
+  const candidates = root.members ?? (await readWorkspaceList(rootPkg));
+
+  if (!candidates) {
+    if (root.type) {
+      const result: DiscoveryResult = {
+        mode: "standalone",
+        members: [],
+        rootReleaseType: root.type,
+      };
+      if (root.slack !== undefined) {
+        result.rootSlack = root.slack;
+      }
+      return result;
+    }
+    return { mode: "unknown", members: [] };
+  }
+
+  const paths = root.members
+    ? Array.from(candidates)
+    : await expandWorkspaceGlobs(candidates, cwd);
+
+  const members: Member[] = [];
+  for (const memberPath of paths) {
+    const member = await buildMember(memberPath, cwd);
+    if (member) {
+      members.push(member);
+    }
+  }
+
+  if (members.length === 0 && root.type) {
+    const result: DiscoveryResult = {
+      mode: "standalone",
+      members: [],
+      rootReleaseType: root.type,
+    };
+    if (root.slack !== undefined) {
+      result.rootSlack = root.slack;
+    }
+    return result;
+  }
+
+  return { mode: members.length > 0 ? "monorepo" : "unknown", members };
+}

--- a/.github/actions/release-action/src/monorepo/discoverMembers.ts
+++ b/.github/actions/release-action/src/monorepo/discoverMembers.ts
@@ -77,10 +77,7 @@ async function readJsonIfExists(path: string): Promise<unknown> {
   return file.json();
 }
 
-async function expandWorkspaceGlobs(
-  globs: readonly string[],
-  cwd: string,
-): Promise<string[]> {
+async function expandWorkspaceGlobs(globs: readonly string[], cwd: string): Promise<string[]> {
   // Overlapping globs (e.g. `packages/*` plus `packages/lib-a`) can yield the
   // same member directory twice. Deduplicate by path so a member never gets
   // released more than once per run.
@@ -180,9 +177,7 @@ export async function discoverMembers(cwd = process.cwd()): Promise<DiscoveryRes
     return { mode: "unknown", members: [] };
   }
 
-  const paths = root.members
-    ? Array.from(candidates)
-    : await expandWorkspaceGlobs(candidates, cwd);
+  const paths = root.members ? Array.from(candidates) : await expandWorkspaceGlobs(candidates, cwd);
 
   const members: Member[] = [];
   for (const memberPath of paths) {

--- a/.github/actions/release-action/src/monorepo/memberDiff.test.ts
+++ b/.github/actions/release-action/src/monorepo/memberDiff.test.ts
@@ -53,6 +53,20 @@ describe("listMemberCommits", () => {
     }));
 });
 
+describe("listMemberCommits failure", () => {
+  test("throws when git log exits non-zero (e.g. invalid range)", () =>
+    withTempRepo(async (repo) => {
+      await commitInPath(repo, "packages/lib", "f.txt", "feat(lib): seed");
+      await expect(
+        listMemberCommits({
+          cwd: repo,
+          path: "packages/lib",
+          since: "does-not-exist@v999.0.0",
+        }),
+      ).rejects.toThrow(/git log failed/);
+    }));
+});
+
 describe("memberHasChanges", () => {
   test("is true when at least one commit touched the path", () =>
     withTempRepo(async (repo) => {

--- a/.github/actions/release-action/src/monorepo/memberDiff.test.ts
+++ b/.github/actions/release-action/src/monorepo/memberDiff.test.ts
@@ -71,9 +71,7 @@ describe("memberHasChanges", () => {
   test("is true when at least one commit touched the path", () =>
     withTempRepo(async (repo) => {
       await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): seed");
-      expect(
-        await memberHasChanges({ cwd: repo, path: "packages/lib-a", since: null }),
-      ).toBe(true);
+      expect(await memberHasChanges({ cwd: repo, path: "packages/lib-a", since: null })).toBe(true);
     }));
 
   test("is false when no commits touched the path in the range", () =>

--- a/.github/actions/release-action/src/monorepo/memberDiff.test.ts
+++ b/.github/actions/release-action/src/monorepo/memberDiff.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for path-scoped member commit listing.
+ */
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { $ } from "bun";
+
+import { withTempRepo } from "../testHelpers.ts";
+import { listMemberCommits, memberHasChanges } from "./memberDiff.ts";
+
+async function commitInPath(
+  repo: string,
+  relPath: string,
+  fileName: string,
+  message: string,
+): Promise<void> {
+  await mkdir(join(repo, relPath), { recursive: true });
+  await Bun.write(join(repo, relPath, fileName), `${Date.now()}\n`);
+  await $`git add ${join(relPath, fileName)}`.cwd(repo).quiet();
+  await $`git commit -m ${message}`.cwd(repo).quiet();
+}
+
+describe("listMemberCommits", () => {
+  test("returns only commits that touched the member path since the given tag", () =>
+    withTempRepo(async (repo) => {
+      await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): seed");
+      await $`git tag lib-a@v0.1.0`.cwd(repo).quiet();
+      await commitInPath(repo, "packages/lib-a", "f2.txt", "feat(lib-a): add foo");
+      await commitInPath(repo, "packages/lib-b", "f3.txt", "feat(lib-b): unrelated");
+
+      const commits = await listMemberCommits({
+        cwd: repo,
+        path: "packages/lib-a",
+        since: "lib-a@v0.1.0",
+      });
+      expect(commits).toEqual(["feat(lib-a): add foo"]);
+    }));
+
+  test("returns all matching commits when no lower bound is set", () =>
+    withTempRepo(async (repo) => {
+      await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): one");
+      await commitInPath(repo, "packages/lib-a", "f2.txt", "feat(lib-a): two");
+
+      const commits = await listMemberCommits({
+        cwd: repo,
+        path: "packages/lib-a",
+        since: null,
+      });
+      expect(commits).toEqual(["feat(lib-a): two", "feat(lib-a): one"]);
+    }));
+});
+
+describe("memberHasChanges", () => {
+  test("is true when at least one commit touched the path", () =>
+    withTempRepo(async (repo) => {
+      await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): seed");
+      expect(
+        await memberHasChanges({ cwd: repo, path: "packages/lib-a", since: null }),
+      ).toBe(true);
+    }));
+
+  test("is false when no commits touched the path in the range", () =>
+    withTempRepo(async (repo) => {
+      await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): seed");
+      await $`git tag lib-a@v0.1.0`.cwd(repo).quiet();
+      await commitInPath(repo, "packages/lib-b", "f2.txt", "feat(lib-b): elsewhere");
+
+      expect(
+        await memberHasChanges({
+          cwd: repo,
+          path: "packages/lib-a",
+          since: "lib-a@v0.1.0",
+        }),
+      ).toBe(false);
+    }));
+});

--- a/.github/actions/release-action/src/monorepo/memberDiff.ts
+++ b/.github/actions/release-action/src/monorepo/memberDiff.ts
@@ -44,7 +44,10 @@ export async function listMemberCommits(options: MemberDiffOptions): Promise<str
     .quiet()
     .nothrow();
   if (result.exitCode !== 0) {
-    return [];
+    const stderr = result.stderr.toString().trim();
+    throw new Error(
+      `git log failed for ${path} (range ${range}): ${stderr || `exit ${result.exitCode}`}`,
+    );
   }
   return result.stdout.toString().trim().split("\n").filter(Boolean);
 }

--- a/.github/actions/release-action/src/monorepo/memberDiff.ts
+++ b/.github/actions/release-action/src/monorepo/memberDiff.ts
@@ -39,10 +39,7 @@ export interface MemberDiffOptions {
 export async function listMemberCommits(options: MemberDiffOptions): Promise<string[]> {
   const { cwd, path, since } = options;
   const range = since ? `${since}..HEAD` : "HEAD";
-  const result = await $`git log ${range} --pretty=format:%s -- ${path}`
-    .cwd(cwd)
-    .quiet()
-    .nothrow();
+  const result = await $`git log ${range} --pretty=format:%s -- ${path}`.cwd(cwd).quiet().nothrow();
   if (result.exitCode !== 0) {
     const stderr = result.stderr.toString().trim();
     throw new Error(

--- a/.github/actions/release-action/src/monorepo/memberDiff.ts
+++ b/.github/actions/release-action/src/monorepo/memberDiff.ts
@@ -1,0 +1,56 @@
+/**
+ * Path-scoped git log helpers for monorepo member release computation.
+ *
+ * `git log <range> -- <path>` is the standard way to list commits that touched
+ * a particular subdirectory. Members use this to determine whether they have
+ * any changes worth releasing, and `conventional-recommended-bump` /
+ * `conventional-changelog` consume the same range via their `path` filter.
+ *
+ * @example
+ * ```typescript
+ * const since = await getLatestMemberTagReachable("release-action", cwd);
+ * const touched = await memberHasChanges("release-action", {
+ *   cwd,
+ *   path: ".github/actions/release-action",
+ *   since,
+ * });
+ * if (!touched) {
+ *   console.log("Nothing to release for release-action");
+ * }
+ * ```
+ */
+import { $ } from "bun";
+
+/** Options describing the path-scoped range to inspect. */
+export interface MemberDiffOptions {
+  /** Repository root. */
+  cwd: string;
+  /** Path relative to the repo root that scopes the log. */
+  path: string;
+  /** Lower bound for the range (e.g. last release tag). `null` means since-root. */
+  since: string | null;
+}
+
+/**
+ * List commit subjects that touched a member's path since a given tag.
+ *
+ * @returns Array of commit subjects (one per line); empty when no commits match.
+ */
+export async function listMemberCommits(options: MemberDiffOptions): Promise<string[]> {
+  const { cwd, path, since } = options;
+  const range = since ? `${since}..HEAD` : "HEAD";
+  const result = await $`git log ${range} --pretty=format:%s -- ${path}`
+    .cwd(cwd)
+    .quiet()
+    .nothrow();
+  if (result.exitCode !== 0) {
+    return [];
+  }
+  return result.stdout.toString().trim().split("\n").filter(Boolean);
+}
+
+/** Cheap predicate: does the member have any commits in the path-scoped range? */
+export async function memberHasChanges(options: MemberDiffOptions): Promise<boolean> {
+  const commits = await listMemberCommits(options);
+  return commits.length > 0;
+}

--- a/.github/actions/release-action/src/monorepo/memberTags.test.ts
+++ b/.github/actions/release-action/src/monorepo/memberTags.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for per-member git tag helpers.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { $ } from "bun";
+
+import { withTempRepo } from "../testHelpers.ts";
+import {
+  getLatestMemberTagReachable,
+  getLatestMemberVersion,
+  memberMajorTag,
+  memberTagPattern,
+  memberTagPrefix,
+  memberVersionTag,
+  parseMemberTag,
+} from "./memberTags.ts";
+
+describe("tag builders", () => {
+  test("memberTagPrefix returns the <name>@v form", () => {
+    expect(memberTagPrefix("release-action")).toBe("release-action@v");
+  });
+
+  test("memberTagPattern returns the glob used by git tag -l", () => {
+    expect(memberTagPattern("release-action")).toBe("release-action@v*");
+  });
+
+  test("memberVersionTag composes the full tag", () => {
+    expect(memberVersionTag("release-action", "1.2.0")).toBe("release-action@v1.2.0");
+  });
+
+  test("memberMajorTag uses the parsed major number", () => {
+    expect(memberMajorTag("release-action", "1.2.0")).toBe("release-action@v1");
+  });
+
+  test("memberMajorTag throws for invalid versions", () => {
+    expect(() => memberMajorTag("release-action", "not-a-version")).toThrow(
+      /Invalid semver/,
+    );
+  });
+});
+
+describe("parseMemberTag", () => {
+  test("extracts a valid version", () => {
+    expect(parseMemberTag("release-action", "release-action@v1.2.0")).toBe("1.2.0");
+  });
+
+  test("returns null when the prefix does not match", () => {
+    expect(parseMemberTag("release-action", "autopilot@v1.0.0")).toBeNull();
+  });
+
+  test("returns null when the version segment is not valid semver", () => {
+    expect(parseMemberTag("release-action", "release-action@vNOT")).toBeNull();
+  });
+});
+
+async function tagAtHead(cwd: string, tag: string): Promise<void> {
+  await $`git tag ${tag}`.cwd(cwd).quiet();
+}
+
+async function emptyCommit(cwd: string, message: string): Promise<void> {
+  await $`git commit --allow-empty -m ${message}`.cwd(cwd).quiet();
+}
+
+describe("getLatestMemberVersion", () => {
+  test("returns the highest semver tag for a member", () =>
+    withTempRepo(async (repo) => {
+      await emptyCommit(repo, "init");
+      await tagAtHead(repo, "release-action@v0.1.0");
+      await emptyCommit(repo, "second");
+      await tagAtHead(repo, "release-action@v0.2.1");
+      await tagAtHead(repo, "autopilot@v1.0.0");
+
+      expect(await getLatestMemberVersion("release-action", repo)).toBe("0.2.1");
+      expect(await getLatestMemberVersion("autopilot", repo)).toBe("1.0.0");
+    }));
+
+  test("returns null when the member has no tags", () =>
+    withTempRepo(async (repo) => {
+      await emptyCommit(repo, "init");
+      expect(await getLatestMemberVersion("release-action", repo)).toBeNull();
+    }));
+});
+
+describe("getLatestMemberTagReachable", () => {
+  test("returns the most recent member tag reachable from HEAD", () =>
+    withTempRepo(async (repo) => {
+      await emptyCommit(repo, "init");
+      await tagAtHead(repo, "release-action@v0.1.0");
+      await emptyCommit(repo, "later");
+      expect(await getLatestMemberTagReachable("release-action", repo)).toBe(
+        "release-action@v0.1.0",
+      );
+    }));
+});

--- a/.github/actions/release-action/src/monorepo/memberTags.test.ts
+++ b/.github/actions/release-action/src/monorepo/memberTags.test.ts
@@ -34,9 +34,7 @@ describe("tag builders", () => {
   });
 
   test("memberMajorTag throws for invalid versions", () => {
-    expect(() => memberMajorTag("release-action", "not-a-version")).toThrow(
-      /Invalid semver/,
-    );
+    expect(() => memberMajorTag("release-action", "not-a-version")).toThrow(/Invalid semver/);
   });
 });
 

--- a/.github/actions/release-action/src/monorepo/memberTags.ts
+++ b/.github/actions/release-action/src/monorepo/memberTags.ts
@@ -63,10 +63,7 @@ export function parseMemberTag(name: string, tag: string): string | null {
  * Find the latest released version for a member by scanning `<name>@v*` tags.
  * Returns `null` when the member has no prior releases.
  */
-export async function getLatestMemberVersion(
-  name: string,
-  cwd: string,
-): Promise<string | null> {
+export async function getLatestMemberVersion(name: string, cwd: string): Promise<string | null> {
   const tags = await listTags(memberTagPattern(name), cwd);
   for (const tag of tags) {
     const version = parseMemberTag(name, tag);

--- a/.github/actions/release-action/src/monorepo/memberTags.ts
+++ b/.github/actions/release-action/src/monorepo/memberTags.ts
@@ -1,0 +1,90 @@
+/**
+ * Per-member git-tag helpers.
+ *
+ * Tags follow the `<name>@v<version>` shape (e.g. `release-action@v1.2.0`) and
+ * the floating major tag uses `<name>@v<MAJOR>` (e.g. `release-action@v1`). The
+ * `<name>` segment is the unscoped, suffix-preserving member name produced by
+ * {@link deriveMemberName}. The trailing `v` in the version segment mirrors the
+ * single-artifact convention (`v1.2.0`) so consumers can still pin against a
+ * familiar form.
+ *
+ * @example
+ * ```typescript
+ * memberTagPrefix("release-action");        // "release-action@v"
+ * memberTagPattern("release-action");       // "release-action@v*"
+ * parseMemberTag("release-action", "release-action@v1.2.0");
+ * // → "1.2.0"
+ * ```
+ */
+import semver from "semver";
+
+import { getLatestReachableTag, listTags } from "../gitTags.ts";
+
+/** Tag prefix string used by `conventional-recommended-bump` and `conventional-changelog`. */
+export function memberTagPrefix(name: string): string {
+  return `${name}@v`;
+}
+
+/** Tag pattern used by `git tag -l <pattern>` to enumerate a member's tags. */
+export function memberTagPattern(name: string): string {
+  return `${name}@v*`;
+}
+
+/**
+ * Build a per-member version tag (e.g. `release-action@v1.2.0`).
+ */
+export function memberVersionTag(name: string, version: string): string {
+  return `${memberTagPrefix(name)}${version}`;
+}
+
+/**
+ * Build a per-member floating major tag (e.g. `release-action@v1`).
+ */
+export function memberMajorTag(name: string, version: string): string {
+  const parsed = semver.parse(version);
+  if (!parsed) {
+    throw new Error(`Invalid semver version for floating major tag: ${version}`);
+  }
+  return `${memberTagPrefix(name)}${parsed.major}`;
+}
+
+/**
+ * Extract the semver version from a per-member tag, or `null` when the tag
+ * does not belong to the given member.
+ */
+export function parseMemberTag(name: string, tag: string): string | null {
+  const prefix = memberTagPrefix(name);
+  if (!tag.startsWith(prefix)) return null;
+  const rest = tag.slice(prefix.length);
+  return semver.valid(rest);
+}
+
+/**
+ * Find the latest released version for a member by scanning `<name>@v*` tags.
+ * Returns `null` when the member has no prior releases.
+ */
+export async function getLatestMemberVersion(
+  name: string,
+  cwd: string,
+): Promise<string | null> {
+  const tags = await listTags(memberTagPattern(name), cwd);
+  for (const tag of tags) {
+    const version = parseMemberTag(name, tag);
+    if (version) return version;
+  }
+  return null;
+}
+
+/**
+ * Find the latest tag reachable from HEAD by commit topology for a given member.
+ * Returns `null` when no matching tag exists in the member's history.
+ *
+ * @param ref - Git ref to search from (default: "HEAD").
+ */
+export async function getLatestMemberTagReachable(
+  name: string,
+  cwd: string,
+  ref = "HEAD",
+): Promise<string | null> {
+  return getLatestReachableTag(memberTagPattern(name), cwd, ref);
+}

--- a/.github/actions/release-action/src/monorepo/runCreate.test.ts
+++ b/.github/actions/release-action/src/monorepo/runCreate.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Integration test for the runCreate orchestrator against a fixture monorepo.
+ *
+ * The fixture spins up two workspace members in a temporary git repository:
+ * `lib-a` (a Node library) and `lib-b` (a workspace consumer of `lib-a`). The
+ * test seeds path-scoped commits, runs the orchestrator, and asserts on the
+ * per-member artifacts and on dependent-propagation behaviour.
+ */
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { $ } from "bun";
+
+import { withTempRepo } from "../testHelpers.ts";
+import { runCreate } from "./runCreate.ts";
+
+async function writeJson(path: string, value: Record<string, unknown>): Promise<void> {
+  await Bun.write(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function commitInPath(
+  repo: string,
+  relPath: string,
+  file: string,
+  message: string,
+): Promise<void> {
+  await mkdir(join(repo, relPath), { recursive: true });
+  await Bun.write(join(repo, relPath, file), `${Date.now()}\n`);
+  await $`git add ${join(relPath, file)}`.cwd(repo).quiet();
+  await $`git commit -m ${message}`.cwd(repo).quiet();
+}
+
+async function setupFixture(repo: string): Promise<void> {
+  await writeJson(join(repo, "package.json"), {
+    name: "monorepo",
+    private: true,
+    workspaces: ["packages/*"],
+  });
+
+  await mkdir(join(repo, "packages", "lib-a"), { recursive: true });
+  await mkdir(join(repo, "packages", "lib-b"), { recursive: true });
+
+  await writeJson(join(repo, "packages", "lib-a", "package.json"), {
+    name: "@fixture/lib-a",
+    version: "0.0.0",
+    release: { type: "lib-nodejs" },
+  });
+  await writeJson(join(repo, "packages", "lib-b", "package.json"), {
+    name: "@fixture/lib-b",
+    version: "0.0.0",
+    release: { type: "lib-nodejs" },
+    dependencies: { "@fixture/lib-a": "workspace:*" },
+  });
+
+  await $`git add .`.cwd(repo).quiet();
+  await $`git commit -m ${"chore: seed fixture"}`.cwd(repo).quiet();
+}
+
+describe("runCreate", () => {
+  test("skips members with no commits since their last tag", () =>
+    withTempRepo(async (repo) => {
+      await setupFixture(repo);
+      await $`git tag lib-a@v0.1.0 HEAD`.cwd(repo).quiet();
+      await $`git tag lib-b@v0.1.0 HEAD`.cwd(repo).quiet();
+
+      const result = await runCreate({ cwd: repo, dryRun: true });
+      expect(result.discovery.mode).toBe("monorepo");
+      expect(result.releases.map((r) => r.member.name)).toEqual([]);
+    }));
+
+  test("computes a feat bump for a member with a feat commit", () =>
+    withTempRepo(async (repo) => {
+      await setupFixture(repo);
+      await $`git tag lib-a@v0.1.0 HEAD`.cwd(repo).quiet();
+      await $`git tag lib-b@v0.1.0 HEAD`.cwd(repo).quiet();
+      await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): add foo");
+
+      const result = await runCreate({ cwd: repo, dryRun: true });
+      const libA = result.releases.find((r) => r.member.name === "lib-a");
+      expect(libA?.bumpLevel).toBe("minor");
+      expect(libA?.newVersion).toBe("0.2.0");
+      expect(libA?.natural).toBe(true);
+      expect(libA?.tag).toBe("lib-a@v0.2.0");
+      expect(libA?.branch).toBe("release-lib-a-0.2.0");
+    }));
+
+  test("propagates a patch bump to a workspace dependent", () =>
+    withTempRepo(async (repo) => {
+      await setupFixture(repo);
+      await $`git tag lib-a@v0.1.0 HEAD`.cwd(repo).quiet();
+      await $`git tag lib-b@v0.1.0 HEAD`.cwd(repo).quiet();
+      await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): add foo");
+
+      const result = await runCreate({ cwd: repo, dryRun: true });
+      const libB = result.releases.find((r) => r.member.name === "lib-b");
+      expect(libB?.bumpLevel).toBe("patch");
+      expect(libB?.newVersion).toBe("0.1.1");
+      expect(libB?.natural).toBe(false);
+    }));
+
+  test("does not propagate to unaffected members", () =>
+    withTempRepo(async (repo) => {
+      await setupFixture(repo);
+      await $`git tag lib-a@v0.1.0 HEAD`.cwd(repo).quiet();
+      await $`git tag lib-b@v0.1.0 HEAD`.cwd(repo).quiet();
+      // touch only lib-b — lib-a should not be propagated to (lib-b doesn't
+      // depend on itself and there's no consumer of lib-b).
+      await commitInPath(repo, "packages/lib-b", "f1.txt", "fix(lib-b): bug");
+
+      const result = await runCreate({ cwd: repo, dryRun: true });
+      expect(result.releases.map((r) => r.member.name)).toEqual(["lib-b"]);
+    }));
+
+  test("returns standalone mode without releases when there are no eligible workspace members", () =>
+    withTempRepo(async (repo) => {
+      await writeJson(join(repo, "package.json"), {
+        name: "lib",
+        release: { type: "lib-nodejs" },
+      });
+      await $`git add .`.cwd(repo).quiet();
+      await $`git commit -m ${"chore: seed"}`.cwd(repo).quiet();
+
+      const result = await runCreate({ cwd: repo, dryRun: true });
+      expect(result.discovery.mode).toBe("standalone");
+      expect(result.releases).toEqual([]);
+    }));
+});

--- a/.github/actions/release-action/src/monorepo/runCreate.test.ts
+++ b/.github/actions/release-action/src/monorepo/runCreate.test.ts
@@ -65,7 +65,7 @@ describe("runCreate", () => {
       await $`git tag lib-a@v0.1.0 HEAD`.cwd(repo).quiet();
       await $`git tag lib-b@v0.1.0 HEAD`.cwd(repo).quiet();
 
-      const result = await runCreate({ cwd: repo, dryRun: true });
+      const result = await runCreate({ cwd: repo });
       expect(result.discovery.mode).toBe("monorepo");
       expect(result.releases.map((r) => r.member.name)).toEqual([]);
     }));
@@ -77,7 +77,7 @@ describe("runCreate", () => {
       await $`git tag lib-b@v0.1.0 HEAD`.cwd(repo).quiet();
       await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): add foo");
 
-      const result = await runCreate({ cwd: repo, dryRun: true });
+      const result = await runCreate({ cwd: repo });
       const libA = result.releases.find((r) => r.member.name === "lib-a");
       expect(libA?.bumpLevel).toBe("minor");
       expect(libA?.newVersion).toBe("0.2.0");
@@ -93,7 +93,7 @@ describe("runCreate", () => {
       await $`git tag lib-b@v0.1.0 HEAD`.cwd(repo).quiet();
       await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): add foo");
 
-      const result = await runCreate({ cwd: repo, dryRun: true });
+      const result = await runCreate({ cwd: repo });
       const libB = result.releases.find((r) => r.member.name === "lib-b");
       expect(libB?.bumpLevel).toBe("patch");
       expect(libB?.newVersion).toBe("0.1.1");
@@ -109,7 +109,7 @@ describe("runCreate", () => {
       // depend on itself and there's no consumer of lib-b).
       await commitInPath(repo, "packages/lib-b", "f1.txt", "fix(lib-b): bug");
 
-      const result = await runCreate({ cwd: repo, dryRun: true });
+      const result = await runCreate({ cwd: repo });
       expect(result.releases.map((r) => r.member.name)).toEqual(["lib-b"]);
     }));
 
@@ -122,7 +122,7 @@ describe("runCreate", () => {
       await $`git add .`.cwd(repo).quiet();
       await $`git commit -m ${"chore: seed"}`.cwd(repo).quiet();
 
-      const result = await runCreate({ cwd: repo, dryRun: true });
+      const result = await runCreate({ cwd: repo });
       expect(result.discovery.mode).toBe("standalone");
       expect(result.releases).toEqual([]);
     }));

--- a/.github/actions/release-action/src/monorepo/runCreate.ts
+++ b/.github/actions/release-action/src/monorepo/runCreate.ts
@@ -19,10 +19,7 @@ import { join } from "node:path";
 import semver from "semver";
 
 import { assemblePrBody } from "../assemble-pr-body.ts";
-import {
-  appendMigratingSection,
-  readBreakingNotes,
-} from "../migrations/migratingAppend.ts";
+import { appendMigratingSection, readBreakingNotes } from "../migrations/migratingAppend.ts";
 import { bumpVersion, generateChangelog } from "../release.ts";
 import { updateVersionFiles } from "../prepareRelease.ts";
 import { refreshReleaseBadge } from "../updateReleaseBadge.ts";
@@ -32,11 +29,7 @@ import {
   type BumpLevel,
   type MemberManifest,
 } from "./dependentsGraph.ts";
-import {
-  discoverMembers,
-  type DiscoveryResult,
-  type Member,
-} from "./discoverMembers.ts";
+import { discoverMembers, type DiscoveryResult, type Member } from "./discoverMembers.ts";
 import {
   getLatestMemberTagReachable,
   getLatestMemberVersion,
@@ -85,9 +78,7 @@ export interface RunCreateOptions {
  * empty `releases` array — the caller should fall through to the standalone
  * flow.
  */
-export async function runCreate(
-  options: RunCreateOptions = {},
-): Promise<RunCreateResult> {
+export async function runCreate(options: RunCreateOptions = {}): Promise<RunCreateResult> {
   const cwd = options.cwd ?? process.cwd();
   const branchTemplate = options.branchTemplate ?? "release-{member}-{version}";
 
@@ -206,9 +197,7 @@ export interface EmitMemberArtifactsOptions {
  * the emit step with another member's branch is what allowed earlier drafts of
  * this orchestrator to cross-pollinate release commits between PRs.
  */
-export async function emitMemberArtifacts(
-  options: EmitMemberArtifactsOptions,
-): Promise<void> {
+export async function emitMemberArtifacts(options: EmitMemberArtifactsOptions): Promise<void> {
   const { release, cwd } = options;
   const { member, previousVersion, newVersion, bumpLevel, natural, branch } = release;
   const tagPrefix = memberTagPrefix(member.name);
@@ -230,9 +219,7 @@ export async function emitMemberArtifacts(
   // stripped of its own header by `startOfLastReleasePattern`).
   const memberChangelogPath = join(member.path, "CHANGELOG.md");
   const memberChangelogFile = Bun.file(memberChangelogPath);
-  const priorContent = (await memberChangelogFile.exists())
-    ? await memberChangelogFile.text()
-    : "";
+  const priorContent = (await memberChangelogFile.exists()) ? await memberChangelogFile.text() : "";
   const priorStart = priorContent.search(/(^#+ \[?[0-9]+\.[0-9]+\.[0-9]+|<a name=)/m);
   const history = priorStart !== -1 ? priorContent.substring(priorStart) : "";
   await Bun.write(
@@ -272,6 +259,7 @@ export async function emitMemberArtifacts(
     branchTemplate: branch.replaceAll(newVersion, "{version}"),
   });
 
-  console.log(`Prepared ${member.name} ${previousVersion ?? "0.0.0"} → ${newVersion} (${bumpLevel})`);
+  console.log(
+    `Prepared ${member.name} ${previousVersion ?? "0.0.0"} → ${newVersion} (${bumpLevel})`,
+  );
 }
-

--- a/.github/actions/release-action/src/monorepo/runCreate.ts
+++ b/.github/actions/release-action/src/monorepo/runCreate.ts
@@ -1,0 +1,280 @@
+/**
+ * Monorepo `create` orchestrator: for each release-eligible workspace member,
+ * compute the natural bump from path-scoped commits, propagate workspace
+ * dependents, and emit per-member changelog / release-notes / MIGRATING /
+ * version-file updates.
+ *
+ * This module wires together {@link discoverMembers}, {@link getLatestMemberVersion},
+ * {@link memberHasChanges}, {@link bumpVersion}, {@link generateChangelog},
+ * {@link buildDependentsGraph}, {@link propagateBumps}, {@link updateVersionFiles},
+ * {@link refreshReleaseBadge}, {@link assemblePrBody}, and
+ * {@link appendMigratingSection} into a single per-member flow.
+ *
+ * The orchestrator does NOT push commits or open PRs — that side-effecting
+ * work lives in the consumer-side workflow shell so the same code can be
+ * driven from a unit-test fixture.
+ */
+import { join } from "node:path";
+
+import semver from "semver";
+
+import { assemblePrBody } from "../assemble-pr-body.ts";
+import {
+  appendMigratingSection,
+  readBreakingNotes,
+} from "../migrations/migratingAppend.ts";
+import {
+  bumpVersion,
+  changelogHeader,
+  generateChangelog,
+  startOfLastReleasePattern,
+} from "../release.ts";
+import { updateVersionFiles } from "../prepareRelease.ts";
+import { refreshReleaseBadge } from "../updateReleaseBadge.ts";
+import {
+  buildDependentsGraph,
+  propagateBumps,
+  type BumpLevel,
+  type MemberManifest,
+} from "./dependentsGraph.ts";
+import {
+  discoverMembers,
+  type DiscoveryResult,
+  type Member,
+} from "./discoverMembers.ts";
+import {
+  getLatestMemberTagReachable,
+  getLatestMemberVersion,
+  memberTagPrefix,
+  memberVersionTag,
+} from "./memberTags.ts";
+import { memberHasChanges } from "./memberDiff.ts";
+
+/** A computed release plan for one member. */
+export interface MemberRelease {
+  member: Member;
+  previousVersion: string | null;
+  newVersion: string;
+  bumpLevel: BumpLevel;
+  /** Whether this bump came from the member's own commits (vs. dependent propagation). */
+  natural: boolean;
+  /** Branch the per-member release PR uses. */
+  branch: string;
+  /** Tag the per-member release PR will publish (`<name>@v<version>`). */
+  tag: string;
+}
+
+/** Result of {@link runCreate}: discovery context and computed per-member releases. */
+export interface RunCreateResult {
+  discovery: DiscoveryResult;
+  releases: MemberRelease[];
+}
+
+export interface RunCreateOptions {
+  /** Repository root (defaults to `process.cwd()`). */
+  cwd?: string;
+  /** Branch template for per-member release branches; `{member}` and `{version}` are substituted. */
+  branchTemplate?: string;
+  /**
+   * Skip side effects (file writes, git tag reads stay since they're read-only).
+   * Used by tests and the `--dry-run` CLI mode.
+   */
+  dryRun?: boolean;
+}
+
+/**
+ * Compute and (unless `dryRun`) apply per-member release artifacts for the monorepo.
+ *
+ * Returns the {@link DiscoveryResult} alongside the computed releases. Standalone
+ * repos are returned with `discovery.mode === "standalone"` and an empty
+ * `releases` array — the caller should fall through to the standalone flow.
+ */
+export async function runCreate(
+  options: RunCreateOptions = {},
+): Promise<RunCreateResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const branchTemplate = options.branchTemplate ?? "release-{member}-{version}";
+  const dryRun = options.dryRun ?? false;
+
+  const discovery = await discoverMembers(cwd);
+
+  if (discovery.mode !== "monorepo") {
+    return { discovery, releases: [] };
+  }
+
+  const manifests = await loadMemberManifests(discovery.members);
+  const naturalBumps = new Map<string, BumpLevel>();
+  const previousVersions = new Map<string, string | null>();
+
+  for (const member of discovery.members) {
+    const previous = await getLatestMemberVersion(member.name, cwd);
+    previousVersions.set(member.name, previous);
+
+    const since = await getLatestMemberTagReachable(member.name, cwd);
+    if (!(await memberHasChanges({ cwd, path: member.relPath, since }))) {
+      console.log(
+        `Skipping ${member.name}: no commits touching ${member.relPath} since ${since ?? "init"}`,
+      );
+      continue;
+    }
+
+    const bump = await computeNaturalBump(member, cwd, previous ?? "0.0.0");
+    if (bump) {
+      naturalBumps.set(member.name, bump);
+    }
+  }
+
+  const graph = await buildDependentsGraph(manifests);
+  const finalBumps = propagateBumps(graph, naturalBumps);
+  const releases: MemberRelease[] = [];
+
+  for (const member of discovery.members) {
+    const bump = finalBumps.get(member.name);
+    if (!bump) continue;
+
+    const previous = previousVersions.get(member.name) ?? null;
+    const newVersion = nextVersion(previous, bump);
+    const branch = renderBranch(branchTemplate, member.name, newVersion);
+    const tag = memberVersionTag(member.name, newVersion);
+
+    releases.push({
+      member,
+      previousVersion: previous,
+      newVersion,
+      bumpLevel: bump,
+      natural: naturalBumps.has(member.name),
+      branch,
+      tag,
+    });
+
+    if (!dryRun) {
+      await emitMemberArtifacts({
+        member,
+        previousVersion: previous,
+        newVersion,
+        bumpLevel: bump,
+        natural: naturalBumps.has(member.name),
+        cwd,
+        branch,
+      });
+    }
+  }
+
+  return { discovery, releases };
+}
+
+async function loadMemberManifests(members: readonly Member[]): Promise<MemberManifest[]> {
+  const out: MemberManifest[] = [];
+  for (const member of members) {
+    const pkg = (await Bun.file(join(member.path, "package.json")).json()) as
+      | Record<string, unknown>
+      | undefined;
+    const packageName = pkg && typeof pkg.name === "string" ? pkg.name : member.name;
+    out.push({ name: member.name, path: member.path, packageName });
+  }
+  return out;
+}
+
+async function computeNaturalBump(
+  member: Member,
+  repoCwd: string,
+  currentVersion: string,
+): Promise<BumpLevel | undefined> {
+  const tagPrefix = memberTagPrefix(member.name);
+  const result = await bumpVersion(currentVersion, repoCwd, {
+    tagPrefix,
+    path: member.relPath,
+  });
+  if (result.type !== "patch" && result.type !== "minor" && result.type !== "major") {
+    return undefined;
+  }
+  return result.type;
+}
+
+function nextVersion(previous: string | null, bump: BumpLevel): string {
+  const base = previous ?? "0.0.0";
+  const next = semver.inc(base, bump);
+  if (!next) {
+    throw new Error(`Failed to compute next version from ${base} with bump ${bump}`);
+  }
+  return next;
+}
+
+function renderBranch(template: string, memberName: string, version: string): string {
+  return template.replaceAll("{member}", memberName).replaceAll("{version}", version);
+}
+
+async function emitMemberArtifacts(input: {
+  member: Member;
+  previousVersion: string | null;
+  newVersion: string;
+  bumpLevel: BumpLevel;
+  natural: boolean;
+  cwd: string;
+  branch: string;
+}): Promise<void> {
+  const { member, previousVersion, newVersion, bumpLevel, natural, cwd, branch } = input;
+  const tagPrefix = memberTagPrefix(member.name);
+
+  // Per-member changelog
+  const log = await generateChangelog(newVersion, member.path, {
+    tagPrefix,
+    path: member.relPath,
+  });
+
+  // Per-member release notes (initial body — AI/Slack enrichment happens later
+  // by the consumer side after `assemblePrBody`).
+  await Bun.write(join(member.path, ".release_notes", `${newVersion}.md`), log.release, {
+    createPath: true,
+  });
+
+  // Per-member CHANGELOG.md
+  const changelogPath = join(member.path, "CHANGELOG.md");
+  await Bun.write(
+    changelogPath,
+    `${changelogHeader}${log.release}${stripChangelogHeader(log.history)}`.replace(/\n+$/, "\n"),
+  );
+
+  // Per-member version-file write (package.json / pyproject.toml / plugin.json)
+  await updateVersionFiles(newVersion, member.path);
+  await Bun.write(join(member.path, "version"), newVersion);
+
+  // Per-member README badge
+  await refreshReleaseBadge(member.path);
+
+  // Per-member MIGRATING.md on major bump
+  if (bumpLevel === "major") {
+    const breakingNotes = await readBreakingNotes({
+      cwd,
+      path: member.relPath,
+      since: previousVersion ? `${tagPrefix}${previousVersion}` : null,
+    });
+    await appendMigratingSection({
+      memberPath: member.path,
+      previousVersion,
+      newVersion,
+      breakingNotes,
+    });
+  }
+
+  // PR-body skeleton: same content as the changelog, plus a single-line note
+  // for dependent-driven bumps so reviewers can see why the member is moving.
+  const bodyPrefix = natural ? "" : "_Workspace dependent bump._\n\n";
+  await Bun.write(join(member.path, ".release_bot", "body"), `${bodyPrefix}${log.release}`, {
+    createPath: true,
+  });
+
+  await assemblePrBody({
+    cwd: member.path,
+    branchTemplate: branch.replaceAll(newVersion, "{version}"),
+  });
+
+  console.log(`Prepared ${member.name} ${previousVersion ?? "0.0.0"} → ${newVersion} (${bumpLevel})`);
+}
+
+function stripChangelogHeader(history: string): string {
+  // The first occurrence of the conventional-changelog header is meaningful
+  // only when there is no prior history; the orchestrator always prepends a
+  // canonical `changelogHeader`, so any previously-stored header is dropped.
+  return history.replace(startOfLastReleasePattern, (match) => match);
+}

--- a/.github/actions/release-action/src/monorepo/runCreate.ts
+++ b/.github/actions/release-action/src/monorepo/runCreate.ts
@@ -23,12 +23,7 @@ import {
   appendMigratingSection,
   readBreakingNotes,
 } from "../migrations/migratingAppend.ts";
-import {
-  bumpVersion,
-  changelogHeader,
-  generateChangelog,
-  startOfLastReleasePattern,
-} from "../release.ts";
+import { bumpVersion, generateChangelog } from "../release.ts";
 import { updateVersionFiles } from "../prepareRelease.ts";
 import { refreshReleaseBadge } from "../updateReleaseBadge.ts";
 import {
@@ -75,26 +70,26 @@ export interface RunCreateOptions {
   cwd?: string;
   /** Branch template for per-member release branches; `{member}` and `{version}` are substituted. */
   branchTemplate?: string;
-  /**
-   * Skip side effects (file writes, git tag reads stay since they're read-only).
-   * Used by tests and the `--dry-run` CLI mode.
-   */
-  dryRun?: boolean;
 }
 
 /**
- * Compute and (unless `dryRun`) apply per-member release artifacts for the monorepo.
+ * Compute the per-member release plan for a monorepo.
  *
- * Returns the {@link DiscoveryResult} alongside the computed releases. Standalone
- * repos are returned with `discovery.mode === "standalone"` and an empty
- * `releases` array — the caller should fall through to the standalone flow.
+ * This function is pure with respect to the filesystem: it inspects git
+ * history and workspace manifests but does NOT write per-member changelog,
+ * version, or release-notes files. The caller drives side effects by invoking
+ * {@link emitMemberArtifacts} once per release inside a `git checkout -B
+ * <branch> origin/main` boundary so commits never cross-contaminate.
+ *
+ * Standalone repos are returned with `discovery.mode === "standalone"` and an
+ * empty `releases` array — the caller should fall through to the standalone
+ * flow.
  */
 export async function runCreate(
   options: RunCreateOptions = {},
 ): Promise<RunCreateResult> {
   const cwd = options.cwd ?? process.cwd();
   const branchTemplate = options.branchTemplate ?? "release-{member}-{version}";
-  const dryRun = options.dryRun ?? false;
 
   const discovery = await discoverMembers(cwd);
 
@@ -146,18 +141,6 @@ export async function runCreate(
       branch,
       tag,
     });
-
-    if (!dryRun) {
-      await emitMemberArtifacts({
-        member,
-        previousVersion: previous,
-        newVersion,
-        bumpLevel: bump,
-        natural: naturalBumps.has(member.name),
-        cwd,
-        branch,
-      });
-    }
   }
 
   return { discovery, releases };
@@ -181,6 +164,10 @@ async function computeNaturalBump(
   currentVersion: string,
 ): Promise<BumpLevel | undefined> {
   const tagPrefix = memberTagPrefix(member.name);
+  // Git path filters are resolved relative to the process working directory,
+  // not the repository root, so the orchestrator pins cwd to the repo root and
+  // uses the member's repo-relative path as the filter. Mixing them silently
+  // skipped real commits in early drafts of this orchestrator.
   const result = await bumpVersion(currentVersion, repoCwd, {
     tagPrefix,
     path: member.relPath,
@@ -204,45 +191,60 @@ function renderBranch(template: string, memberName: string, version: string): st
   return template.replaceAll("{member}", memberName).replaceAll("{version}", version);
 }
 
-async function emitMemberArtifacts(input: {
-  member: Member;
-  previousVersion: string | null;
-  newVersion: string;
-  bumpLevel: BumpLevel;
-  natural: boolean;
+export interface EmitMemberArtifactsOptions {
+  release: MemberRelease;
+  /** Repository root (used for git operations and path resolution). */
   cwd: string;
-  branch: string;
-}): Promise<void> {
-  const { member, previousVersion, newVersion, bumpLevel, natural, cwd, branch } = input;
+}
+
+/**
+ * Write all per-member artifacts (changelog, release notes, version file,
+ * README badge, MIGRATING.md on major bumps, and the PR-body skeleton).
+ *
+ * Must be invoked AFTER the per-member branch has been checked out from
+ * `origin/main`, so the working tree is clean of prior members' files. Mixing
+ * the emit step with another member's branch is what allowed earlier drafts of
+ * this orchestrator to cross-pollinate release commits between PRs.
+ */
+export async function emitMemberArtifacts(
+  options: EmitMemberArtifactsOptions,
+): Promise<void> {
+  const { release, cwd } = options;
+  const { member, previousVersion, newVersion, bumpLevel, natural, branch } = release;
   const tagPrefix = memberTagPrefix(member.name);
 
-  // Per-member changelog
-  const log = await generateChangelog(newVersion, member.path, {
+  // Generate the changelog using the same (repoCwd, path) shape as
+  // `computeNaturalBump`. The history portion read from `<member>/CHANGELOG.md`
+  // is preserved via `generateChangelog`'s own logic — see release.ts.
+  const log = await generateChangelog(newVersion, cwd, {
     tagPrefix,
     path: member.relPath,
   });
 
-  // Per-member release notes (initial body — AI/Slack enrichment happens later
-  // by the consumer side after `assemblePrBody`).
   await Bun.write(join(member.path, ".release_notes", `${newVersion}.md`), log.release, {
     createPath: true,
   });
 
-  // Per-member CHANGELOG.md
-  const changelogPath = join(member.path, "CHANGELOG.md");
+  // Per-member CHANGELOG.md: prepend the canonical header + this release, then
+  // append the prior `history` returned by `generateChangelog` (already
+  // stripped of its own header by `startOfLastReleasePattern`).
+  const memberChangelogPath = join(member.path, "CHANGELOG.md");
+  const memberChangelogFile = Bun.file(memberChangelogPath);
+  const priorContent = (await memberChangelogFile.exists())
+    ? await memberChangelogFile.text()
+    : "";
+  const priorStart = priorContent.search(/(^#+ \[?[0-9]+\.[0-9]+\.[0-9]+|<a name=)/m);
+  const history = priorStart !== -1 ? priorContent.substring(priorStart) : "";
   await Bun.write(
-    changelogPath,
-    `${changelogHeader}${log.release}${stripChangelogHeader(log.history)}`.replace(/\n+$/, "\n"),
+    memberChangelogPath,
+    `${log.header}${log.release}${history}`.replace(/\n+$/, "\n"),
   );
 
-  // Per-member version-file write (package.json / pyproject.toml / plugin.json)
   await updateVersionFiles(newVersion, member.path);
   await Bun.write(join(member.path, "version"), newVersion);
 
-  // Per-member README badge
   await refreshReleaseBadge(member.path);
 
-  // Per-member MIGRATING.md on major bump
   if (bumpLevel === "major") {
     const breakingNotes = await readBreakingNotes({
       cwd,
@@ -257,8 +259,8 @@ async function emitMemberArtifacts(input: {
     });
   }
 
-  // PR-body skeleton: same content as the changelog, plus a single-line note
-  // for dependent-driven bumps so reviewers can see why the member is moving.
+  // PR-body skeleton: the changelog body plus a single-line note for
+  // dependent-driven bumps so reviewers can see why the member is moving.
   const bodyPrefix = natural ? "" : "_Workspace dependent bump._\n\n";
   await Bun.write(join(member.path, ".release_bot", "body"), `${bodyPrefix}${log.release}`, {
     createPath: true,
@@ -266,15 +268,10 @@ async function emitMemberArtifacts(input: {
 
   await assemblePrBody({
     cwd: member.path,
+    memberRelPath: member.relPath,
     branchTemplate: branch.replaceAll(newVersion, "{version}"),
   });
 
   console.log(`Prepared ${member.name} ${previousVersion ?? "0.0.0"} → ${newVersion} (${bumpLevel})`);
 }
 
-function stripChangelogHeader(history: string): string {
-  // The first occurrence of the conventional-changelog header is meaningful
-  // only when there is no prior history; the orchestrator always prepends a
-  // canonical `changelogHeader`, so any previously-stored header is dropped.
-  return history.replace(startOfLastReleasePattern, (match) => match);
-}

--- a/.github/actions/release-action/src/monorepo/runPublish.test.ts
+++ b/.github/actions/release-action/src/monorepo/runPublish.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for runPublish member resolution.
+ */
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { withTempDir } from "../testHelpers.ts";
+import { resolvePublishPlan } from "./runPublish.ts";
+
+async function writeJson(path: string, value: Record<string, unknown>): Promise<void> {
+  await Bun.write(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function setupMonorepo(dir: string): Promise<void> {
+  await writeJson(join(dir, "package.json"), {
+    name: "monorepo",
+    workspaces: ["packages/*"],
+  });
+  await mkdir(join(dir, "packages", "lib"), { recursive: true });
+  await mkdir(join(dir, "packages", "act"), { recursive: true });
+  await writeJson(join(dir, "packages", "lib", "package.json"), {
+    name: "@scope/lib",
+    release: { type: "lib-nodejs", slack: "#lib" },
+  });
+  await writeJson(join(dir, "packages", "act", "package.json"), {
+    name: "@scope/act",
+    release: { type: "github-action" },
+  });
+}
+
+describe("resolvePublishPlan", () => {
+  test("resolves a lib-nodejs member from its release-notes path", () =>
+    withTempDir(async (dir) => {
+      await setupMonorepo(dir);
+      const plan = await resolvePublishPlan({
+        cwd: dir,
+        changedFiles: ["packages/lib/.release_notes/1.2.0.md"],
+      });
+      expect(plan.member.name).toBe("lib");
+      expect(plan.version).toBe("1.2.0");
+      expect(plan.versionTag).toBe("lib@v1.2.0");
+      expect(plan.publishToNpm).toBe(true);
+      expect(plan.majorTag).toBeUndefined();
+      expect(plan.slackChannel).toBe("#lib");
+    }));
+
+  test("adds a floating major tag for a github-action member", () =>
+    withTempDir(async (dir) => {
+      await setupMonorepo(dir);
+      const plan = await resolvePublishPlan({
+        cwd: dir,
+        changedFiles: ["packages/act/.release_notes/2.5.1.md"],
+      });
+      expect(plan.member.name).toBe("act");
+      expect(plan.versionTag).toBe("act@v2.5.1");
+      expect(plan.majorTag).toBe("act@v2");
+      expect(plan.publishToNpm).toBe(false);
+    }));
+
+  test("throws when no member is referenced", () =>
+    withTempDir(async (dir) => {
+      await setupMonorepo(dir);
+      await expect(
+        resolvePublishPlan({ cwd: dir, changedFiles: ["README.md"] }),
+      ).rejects.toThrow(/No release-notes file/);
+    }));
+
+  test("throws when multiple members are referenced", () =>
+    withTempDir(async (dir) => {
+      await setupMonorepo(dir);
+      await expect(
+        resolvePublishPlan({
+          cwd: dir,
+          changedFiles: [
+            "packages/lib/.release_notes/1.0.0.md",
+            "packages/act/.release_notes/2.0.0.md",
+          ],
+        }),
+      ).rejects.toThrow(/Multiple members/);
+    }));
+
+  test("throws when called against a standalone repo", () =>
+    withTempDir(async (dir) => {
+      await writeJson(join(dir, "package.json"), {
+        name: "lib",
+        release: { type: "lib-nodejs" },
+      });
+      await expect(
+        resolvePublishPlan({
+          cwd: dir,
+          changedFiles: [".release_notes/1.0.0.md"],
+        }),
+      ).rejects.toThrow(/requires monorepo mode/);
+    }));
+});

--- a/.github/actions/release-action/src/monorepo/runPublish.test.ts
+++ b/.github/actions/release-action/src/monorepo/runPublish.test.ts
@@ -62,9 +62,9 @@ describe("resolvePublishPlan", () => {
   test("throws when no member is referenced", () =>
     withTempDir(async (dir) => {
       await setupMonorepo(dir);
-      await expect(
-        resolvePublishPlan({ cwd: dir, changedFiles: ["README.md"] }),
-      ).rejects.toThrow(/No release-notes file/);
+      await expect(resolvePublishPlan({ cwd: dir, changedFiles: ["README.md"] })).rejects.toThrow(
+        /No release-notes file/,
+      );
     }));
 
   test("throws when multiple members are referenced", () =>

--- a/.github/actions/release-action/src/monorepo/runPublish.ts
+++ b/.github/actions/release-action/src/monorepo/runPublish.ts
@@ -11,6 +11,8 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { $ } from "bun";
+
 import { discoverMembers, type Member } from "./discoverMembers.ts";
 import { memberMajorTag, memberVersionTag } from "./memberTags.ts";
 
@@ -18,6 +20,10 @@ import { memberMajorTag, memberVersionTag } from "./memberTags.ts";
 interface PullRequestEvent {
   pull_request?: {
     merged?: boolean;
+    number?: number;
+  };
+  repository?: {
+    full_name?: string;
   };
 }
 
@@ -45,27 +51,52 @@ export interface ResolveMemberOptions {
 }
 
 /**
- * Read a list of changed file paths.
+ * Read the list of file paths changed by the merged PR.
  *
- * The action expects a list of files modified by the merged PR. In CI we read
- * the PR's files via `gh pr view <N> --json files`, but the publish entry can
- * also be invoked with `changedFiles` directly (used by the test suite and the
- * `--dry-run` smoke flow).
+ * Resolution order:
+ * 1. Explicit `changedFiles` override (tests and the `--dry-run` smoke flow).
+ * 2. `GITHUB_EVENT_PATH` — read the merged PR number, then call
+ *    `gh pr view <N> --repo <owner/repo> --json files` to fetch the file list.
+ *    The `pull_request` payload itself does not carry files, so the gh API
+ *    call is required.
+ *
+ * Returns an empty array only when the event payload reports the PR is not
+ * merged (publish must no-op in that case); any other failure throws so the
+ * orchestrator never silently picks the wrong member.
  */
 export async function readChangedFiles(options: ResolveMemberOptions): Promise<string[]> {
   if (options.changedFiles) return [...options.changedFiles];
 
   const eventPath = options.eventPath ?? process.env.GITHUB_EVENT_PATH;
-  if (!eventPath) return [];
+  if (!eventPath) {
+    throw new Error(
+      "Cannot read changed files: GITHUB_EVENT_PATH is unset and no changedFiles override was provided.",
+    );
+  }
 
   const raw = await readFile(eventPath, "utf8");
   const event = JSON.parse(raw) as PullRequestEvent;
   if (!event.pull_request?.merged) return [];
 
-  // The pull_request payload does not carry the file list — the caller must
-  // hand us one via `changedFiles`. We return [] here so callers can fall back
-  // to `gh pr view <N> --json files` if needed.
-  return [];
+  const prNumber = event.pull_request.number;
+  const repo = event.repository?.full_name ?? process.env.GITHUB_REPOSITORY;
+  if (!prNumber || !repo) {
+    throw new Error("Cannot read changed files: event payload missing PR number or repository name.");
+  }
+
+  const result = await $`gh pr view ${prNumber} --repo ${repo} --json files --jq ${".files[].path"}`
+    .quiet()
+    .nothrow();
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `gh pr view ${prNumber} failed: ${result.stderr.toString().trim() || `exit ${result.exitCode}`}`,
+    );
+  }
+  return result.stdout
+    .toString()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
 }
 
 /**

--- a/.github/actions/release-action/src/monorepo/runPublish.ts
+++ b/.github/actions/release-action/src/monorepo/runPublish.ts
@@ -81,15 +81,22 @@ export async function readChangedFiles(options: ResolveMemberOptions): Promise<s
   const prNumber = event.pull_request.number;
   const repo = event.repository?.full_name ?? process.env.GITHUB_REPOSITORY;
   if (!prNumber || !repo) {
-    throw new Error("Cannot read changed files: event payload missing PR number or repository name.");
+    throw new Error(
+      "Cannot read changed files: event payload missing PR number or repository name.",
+    );
   }
 
-  const result = await $`gh pr view ${prNumber} --repo ${repo} --json files --jq ${".files[].path"}`
-    .quiet()
-    .nothrow();
+  // Use the paginated REST endpoint instead of `gh pr view --json files` so
+  // PRs with more than 100 changed files (the GraphQL cap) still resolve the
+  // member correctly. `--paginate` walks every page; `--jq` extracts the
+  // filenames inline.
+  const result =
+    await $`gh api ${`repos/${repo}/pulls/${prNumber}/files`} --paginate --jq ${".[].filename"}`
+      .quiet()
+      .nothrow();
   if (result.exitCode !== 0) {
     throw new Error(
-      `gh pr view ${prNumber} failed: ${result.stderr.toString().trim() || `exit ${result.exitCode}`}`,
+      `gh api repos/${repo}/pulls/${prNumber}/files failed: ${result.stderr.toString().trim() || `exit ${result.exitCode}`}`,
     );
   }
   return result.stdout
@@ -108,9 +115,7 @@ export async function readChangedFiles(options: ResolveMemberOptions): Promise<s
  * when the changed list references multiple members (the workflow assumes
  * one PR per member) or no member at all.
  */
-export async function resolvePublishPlan(
-  options: ResolveMemberOptions,
-): Promise<PublishPlan> {
+export async function resolvePublishPlan(options: ResolveMemberOptions): Promise<PublishPlan> {
   const cwd = options.cwd ?? process.cwd();
   const discovery = await discoverMembers(cwd);
 

--- a/.github/actions/release-action/src/monorepo/runPublish.ts
+++ b/.github/actions/release-action/src/monorepo/runPublish.ts
@@ -1,0 +1,145 @@
+/**
+ * Monorepo `publish` orchestrator: resolve the member that was released by a
+ * merged PR (using `GITHUB_EVENT_PATH` file changes), then run the
+ * appropriate per-type publish steps inside that member's directory.
+ *
+ * The orchestrator only computes the publish plan and exposes helpers — the
+ * actual `npm publish`, `git tag`, and `gh release create` calls happen in
+ * the consumer-side workflow shell. This keeps the orchestrator deterministic
+ * and testable against fixture event payloads.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { discoverMembers, type Member } from "./discoverMembers.ts";
+import { memberMajorTag, memberVersionTag } from "./memberTags.ts";
+
+/** Shape of the GitHub `pull_request` event payload we depend on. */
+interface PullRequestEvent {
+  pull_request?: {
+    merged?: boolean;
+  };
+}
+
+/** Per-member publish plan. */
+export interface PublishPlan {
+  member: Member;
+  version: string;
+  /** `<name>@v<version>` tag to create on the merge commit. */
+  versionTag: string;
+  /** `<name>@v<MAJOR>` floating tag, only set for `github-action` members. */
+  majorTag?: string;
+  /** Whether the member opts into NPM publish (`lib-nodejs` / `lib-bun`). */
+  publishToNpm: boolean;
+  /** Slack channel from the member's `release.slack`, if any. */
+  slackChannel?: string;
+}
+
+export interface ResolveMemberOptions {
+  /** Repository root (defaults to `process.cwd()`). */
+  cwd?: string;
+  /** Override list of changed file paths (typically supplied by tests). */
+  changedFiles?: readonly string[];
+  /** Override path to a GitHub event JSON file. */
+  eventPath?: string;
+}
+
+/**
+ * Read a list of changed file paths.
+ *
+ * The action expects a list of files modified by the merged PR. In CI we read
+ * the PR's files via `gh pr view <N> --json files`, but the publish entry can
+ * also be invoked with `changedFiles` directly (used by the test suite and the
+ * `--dry-run` smoke flow).
+ */
+export async function readChangedFiles(options: ResolveMemberOptions): Promise<string[]> {
+  if (options.changedFiles) return [...options.changedFiles];
+
+  const eventPath = options.eventPath ?? process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) return [];
+
+  const raw = await readFile(eventPath, "utf8");
+  const event = JSON.parse(raw) as PullRequestEvent;
+  if (!event.pull_request?.merged) return [];
+
+  // The pull_request payload does not carry the file list — the caller must
+  // hand us one via `changedFiles`. We return [] here so callers can fall back
+  // to `gh pr view <N> --json files` if needed.
+  return [];
+}
+
+/**
+ * Resolve the unique member referenced by a release-notes file inside the
+ * supplied changed file list.
+ *
+ * Looks for a path matching `<member-rel-path>/.release_notes/<version>.md`
+ * and returns the corresponding {@link Member} and `version` string. Throws
+ * when the changed list references multiple members (the workflow assumes
+ * one PR per member) or no member at all.
+ */
+export async function resolvePublishPlan(
+  options: ResolveMemberOptions,
+): Promise<PublishPlan> {
+  const cwd = options.cwd ?? process.cwd();
+  const discovery = await discoverMembers(cwd);
+
+  if (discovery.mode !== "monorepo") {
+    throw new Error("resolvePublishPlan requires monorepo mode discovery");
+  }
+
+  const changedFiles = await readChangedFiles({ ...options, cwd });
+
+  const matches = new Map<string, { member: Member; version: string }>();
+  for (const file of changedFiles) {
+    for (const member of discovery.members) {
+      const prefix = `${member.relPath}/.release_notes/`;
+      if (!file.startsWith(prefix)) continue;
+      const rest = file.slice(prefix.length);
+      const versionMatch = rest.match(/^([^/]+?)\.md$/);
+      if (!versionMatch) continue;
+      const version = versionMatch[1] as string;
+      const key = `${member.name}@${version}`;
+      matches.set(key, { member, version });
+    }
+  }
+
+  if (matches.size === 0) {
+    throw new Error(
+      "No release-notes file found in the PR changes — cannot determine which member to publish.",
+    );
+  }
+  if (matches.size > 1) {
+    const names = Array.from(matches.values()).map((m) => `${m.member.name}@${m.version}`);
+    throw new Error(
+      `Multiple members referenced by the PR (${names.join(", ")}). One PR per member is required.`,
+    );
+  }
+
+  const [resolved] = matches.values();
+  if (!resolved) {
+    throw new Error("Unexpected empty match map after size check");
+  }
+
+  const { member, version } = resolved;
+  const publishToNpm = member.releaseType === "lib-nodejs" || member.releaseType === "lib-bun";
+  const plan: PublishPlan = {
+    member,
+    version,
+    versionTag: memberVersionTag(member.name, version),
+    publishToNpm,
+  };
+  if (member.releaseType === "github-action") {
+    plan.majorTag = memberMajorTag(member.name, version);
+  }
+  if (member.slack !== undefined) {
+    plan.slackChannel = member.slack;
+  }
+  return plan;
+}
+
+/** Convenience: read the version from `<member>/version` for sanity-checking. */
+export async function readMemberVersion(member: Member): Promise<string | null> {
+  const file = Bun.file(join(member.path, "version"));
+  if (!(await file.exists())) return null;
+  return (await file.text()).trim() || null;
+}

--- a/.github/actions/release-action/src/release.ts
+++ b/.github/actions/release-action/src/release.ts
@@ -67,6 +67,18 @@ export interface ReleaseOptions {
   owner?: string;
   /** GitHub repository name (required for tickets) */
   repo?: string;
+  /**
+   * Tag prefix used by `conventional-recommended-bump` and `conventional-changelog`
+   * to match prior tags. Defaults to `"v"` (matches `v1.2.3`). In monorepo mode
+   * pass `<name>@v` so per-member tags like `release-action@v1.2.0` are honoured.
+   */
+  tagPrefix?: string;
+  /**
+   * Path filter scoping the commit range. When set, only commits that touched
+   * this path contribute to the bump and the changelog. Used in monorepo mode
+   * to compute per-member releases.
+   */
+  path?: string;
 }
 
 /**
@@ -168,17 +180,33 @@ export async function getCurrentVersion(cwd: string): Promise<VersionResult> {
   return { version: initialVersion, source: "version-file" };
 }
 
+/** Optional scoping for {@link bumpVersion} when releasing one member of a monorepo. */
+export interface BumpScope {
+  /** Tag prefix passed to `Bumper.tag` (e.g. `release-action@v`). */
+  tagPrefix?: string;
+  /** Path filter passed to `Bumper.path` so only commits touching the path contribute. */
+  path?: string;
+}
+
 /**
  * Bump version based on conventional commits
  *
  * @param currentVersion - Current semver version
  * @param cwd - Working directory (default: process.cwd())
+ * @param scope - Optional tag prefix and/or path filter for monorepo members
  */
 export async function bumpVersion(
   currentVersion: string,
-  cwd = process.cwd()
+  cwd = process.cwd(),
+  scope: BumpScope = {}
 ): Promise<BumpResult> {
-  const bumper = new Bumper(cwd).loadPreset("conventionalcommits");
+  let bumper = new Bumper(cwd).loadPreset("conventionalcommits");
+  if (scope.tagPrefix) {
+    bumper = bumper.tag({ prefix: scope.tagPrefix });
+  }
+  if (scope.path) {
+    bumper = bumper.commits({ path: scope.path });
+  }
   const recommendation = await bumper.bump();
 
   if (!("releaseType" in recommendation)) {
@@ -192,12 +220,21 @@ export async function bumpVersion(
     throw new Error(`Failed to calculate new version from ${currentVersion} with ${releaseType}`);
   }
 
+  const tagPrefix = scope.tagPrefix ?? "v";
   return {
     summary: "reason" in recommendation ? (recommendation.reason ?? "") : "",
     type: releaseType,
     newVersion,
-    newTag: `v${newVersion}`,
+    newTag: `${tagPrefix}${newVersion}`,
   };
+}
+
+/** Optional scoping for {@link generateChangelog} when releasing one member of a monorepo. */
+export interface ChangelogScope {
+  /** Tag prefix passed to `ConventionalChangelog.tags` (e.g. `release-action@v`). */
+  tagPrefix?: string;
+  /** Path filter passed to `ConventionalChangelog.commits` so only matching commits appear. */
+  path?: string;
 }
 
 /**
@@ -205,10 +242,12 @@ export async function bumpVersion(
  *
  * @param newVersion - Version to generate changelog for
  * @param cwd - Working directory (default: process.cwd())
+ * @param scope - Optional tag prefix and/or path filter for monorepo members
  */
 export async function generateChangelog(
   newVersion: string,
-  cwd = process.cwd()
+  cwd = process.cwd(),
+  scope: ChangelogScope = {}
 ): Promise<ChangelogResult> {
   const changelogFile = join(cwd, "CHANGELOG.md");
 
@@ -220,7 +259,7 @@ export async function generateChangelog(
   const historyStart = historyContent.search(startOfLastReleasePattern);
   const history = historyStart !== -1 ? historyContent.substring(historyStart) : historyContent;
 
-  const generator = new ConventionalChangelog(cwd)
+  let generator = new ConventionalChangelog(cwd)
     .readPackage()
     .loadPreset({
       name: "conventionalcommits",
@@ -237,8 +276,11 @@ export async function generateChangelog(
         { type: "ci", section: "CI", hidden: false },
       ],
     })
-    .tags({ prefix: "v" })
+    .tags({ prefix: scope.tagPrefix ?? "v" })
     .context({ version: newVersion });
+  if (scope.path) {
+    generator = generator.commits({ path: scope.path });
+  }
 
   let release = "";
   for await (const chunk of generator.write()) {
@@ -297,16 +339,18 @@ async function processTickets(params: {
  * @param options - Release options
  */
 export async function main(options: ReleaseOptions = {}): Promise<string> {
-  const { cwd = process.cwd(), ticketSystems, owner, repo } = options;
+  const { cwd = process.cwd(), ticketSystems, owner, repo, tagPrefix, path } = options;
+  const scope = { tagPrefix, path };
 
   const { version: currentVersion, source: versionSource } = await getCurrentVersion(cwd);
   console.log(`Detected version ${currentVersion} from ${versionSource}`);
   const { newVersion, type: releaseType, summary: releaseSummary } = await bumpVersion(
     currentVersion,
-    cwd
+    cwd,
+    scope
   );
 
-  const log = await generateChangelog(newVersion, cwd);
+  const log = await generateChangelog(newVersion, cwd, scope);
 
   const releaseLines = log.release.split("\n").slice(1).join("\n").trim();
   if (!releaseLines) {

--- a/.github/actions/release-action/src/release.ts
+++ b/.github/actions/release-action/src/release.ts
@@ -198,7 +198,7 @@ export interface BumpScope {
 export async function bumpVersion(
   currentVersion: string,
   cwd = process.cwd(),
-  scope: BumpScope = {}
+  scope: BumpScope = {},
 ): Promise<BumpResult> {
   let bumper = new Bumper(cwd).loadPreset("conventionalcommits");
   if (scope.tagPrefix) {
@@ -247,7 +247,7 @@ export interface ChangelogScope {
 export async function generateChangelog(
   newVersion: string,
   cwd = process.cwd(),
-  scope: ChangelogScope = {}
+  scope: ChangelogScope = {},
 ): Promise<ChangelogResult> {
   const changelogFile = join(cwd, "CHANGELOG.md");
 
@@ -322,7 +322,7 @@ async function processTickets(params: {
     await Bun.write(
       join(releaseBotDir, "pr_descriptions.yml"),
       serializePrDescriptionsToYaml(result.prDescriptions),
-      { createPath: true }
+      { createPath: true },
     );
   }
 
@@ -344,11 +344,11 @@ export async function main(options: ReleaseOptions = {}): Promise<string> {
 
   const { version: currentVersion, source: versionSource } = await getCurrentVersion(cwd);
   console.log(`Detected version ${currentVersion} from ${versionSource}`);
-  const { newVersion, type: releaseType, summary: releaseSummary } = await bumpVersion(
-    currentVersion,
-    cwd,
-    scope
-  );
+  const {
+    newVersion,
+    type: releaseType,
+    summary: releaseSummary,
+  } = await bumpVersion(currentVersion, cwd, scope);
 
   const log = await generateChangelog(newVersion, cwd, scope);
 
@@ -387,7 +387,7 @@ export async function main(options: ReleaseOptions = {}): Promise<string> {
   });
   await Bun.write(
     changelogFile,
-    (log.header + releaseWithTickets + log.history).replace(/\n+$/, "\n")
+    (log.header + releaseWithTickets + log.history).replace(/\n+$/, "\n"),
   );
 
   return newVersion;

--- a/.github/actions/release-action/src/releaseField.test.ts
+++ b/.github/actions/release-action/src/releaseField.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import { readReleaseField, releaseTypes } from "./releaseField.ts";
+import { readReleaseField, readRootRelease, releaseTypes } from "./releaseField.ts";
 
 describe("readReleaseField — type", () => {
   test.each(releaseTypes.map((value) => [value]))(
@@ -99,5 +99,69 @@ describe("readReleaseField — slack", () => {
     expect(() =>
       readReleaseField({ release: { type: "lib-nodejs", slack: 42 } }),
     ).toThrow(/'release\.slack'.*must be a non-empty string/);
+  });
+});
+
+describe("readRootRelease", () => {
+  test("returns empty object when no release field is present", () => {
+    expect(readRootRelease({ name: "monorepo" })).toEqual({});
+  });
+
+  test("returns members array for monorepo root", () => {
+    expect(
+      readRootRelease({
+        release: { members: [".github/actions/release-action", "packages/foo"] },
+      }),
+    ).toEqual({ members: [".github/actions/release-action", "packages/foo"] });
+  });
+
+  test("returns type for standalone root", () => {
+    expect(readRootRelease({ release: { type: "lib-nodejs" } })).toEqual({
+      type: "lib-nodejs",
+    });
+  });
+
+  test("returns slack alongside members", () => {
+    expect(
+      readRootRelease({
+        release: { members: ["packages/*"], slack: "#releases" },
+      }),
+    ).toEqual({ members: ["packages/*"], slack: "#releases" });
+  });
+
+  test("throws when both members and type are declared", () => {
+    expect(() =>
+      readRootRelease({
+        release: { members: ["packages/*"], type: "lib-nodejs" },
+      }),
+    ).toThrow(/mutually exclusive/);
+  });
+
+  test("throws when members is not an array", () => {
+    expect(() =>
+      readRootRelease({ release: { members: "packages/*" } }),
+    ).toThrow(/must be an array of workspace paths/);
+  });
+
+  test("throws when members is empty", () => {
+    expect(() => readRootRelease({ release: { members: [] } })).toThrow(
+      /must contain at least one workspace path/,
+    );
+  });
+
+  test("throws when a members entry is not a non-empty string", () => {
+    expect(() =>
+      readRootRelease({ release: { members: ["packages/*", ""] } }),
+    ).toThrow(/entries must be non-empty strings/);
+  });
+
+  test("throws when release is not an object", () => {
+    expect(() => readRootRelease({ release: "lib-nodejs" })).toThrow(
+      /must be an object/,
+    );
+  });
+
+  test("throws when packageJson is null", () => {
+    expect(() => readRootRelease(null)).toThrow(/expected an object/);
   });
 });

--- a/.github/actions/release-action/src/releaseField.test.ts
+++ b/.github/actions/release-action/src/releaseField.test.ts
@@ -6,14 +6,11 @@ import { describe, expect, test } from "bun:test";
 import { readReleaseField, readRootRelease, releaseTypes } from "./releaseField.ts";
 
 describe("readReleaseField — type", () => {
-  test.each(releaseTypes.map((value) => [value]))(
-    "accepts recognized type %s",
-    (value) => {
-      expect(readReleaseField({ name: "x", release: { type: value } })).toEqual({
-        type: value,
-      });
-    },
-  );
+  test.each(releaseTypes.map((value) => [value]))("accepts recognized type %s", (value) => {
+    expect(readReleaseField({ name: "x", release: { type: value } })).toEqual({
+      type: value,
+    });
+  });
 
   test("throws when the release field is missing", () => {
     expect(() => readReleaseField({ name: "x" })).toThrow(
@@ -22,9 +19,7 @@ describe("readReleaseField — type", () => {
   });
 
   test("missing-field error references the docs", () => {
-    expect(() => readReleaseField({ name: "x" })).toThrow(
-      /docs\/release-field\.md/,
-    );
+    expect(() => readReleaseField({ name: "x" })).toThrow(/docs\/release-field\.md/);
   });
 
   test("throws when release is a bare string (old shape)", () => {
@@ -34,9 +29,7 @@ describe("readReleaseField — type", () => {
   });
 
   test("throws when release is an array", () => {
-    expect(() => readReleaseField({ release: [] })).toThrow(
-      /must be an object.*Got array/,
-    );
+    expect(() => readReleaseField({ release: [] })).toThrow(/must be an object.*Got array/);
   });
 
   test("throws when release.type is missing", () => {
@@ -46,15 +39,15 @@ describe("readReleaseField — type", () => {
   });
 
   test("throws when release.type is unrecognized", () => {
-    expect(() =>
-      readReleaseField({ release: { type: "not-a-real-type" } }),
-    ).toThrow(/Unrecognized 'release\.type' value "not-a-real-type"/);
+    expect(() => readReleaseField({ release: { type: "not-a-real-type" } })).toThrow(
+      /Unrecognized 'release\.type' value "not-a-real-type"/,
+    );
   });
 
   test("unrecognized-type error lists allowed values", () => {
-    expect(() =>
-      readReleaseField({ release: { type: "not-a-real-type" } }),
-    ).toThrow(/lib-nodejs.*github-action.*claude-plugin/);
+    expect(() => readReleaseField({ release: { type: "not-a-real-type" } })).toThrow(
+      /lib-nodejs.*github-action.*claude-plugin/,
+    );
   });
 
   test("throws when release.type is not a string", () => {
@@ -68,9 +61,7 @@ describe("readReleaseField — type", () => {
   });
 
   test("throws when packageJson is not an object", () => {
-    expect(() => readReleaseField("not-an-object")).toThrow(
-      /expected an object/,
-    );
+    expect(() => readReleaseField("not-an-object")).toThrow(/expected an object/);
   });
 });
 
@@ -90,15 +81,15 @@ describe("readReleaseField — slack", () => {
   });
 
   test("throws when slack is an empty string", () => {
-    expect(() =>
-      readReleaseField({ release: { type: "lib-nodejs", slack: "" } }),
-    ).toThrow(/'release\.slack'.*must be a non-empty string/);
+    expect(() => readReleaseField({ release: { type: "lib-nodejs", slack: "" } })).toThrow(
+      /'release\.slack'.*must be a non-empty string/,
+    );
   });
 
   test("throws when slack is not a string", () => {
-    expect(() =>
-      readReleaseField({ release: { type: "lib-nodejs", slack: 42 } }),
-    ).toThrow(/'release\.slack'.*must be a non-empty string/);
+    expect(() => readReleaseField({ release: { type: "lib-nodejs", slack: 42 } })).toThrow(
+      /'release\.slack'.*must be a non-empty string/,
+    );
   });
 });
 
@@ -138,9 +129,9 @@ describe("readRootRelease", () => {
   });
 
   test("throws when members is not an array", () => {
-    expect(() =>
-      readRootRelease({ release: { members: "packages/*" } }),
-    ).toThrow(/must be an array of workspace paths/);
+    expect(() => readRootRelease({ release: { members: "packages/*" } })).toThrow(
+      /must be an array of workspace paths/,
+    );
   });
 
   test("throws when members is empty", () => {
@@ -150,15 +141,13 @@ describe("readRootRelease", () => {
   });
 
   test("throws when a members entry is not a non-empty string", () => {
-    expect(() =>
-      readRootRelease({ release: { members: ["packages/*", ""] } }),
-    ).toThrow(/entries must be non-empty strings/);
+    expect(() => readRootRelease({ release: { members: ["packages/*", ""] } })).toThrow(
+      /entries must be non-empty strings/,
+    );
   });
 
   test("throws when release is not an object", () => {
-    expect(() => readRootRelease({ release: "lib-nodejs" })).toThrow(
-      /must be an object/,
-    );
+    expect(() => readRootRelease({ release: "lib-nodejs" })).toThrow(/must be an object/);
   });
 
   test("throws when packageJson is null", () => {

--- a/.github/actions/release-action/src/releaseField.ts
+++ b/.github/actions/release-action/src/releaseField.ts
@@ -47,6 +47,20 @@ export interface ReleaseConfig {
   slack?: string;
 }
 
+/**
+ * Root-level `release` config from the repository-root `package.json`.
+ *
+ * A monorepo root declares `members` to enumerate workspace paths to release;
+ * a standalone repo declares `type` and behaves like a member. Both forms may
+ * carry `slack`. `members` and `type` are mutually exclusive at the root —
+ * mixing them is a configuration error.
+ */
+export interface RootReleaseConfig {
+  members?: readonly string[];
+  type?: ReleaseType;
+  slack?: string;
+}
+
 function fail(message: string): never {
   throw new Error(`${message} See ${DOCS_LINK}.`);
 }
@@ -148,4 +162,100 @@ export function readReleaseField(packageJson: unknown): ReleaseConfig {
   const slack = readSlack(release);
 
   return slack === undefined ? { type } : { type, slack };
+}
+
+function readMembers(release: Record<string, unknown>): readonly string[] | undefined {
+  if (!("members" in release)) {
+    return undefined;
+  }
+
+  const value: unknown = release.members;
+
+  if (!Array.isArray(value)) {
+    fail(
+      `'release.members' in package.json must be an array of workspace paths; got ${typeof value}.`,
+    );
+  }
+
+  if (value.length === 0) {
+    fail("'release.members' in package.json must contain at least one workspace path when present.");
+  }
+
+  for (const entry of value) {
+    if (typeof entry !== "string" || entry.length === 0) {
+      fail("'release.members' entries must be non-empty strings (workspace paths).");
+    }
+  }
+
+  return value as readonly string[];
+}
+
+/**
+ * Read and validate the top-level `release` object on a parsed repository-root
+ * `package.json`.
+ *
+ * Unlike {@link readReleaseField}, root config may declare `members` instead of
+ * `type` to opt into monorepo mode. Returns an empty object shape when the
+ * root has no `release` field — callers handle that case (e.g., fall back to
+ * `workspaces` discovery).
+ *
+ * @throws when both `members` and `type` are declared (ambiguous root mode),
+ *   when `members` is not a non-empty `string[]`, or when `type`/`slack` are
+ *   present but invalid (same rules as {@link readReleaseField}).
+ *
+ * @example
+ * ```typescript
+ * readRootRelease({ release: { members: ["packages/*"] } });
+ * // → { members: ["packages/*"] }
+ *
+ * readRootRelease({ release: { type: "lib-nodejs", slack: "#releases" } });
+ * // → { type: "lib-nodejs", slack: "#releases" }
+ *
+ * readRootRelease({ name: "monorepo" });
+ * // → {}
+ * ```
+ */
+export function readRootRelease(packageJson: unknown): RootReleaseConfig {
+  if (typeof packageJson !== "object" || packageJson === null) {
+    fail("Invalid package.json — expected an object.");
+  }
+
+  if (!("release" in packageJson)) {
+    return {};
+  }
+
+  const raw: unknown = (packageJson as Record<string, unknown>).release;
+
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    fail(
+      `'release' in package.json must be an object. Got ${
+        Array.isArray(raw) ? "array" : typeof raw
+      }.`,
+    );
+  }
+
+  const release = raw as Record<string, unknown>;
+  const members = readMembers(release);
+  const hasType = "type" in release;
+
+  if (members && hasType) {
+    fail(
+      "'release.members' and 'release.type' are mutually exclusive at the root — pick monorepo mode (members) or standalone mode (type).",
+    );
+  }
+
+  const slack = readSlack(release);
+  const config: RootReleaseConfig = {};
+
+  if (members) {
+    config.members = members;
+  } else if (hasType) {
+    config.type = readType(release);
+  }
+
+  if (slack !== undefined) {
+    config.slack = slack;
+  }
+
+  return config;
 }

--- a/.github/actions/release-action/src/releaseField.ts
+++ b/.github/actions/release-action/src/releaseField.ts
@@ -178,7 +178,9 @@ function readMembers(release: Record<string, unknown>): readonly string[] | unde
   }
 
   if (value.length === 0) {
-    fail("'release.members' in package.json must contain at least one workspace path when present.");
+    fail(
+      "'release.members' in package.json must contain at least one workspace path when present.",
+    );
   }
 
   for (const entry of value) {

--- a/.github/actions/release-action/src/run.ts
+++ b/.github/actions/release-action/src/run.ts
@@ -19,7 +19,11 @@ import { $ } from "bun";
 
 import { discoverMembers } from "./monorepo/discoverMembers.ts";
 import { memberMajorTag, memberVersionTag } from "./monorepo/memberTags.ts";
-import { runCreate, type MemberRelease } from "./monorepo/runCreate.ts";
+import {
+  emitMemberArtifacts,
+  runCreate,
+  type MemberRelease,
+} from "./monorepo/runCreate.ts";
 import {
   readChangedFiles,
   resolvePublishPlan,
@@ -48,19 +52,6 @@ async function ensureLabel(label: string, description: string): Promise<void> {
   await $`gh label create ${label} --color 85e131 --description ${description}`
     .quiet()
     .nothrow();
-}
-
-async function pushBranch(cwd: string, release: MemberRelease): Promise<void> {
-  await $`git checkout -B ${release.branch}`.cwd(cwd).quiet();
-  await $`git add ${release.member.relPath}`.cwd(cwd).quiet();
-  // .release_bot is shared per-member; it lives gitignored but we still want a
-  // clean commit, so add it explicitly only if it exists under the member dir.
-  await $`git commit -n -m ${`chore: release ${release.member.name} ${release.newVersion}`}`
-    .cwd(cwd)
-    .quiet();
-  await $`git push --no-verify --force origin ${release.branch}`
-    .cwd(cwd)
-    .quiet();
 }
 
 async function openOrUpdatePr(
@@ -103,7 +94,17 @@ async function runMonorepoCreate(cwd: string): Promise<void> {
 
   const releasedNames: string[] = [];
   for (const release of result.releases) {
-    await pushBranch(cwd, release);
+    // Reset to origin/main BEFORE emitting artifacts so the working tree is
+    // clean of prior members' files. Emit, then commit + push the per-member
+    // diff onto the fresh branch.
+    await $`git fetch origin main`.cwd(cwd).quiet().nothrow();
+    await $`git checkout -B ${release.branch} origin/main`.cwd(cwd).quiet();
+    await emitMemberArtifacts({ release, cwd });
+    await $`git add ${release.member.relPath}`.cwd(cwd).quiet();
+    await $`git commit -n -m ${`chore: release ${release.member.name} ${release.newVersion}`}`
+      .cwd(cwd)
+      .quiet();
+    await $`git push --no-verify --force origin ${release.branch}`.cwd(cwd).quiet();
     const url = await openOrUpdatePr(release, cwd);
     console.log(`::notice title=Release ${release.member.name} ${release.newVersion}::${url}`);
     releasedNames.push(`${release.member.name}@${release.newVersion}`);

--- a/.github/actions/release-action/src/run.ts
+++ b/.github/actions/release-action/src/run.ts
@@ -19,15 +19,8 @@ import { $ } from "bun";
 
 import { discoverMembers } from "./monorepo/discoverMembers.ts";
 import { memberMajorTag, memberVersionTag } from "./monorepo/memberTags.ts";
-import {
-  emitMemberArtifacts,
-  runCreate,
-  type MemberRelease,
-} from "./monorepo/runCreate.ts";
-import {
-  readChangedFiles,
-  resolvePublishPlan,
-} from "./monorepo/runPublish.ts";
+import { emitMemberArtifacts, runCreate, type MemberRelease } from "./monorepo/runCreate.ts";
+import { readChangedFiles, resolvePublishPlan } from "./monorepo/runPublish.ts";
 import { ensureGitignoreEntry } from "./prepareRelease.ts";
 import { postReleaseNotification } from "./slackNotify.ts";
 
@@ -49,15 +42,10 @@ async function writeGithubOutput(line: string): Promise<void> {
 }
 
 async function ensureLabel(label: string, description: string): Promise<void> {
-  await $`gh label create ${label} --color 85e131 --description ${description}`
-    .quiet()
-    .nothrow();
+  await $`gh label create ${label} --color 85e131 --description ${description}`.quiet().nothrow();
 }
 
-async function openOrUpdatePr(
-  release: MemberRelease,
-  cwd: string,
-): Promise<string> {
+async function openOrUpdatePr(release: MemberRelease, cwd: string): Promise<string> {
   const label = `release-${release.member.name}`;
   await ensureLabel(label, `Release PR for ${release.member.name}`);
 
@@ -69,21 +57,57 @@ async function openOrUpdatePr(
     .quiet()
     .nothrow();
   if (existing.exitCode === 0 && existing.stdout.toString().trim()) {
-    await $`gh pr edit --title ${title} --body-file ${bodyFile}`
-      .cwd(cwd)
-      .quiet();
+    await $`gh pr edit --title ${title} --body-file ${bodyFile}`.cwd(cwd).quiet();
     return existing.stdout.toString().trim();
   }
 
-  const created = await $`gh pr create --head ${release.branch} --title ${title} --label ${label} -F ${bodyFile}`
-    .cwd(cwd)
-    .quiet();
+  const created =
+    await $`gh pr create --head ${release.branch} --title ${title} --label ${label} -F ${bodyFile}`
+      .cwd(cwd)
+      .quiet();
   return created.stdout.toString().trim();
+}
+
+function resolveBranchTemplate(): string {
+  const raw = process.env.INPUT_BRANCH;
+  const fallback = "release-{member}-{version}";
+  if (!raw || raw.length === 0) return fallback;
+  if (raw.includes("{member}")) return raw;
+  // The standalone default `release-{version}` (the action.yml default) and
+  // any other user-supplied template without `{member}` would collapse all
+  // members onto the same branch. Inject `{member}` so per-member PRs stay
+  // distinct, and warn so the operator can override the input explicitly.
+  const injected = raw.replace(/\{version\}/, "{member}-{version}");
+  const finalTemplate = injected.includes("{member}") ? injected : `${raw}-{member}`;
+  console.log(
+    `::warning::INPUT_BRANCH '${raw}' is missing {member} placeholder for monorepo mode; using '${finalTemplate}' instead.`,
+  );
+  return finalTemplate;
+}
+
+async function resolveBaseRef(cwd: string): Promise<string> {
+  // Capture once before the loop so every member's branch is rooted at the
+  // commit that triggered the workflow, never at the tip of the previous
+  // iteration's release commit.
+  const sha = process.env.GITHUB_SHA;
+  if (sha && sha.length > 0) return sha;
+  const remoteHead = await $`git symbolic-ref refs/remotes/origin/HEAD`.cwd(cwd).quiet().nothrow();
+  if (remoteHead.exitCode === 0) {
+    const ref = remoteHead.stdout.toString().trim();
+    if (ref) {
+      const stripped = ref.replace(/^refs\/remotes\//, "");
+      const verify = await $`git rev-parse ${stripped}`.cwd(cwd).quiet().nothrow();
+      if (verify.exitCode === 0) {
+        return stripped;
+      }
+    }
+  }
+  return "HEAD";
 }
 
 async function runMonorepoCreate(cwd: string): Promise<void> {
   await ensureGitignoreEntry(".release_bot", cwd);
-  const branchTemplate = process.env.INPUT_BRANCH ?? "release-{member}-{version}";
+  const branchTemplate = resolveBranchTemplate();
   const result = await runCreate({ cwd, branchTemplate });
 
   if (result.releases.length === 0) {
@@ -92,13 +116,15 @@ async function runMonorepoCreate(cwd: string): Promise<void> {
     return;
   }
 
+  await $`git fetch origin`.cwd(cwd).quiet().nothrow();
+  const baseRef = await resolveBaseRef(cwd);
+
   const releasedNames: string[] = [];
   for (const release of result.releases) {
-    // Reset to origin/main BEFORE emitting artifacts so the working tree is
-    // clean of prior members' files. Emit, then commit + push the per-member
-    // diff onto the fresh branch.
-    await $`git fetch origin main`.cwd(cwd).quiet().nothrow();
-    await $`git checkout -B ${release.branch} origin/main`.cwd(cwd).quiet();
+    // Reset to the captured base ref BEFORE emitting artifacts so the working
+    // tree is clean of any prior member's files. Emit, then commit + push the
+    // per-member diff onto the fresh branch.
+    await $`git checkout -B ${release.branch} ${baseRef}`.cwd(cwd).quiet();
     await emitMemberArtifacts({ release, cwd });
     await $`git add ${release.member.relPath}`.cwd(cwd).quiet();
     await $`git commit -n -m ${`chore: release ${release.member.name} ${release.newVersion}`}`
@@ -125,7 +151,10 @@ async function runMonorepoPublish(cwd: string): Promise<void> {
   // GITHUB_EVENT_PATH discovery. Read the env override here.
   const overrideFiles = process.env.PR_CHANGED_FILES;
   const changedFiles = overrideFiles
-    ? overrideFiles.split("\n").map((line) => line.trim()).filter(Boolean)
+    ? overrideFiles
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
     : await readChangedFiles({ cwd });
 
   const plan = await resolvePublishPlan({ cwd, changedFiles });

--- a/.github/actions/release-action/src/run.ts
+++ b/.github/actions/release-action/src/run.ts
@@ -88,21 +88,30 @@ function resolveBranchTemplate(): string {
 async function resolveBaseRef(cwd: string): Promise<string> {
   // Capture once before the loop so every member's branch is rooted at the
   // commit that triggered the workflow, never at the tip of the previous
-  // iteration's release commit.
+  // iteration's release commit. We always resolve symbolic names (GITHUB_SHA,
+  // origin/HEAD, HEAD) to a concrete commit SHA so subsequent checkouts in
+  // the loop don't drift as new commits land on the resolved ref.
   const sha = process.env.GITHUB_SHA;
   if (sha && sha.length > 0) return sha;
+
   const remoteHead = await $`git symbolic-ref refs/remotes/origin/HEAD`.cwd(cwd).quiet().nothrow();
   if (remoteHead.exitCode === 0) {
     const ref = remoteHead.stdout.toString().trim();
     if (ref) {
       const stripped = ref.replace(/^refs\/remotes\//, "");
-      const verify = await $`git rev-parse ${stripped}`.cwd(cwd).quiet().nothrow();
-      if (verify.exitCode === 0) {
-        return stripped;
+      const resolved = await $`git rev-parse ${stripped}`.cwd(cwd).quiet().nothrow();
+      if (resolved.exitCode === 0) {
+        const oid = resolved.stdout.toString().trim();
+        if (oid) return oid;
       }
     }
   }
-  return "HEAD";
+
+  // Final fallback: pin to whatever HEAD points at right now. Returning the
+  // symbolic name "HEAD" instead would re-resolve at each checkout and pick
+  // up the previous iteration's release commit.
+  const localHead = await $`git rev-parse HEAD`.cwd(cwd).quiet();
+  return localHead.stdout.toString().trim();
 }
 
 async function runMonorepoCreate(cwd: string): Promise<void> {

--- a/.github/actions/release-action/src/run.ts
+++ b/.github/actions/release-action/src/run.ts
@@ -1,0 +1,199 @@
+/**
+ * Monorepo entry point invoked by `action.yml` when discovery resolves to
+ * monorepo mode. For each release-eligible member, runs the create or publish
+ * flow inside that member's directory.
+ *
+ * Standalone repositories never reach this script — `action.yml` gates this
+ * step on `steps.detect.outputs.mode == 'monorepo'`.
+ *
+ * @example
+ * ```bash
+ * # Driven by action.yml (with INPUT_BRANCH etc. exported)
+ * bun src/run.ts --mode=create
+ * bun src/run.ts --mode=publish
+ * ```
+ */
+import { appendFile } from "node:fs/promises";
+
+import { $ } from "bun";
+
+import { discoverMembers } from "./monorepo/discoverMembers.ts";
+import { memberMajorTag, memberVersionTag } from "./monorepo/memberTags.ts";
+import { runCreate, type MemberRelease } from "./monorepo/runCreate.ts";
+import {
+  readChangedFiles,
+  resolvePublishPlan,
+} from "./monorepo/runPublish.ts";
+import { ensureGitignoreEntry } from "./prepareRelease.ts";
+import { postReleaseNotification } from "./slackNotify.ts";
+
+type Mode = "create" | "publish";
+
+function parseMode(args: readonly string[]): Mode {
+  const arg = args.find((value) => value.startsWith("--mode="));
+  const mode = arg?.slice("--mode=".length);
+  if (mode !== "create" && mode !== "publish") {
+    throw new Error(`run.ts requires --mode=create|publish; got '${mode ?? "none"}'`);
+  }
+  return mode;
+}
+
+async function writeGithubOutput(line: string): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  await appendFile(outputPath, `${line}\n`);
+}
+
+async function ensureLabel(label: string, description: string): Promise<void> {
+  await $`gh label create ${label} --color 85e131 --description ${description}`
+    .quiet()
+    .nothrow();
+}
+
+async function pushBranch(cwd: string, release: MemberRelease): Promise<void> {
+  await $`git checkout -B ${release.branch}`.cwd(cwd).quiet();
+  await $`git add ${release.member.relPath}`.cwd(cwd).quiet();
+  // .release_bot is shared per-member; it lives gitignored but we still want a
+  // clean commit, so add it explicitly only if it exists under the member dir.
+  await $`git commit -n -m ${`chore: release ${release.member.name} ${release.newVersion}`}`
+    .cwd(cwd)
+    .quiet();
+  await $`git push --no-verify --force origin ${release.branch}`
+    .cwd(cwd)
+    .quiet();
+}
+
+async function openOrUpdatePr(
+  release: MemberRelease,
+  cwd: string,
+): Promise<string> {
+  const label = `release-${release.member.name}`;
+  await ensureLabel(label, `Release PR for ${release.member.name}`);
+
+  const bodyFile = `${release.member.relPath}/.release_bot/body_enhanced`;
+  const title = `Release ${release.member.name} ${release.newVersion}`;
+
+  const existing = await $`gh pr view --head ${release.branch} --json url -q .url`
+    .cwd(cwd)
+    .quiet()
+    .nothrow();
+  if (existing.exitCode === 0 && existing.stdout.toString().trim()) {
+    await $`gh pr edit --title ${title} --body-file ${bodyFile}`
+      .cwd(cwd)
+      .quiet();
+    return existing.stdout.toString().trim();
+  }
+
+  const created = await $`gh pr create --head ${release.branch} --title ${title} --label ${label} -F ${bodyFile}`
+    .cwd(cwd)
+    .quiet();
+  return created.stdout.toString().trim();
+}
+
+async function runMonorepoCreate(cwd: string): Promise<void> {
+  await ensureGitignoreEntry(".release_bot", cwd);
+  const branchTemplate = process.env.INPUT_BRANCH ?? "release-{member}-{version}";
+  const result = await runCreate({ cwd, branchTemplate });
+
+  if (result.releases.length === 0) {
+    console.log("No members need releasing.");
+    await writeGithubOutput("released-count=0");
+    return;
+  }
+
+  const releasedNames: string[] = [];
+  for (const release of result.releases) {
+    await pushBranch(cwd, release);
+    const url = await openOrUpdatePr(release, cwd);
+    console.log(`::notice title=Release ${release.member.name} ${release.newVersion}::${url}`);
+    releasedNames.push(`${release.member.name}@${release.newVersion}`);
+  }
+
+  await writeGithubOutput(`released-count=${result.releases.length}`);
+  await writeGithubOutput(`released=${releasedNames.join(",")}`);
+}
+
+async function runMonorepoPublish(cwd: string): Promise<void> {
+  const discovery = await discoverMembers(cwd);
+  if (discovery.mode !== "monorepo") {
+    throw new Error("Publish invoked without monorepo discovery — check action.yml gating");
+  }
+
+  // The PR file list is supplied via gh pr view in the workflow shell; the
+  // resolver supports either a `changedFiles` override (passed via env) or
+  // GITHUB_EVENT_PATH discovery. Read the env override here.
+  const overrideFiles = process.env.PR_CHANGED_FILES;
+  const changedFiles = overrideFiles
+    ? overrideFiles.split("\n").map((line) => line.trim()).filter(Boolean)
+    : await readChangedFiles({ cwd });
+
+  const plan = await resolvePublishPlan({ cwd, changedFiles });
+
+  if (plan.publishToNpm) {
+    const npmToken = process.env.NPM_TOKEN ?? "";
+    if (!npmToken) {
+      throw new Error("NPM_TOKEN required to publish lib-nodejs/lib-bun member");
+    }
+    await $`bun install`.cwd(plan.member.path).quiet();
+    await $`npm config set //registry.npmjs.org/:_authToken ${npmToken}`.quiet();
+    await $`npm publish`.cwd(plan.member.path);
+  }
+
+  await $`git tag ${plan.versionTag}`.cwd(cwd).quiet();
+  await $`git push --no-verify origin ${plan.versionTag}`.cwd(cwd).quiet();
+  console.log(`Created and pushed tag ${plan.versionTag}`);
+
+  if (plan.majorTag) {
+    await $`git tag -fa ${plan.majorTag} -m ${`Update ${plan.majorTag} tag`}`.cwd(cwd).quiet();
+    await $`git push origin ${plan.majorTag} --force`.cwd(cwd).quiet();
+    console.log(`Updated major version tag ${plan.majorTag}`);
+  }
+
+  const notesFile = `${plan.member.relPath}/.release_notes/${plan.version}.md`;
+  const releaseTitle = `Release ${plan.member.name} ${plan.version}`;
+  await $`gh release create ${plan.versionTag} --title ${releaseTitle} -F ${notesFile}`
+    .cwd(cwd)
+    .quiet();
+  console.log(`Created GitHub release ${releaseTitle} (${plan.versionTag})`);
+
+  if (plan.slackChannel) {
+    try {
+      await postReleaseNotification({
+        cwd: plan.member.path,
+        releaseTag: plan.versionTag,
+        displayName: plan.member.name,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(`::warning::Slack notification failed: ${message}`);
+    }
+  }
+
+  await writeGithubOutput(`released-member=${plan.member.name}`);
+  await writeGithubOutput(`released-version=${plan.version}`);
+  await writeGithubOutput(`released-tag=${plan.versionTag}`);
+}
+
+async function main(): Promise<void> {
+  const mode = parseMode(process.argv.slice(2));
+  const cwd = process.cwd();
+
+  const discovery = await discoverMembers(cwd);
+  if (discovery.mode !== "monorepo") {
+    console.log(`Standalone mode detected — run.ts is a no-op; action.yml drives the flow.`);
+    return;
+  }
+
+  if (mode === "create") {
+    await runMonorepoCreate(cwd);
+  } else {
+    await runMonorepoPublish(cwd);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}
+
+// Re-exports for downstream tooling
+export { memberVersionTag, memberMajorTag };

--- a/.github/actions/release-action/src/slackNotify.ts
+++ b/.github/actions/release-action/src/slackNotify.ts
@@ -87,95 +87,113 @@ export function extractReleaseNotes(content: string): string {
   return notes;
 }
 
-// Only run when executed directly (not when imported for testing)
-if (import.meta.main) {
-  void (async () => {
-    const slackToken = process.env.SLACK_TOKEN;
-    if (!slackToken) {
-      console.log("SLACK_TOKEN not set, skipping Slack notification");
-      process.exit(0);
-    }
+/** Options accepted by {@link postReleaseNotification}. */
+export interface SlackNotifyOptions {
+  /** Member directory (defaults to `process.cwd()`). */
+  cwd?: string;
+  /** Per-member tag form (e.g. `release-action@v1.2.0`). Defaults to `v<version>`. */
+  releaseTag?: string;
+  /** Display name for the Slack header (defaults to the repo's basename). */
+  displayName?: string;
+}
 
-    const repo = process.env.GITHUB_REPOSITORY ?? "";
-    const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+/**
+ * Post the per-member release notification to Slack. No-op when SLACK_TOKEN is
+ * unset or the member's `package.json` has no `release.slack` field.
+ */
+export async function postReleaseNotification(
+  options: SlackNotifyOptions = {},
+): Promise<void> {
+  const { join } = await import("node:path");
+  const cwd = options.cwd ?? process.cwd();
 
-    // Read package.json release.slack for channel
-    const pkgFile = Bun.file("package.json");
-    if (!(await pkgFile.exists())) {
-      console.log("package.json not found, skipping Slack notification");
-      process.exit(0);
-    }
+  const slackToken = process.env.SLACK_TOKEN;
+  if (!slackToken) {
+    console.log("SLACK_TOKEN not set, skipping Slack notification");
+    return;
+  }
 
-    const { slack: channel } = readReleaseField(await pkgFile.json());
-    if (!channel) {
-      console.log("No release.slack field in package.json, skipping notification");
-      process.exit(0);
-    }
+  const repo = process.env.GITHUB_REPOSITORY ?? "";
+  const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
 
-    // Read version and release notes
-    const version = (await Bun.file("version").text()).trim();
-    const repoName = repo.split("/").pop() ?? repo;
-    const releaseUrl = `${serverUrl}/${repo}/releases/tag/v${version}`;
+  const pkgFile = Bun.file(join(cwd, "package.json"));
+  if (!(await pkgFile.exists())) {
+    console.log("package.json not found, skipping Slack notification");
+    return;
+  }
 
-    const releaseNotesFile = Bun.file(`.release_notes/${version}.md`);
-    const releaseNotesContent = (await releaseNotesFile.exists())
-      ? await releaseNotesFile.text()
-      : "";
-    const notes = extractReleaseNotes(releaseNotesContent);
+  const { slack: channel } = readReleaseField(await pkgFile.json());
+  if (!channel) {
+    console.log("No release.slack field in package.json, skipping notification");
+    return;
+  }
 
-    // Post to Slack using Block Kit
-    const slack = new WebClient(slackToken);
+  const version = (await Bun.file(join(cwd, "version")).text()).trim();
+  const releaseTag = options.releaseTag ?? `v${version}`;
+  const repoName = options.displayName ?? repo.split("/").pop() ?? repo;
+  const releaseUrl = `${serverUrl}/${repo}/releases/tag/${encodeURIComponent(releaseTag)}`;
 
-    try {
-      const result = await slack.chat.postMessage({
-        channel,
-        text: `${repo} v${version} released`,
-        unfurl_links: false,
-        blocks: [
-          {
-            type: "header",
-            text: {
-              type: "plain_text",
-              text: `📦 ${repoName} v${version}`,
-              emoji: true,
-            },
+  const releaseNotesFile = Bun.file(join(cwd, ".release_notes", `${version}.md`));
+  const releaseNotesContent = (await releaseNotesFile.exists())
+    ? await releaseNotesFile.text()
+    : "";
+  const notes = extractReleaseNotes(releaseNotesContent);
+
+  const slack = new WebClient(slackToken);
+
+  try {
+    const result = await slack.chat.postMessage({
+      channel,
+      text: `${repo} ${releaseTag} released`,
+      unfurl_links: false,
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: `📦 ${repoName} v${version}`,
+            emoji: true,
           },
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: notes,
-            },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: notes,
           },
-          {
-            type: "divider",
-          },
-          {
-            type: "actions",
-            elements: [
-              {
-                type: "button",
-                text: {
-                  type: "plain_text",
-                  text: "View release",
-                },
-                url: releaseUrl,
-                action_id: "view_release",
-                style: "primary",
+        },
+        {
+          type: "divider",
+        },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "View release",
               },
-            ],
-          },
-        ],
-      });
+              url: releaseUrl,
+              action_id: "view_release",
+              style: "primary",
+            },
+          ],
+        },
+      ],
+    });
 
-      if (result.ok) {
-        console.log(`Slack notification sent to ${channel}`);
-      } else {
-        console.log(`::warning::Slack notification failed: ${result.error}`);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.log(`::warning::Slack notification failed: ${message}`);
+    if (result.ok) {
+      console.log(`Slack notification sent to ${channel}`);
+    } else {
+      console.log(`::warning::Slack notification failed: ${result.error}`);
     }
-  })();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`::warning::Slack notification failed: ${message}`);
+  }
+}
+
+if (import.meta.main) {
+  await postReleaseNotification();
 }

--- a/.github/actions/release-action/src/slackNotify.ts
+++ b/.github/actions/release-action/src/slackNotify.ts
@@ -101,9 +101,7 @@ export interface SlackNotifyOptions {
  * Post the per-member release notification to Slack. No-op when SLACK_TOKEN is
  * unset or the member's `package.json` has no `release.slack` field.
  */
-export async function postReleaseNotification(
-  options: SlackNotifyOptions = {},
-): Promise<void> {
+export async function postReleaseNotification(options: SlackNotifyOptions = {}): Promise<void> {
   const { join } = await import("node:path");
   const cwd = options.cwd ?? process.cwd();
 

--- a/.github/actions/release-action/src/updateReleaseBadge.ts
+++ b/.github/actions/release-action/src/updateReleaseBadge.ts
@@ -28,7 +28,7 @@ export function updateReleaseBadge(
   readme: string,
   version: string,
   serverUrl: string,
-  repo: string
+  repo: string,
 ): string {
   const releaseBadge = `[![GitHub Release](https://img.shields.io/badge/release-v${version}-blue)](${serverUrl}/${repo}/releases/latest)`;
   const createBadge = `[![Create Release](https://img.shields.io/badge/Create-Release-blue?logo=github)](${serverUrl}/${repo}/actions/workflows/release_create.yml)`;

--- a/.github/actions/release-action/src/updateReleaseBadge.ts
+++ b/.github/actions/release-action/src/updateReleaseBadge.ts
@@ -56,14 +56,23 @@ export function updateReleaseBadge(
   return `${releaseBadge}\n${createBadge}\n\n${readme}`;
 }
 
-async function main(): Promise<void> {
-  const readmeFile = Bun.file("README.md");
+/**
+ * Update the README badge in-place for the given working directory.
+ * No-ops when `<cwd>/README.md` does not exist.
+ *
+ * @param cwd - Member directory (defaults to `process.cwd()`).
+ */
+export async function refreshReleaseBadge(cwd: string = process.cwd()): Promise<void> {
+  const { join } = await import("node:path");
+  const readmePath = join(cwd, "README.md");
+  const versionPath = join(cwd, "version");
+  const readmeFile = Bun.file(readmePath);
 
   if (!(await readmeFile.exists())) {
     return;
   }
 
-  const version = (await Bun.file("version").text()).trim();
+  const version = (await Bun.file(versionPath).text()).trim();
   const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
   const repo = process.env.GITHUB_REPOSITORY ?? "";
 
@@ -71,13 +80,13 @@ async function main(): Promise<void> {
   const updated = updateReleaseBadge(readme, version, serverUrl, repo);
 
   if (updated !== readme) {
-    await Bun.write("README.md", updated);
+    await Bun.write(readmePath, updated);
     console.log(`Updated release badge to v${version}`);
   }
 }
 
 if (import.meta.main) {
-  main().catch((error: Error) => {
+  refreshReleaseBadge().catch((error: Error) => {
     console.log(`::error::${error.message}`);
     process.exit(1);
   });

--- a/docs/release-field.md
+++ b/docs/release-field.md
@@ -38,9 +38,18 @@ interface ReleaseConfig {
   type: ReleaseType; // required
   slack?: string; // optional Slack channel, e.g. "#releases"
 }
+
+// Root-only superset (repository-root `package.json` in a monorepo)
+interface RootReleaseConfig {
+  members?: string[]; // monorepo: explicit member paths (mutually exclusive with `type`)
+  type?: ReleaseType; // standalone: same shape as ReleaseConfig
+  slack?: string;
+}
 ```
 
-`type` is required. `slack` is optional — when omitted, `release-action` skips the Slack notification step. When present, it must be a non-empty string.
+`type` is required on **member** manifests. `slack` is optional — when omitted, `release-action` skips the Slack notification step. When present, it must be a non-empty string.
+
+At the **root** of a monorepo, `release.members` declares the workspace paths to release; `type` is omitted on the root in that case. When neither `members` nor `type` is present, `release-action` falls back to expanding the root's `workspaces` globs and using only members that declare their own `release.type`.
 
 ### Recognized `type` values
 
@@ -118,6 +127,24 @@ The reference implementation is `.github/actions/release-action/src/releaseField
 ```
 
 Version source switches to `plugin.json`; npm publish is skipped; GitHub Release is created.
+
+### Monorepo root
+
+```json
+{
+  "name": "monorepo",
+  "workspaces": [".github/actions/*", "packages/*"],
+  "release": {
+    "members": [
+      ".github/actions/release-action",
+      ".github/actions/files-sync",
+      "claude-plugins/autopilot"
+    ]
+  }
+}
+```
+
+`release-action` runs once per member with the per-member `release.type` driving artifacts. Per-member tags use the form `<name>@v<version>` (e.g. `release-action@v1.2.0`) and the floating major tag becomes `<name>@v1`. When `release.members` is omitted, the action falls back to the root `workspaces` array and skips any member that does not declare its own `release` field.
 
 ## Extending
 

--- a/docs/workspace-structure.md
+++ b/docs/workspace-structure.md
@@ -147,7 +147,7 @@ The root `package.json` declares the repo's stack via a top-level `agents` objec
 
 ### The `release` field
 
-A workspace member's `package.json` declares its release config via a top-level `release` object — see [`docs/release-field.md`](./release-field.md) for the contract. Consumed by [`release-action`](../.github/actions/release-action/README.md) to pick the version source, npm-publish step, major-version tag, and the optional Slack notification channel. Example for a Node.js library member:
+A workspace member's `package.json` declares its release config via a top-level `release` object — see [`docs/release-field.md`](./release-field.md) for the contract. Consumed by [`release-action`](../.github/actions/release-action/README.md) to pick the version source, npm-publish step, major-version tag, and the optional Slack notification channel. The repo-root `package.json` may also declare `release.members` to opt specific workspace paths into monorepo mode — see [`docs/release-field.md`](./release-field.md#monorepo-root) and the [release-action monorepo section](../.github/actions/release-action/README.md#monorepo-mode). Example for a Node.js library member:
 
 ```json
 {


### PR DESCRIPTION
Teach release-action to release each eligible workspace member independently while keeping the existing standalone behaviour as a transparent fallback. Members are discovered via root release.members or workspaces globs and filtered by per-member release field, so internal-only packages (e.g. actions-core) stay untagged.

- Per-member <name>@v<version> tags with floating <name>@v<MAJOR> for github-action members
- Path-scoped commit detection per member; members with no changes since their last tag are skipped silently
- Workspace dependents auto-bump (at least patch) when one of their workspace dependencies is released
- Per-member CHANGELOG.md, .release_notes/<v>.md, and MIGRATING.md on major bumps
- One release-<name>-<version> branch and PR per changed member, label release-<name>
- Publish flow resolves the released member from the merged PR's .release_notes path; one shared workflow handles every member
- Standalone repos (no workspaces or release.members) run the existing yaml pipeline unchanged; detectReleaseType emits a new mode output that gates the legacy steps

---

**Release notes:**

- Added monorepo mode: release each eligible workspace member independently with its own changelog, release notes, tag, and PR
- Added release.members on root package.json to opt specific workspace paths into monorepo mode
- Added workspace-dependents propagation (at least patch) when a dependency is released
- Added per-member MIGRATING.md auto-append on major bumps from BREAKING CHANGE: footers
- Tag format for monorepo members is <name>@v<version> (floating <name>@v<MAJOR> for github-action members); standalone repos remain on v<version>

---

**Issues:**

Closes #46

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds monorepo support to `release-action`: discover eligible workspace members and release each independently with its own tags, notes, and PR, while preserving the standalone flow. Also tightens correctness with concrete base-ref resolution, unique per-member branches, and paginated PR file reads for reliable member resolution.

- **New Features**
  - Monorepo mode triggers when the root has `release.members` or `workspaces`; members are filtered by per-member `release.type` and discovery deduplicates overlapping globs.
  - Per-member artifacts and tags: `CHANGELOG.md`, `.release_notes/<version>.md`, `MIGRATING.md` on majors, and tags like `<name>@v<version>` (plus floating `<name>@v<MAJOR>` for action members); PR body links are scoped to the member path.
  - Path-scoped commit detection; members with no changes since their last tag are skipped, and git errors now fail fast instead of being treated as empty results.
  - Auto-bump workspace dependents (at least patch) when a released member is a dependency; only `workspace:*` specifiers propagate.
  - One branch/PR per changed member; each PR includes only its own release commit. Base ref now resolves to a concrete commit SHA (captures from `GITHUB_SHA`, falls back and resolves to a SHA) and is pinned before the per-member loop; `{member}` is auto-injected into `INPUT_BRANCH` when missing to avoid collisions.
  - Publish workflow resolves the member from changed paths and applies the right tag using a paginated `gh api repos/.../pulls/<n>/files` call (handles >100 files), falling back to `gh pr view` when event data is limited.
  - Action outputs now include `mode` (`standalone` or `monorepo`); legacy standalone steps are gated and unchanged.

- **Migration**
  - To opt in, add `release.members` at the repo root (preferred) or rely on `workspaces`; each released member must declare `release.type`.
  - Omit the `release` field in internal-only packages to keep them untagged.
  - Monorepo tags use `<name>@v<version>`; standalone repos keep `v<version>`. No changes required for standalone setups.

<sup>Written for commit 60b35844783bd786c4f256bd2b5c5e8939f6949c. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/47?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

