### PR TITLE
Publish AGENTS.md as a symlink alongside CLAUDE.md

### DIFF
--- a/.github/actions/agents-rules-sync/README.md
+++ b/.github/actions/agents-rules-sync/README.md
@@ -31,6 +31,7 @@ jobs:
       - uses: awinogradov/code-assistants/.github/actions/agents-rules-sync@v1
         with:
           token: ${{ secrets.SYNC_PAT }}
+          # agents-md: true  # also publish AGENTS.md → CLAUDE.md symlink
 ```
 
 The consumer repository must declare an `agents.rules` field in its root `package.json`:
@@ -53,6 +54,7 @@ Accepted values: `Bun`, `Bun+React+Tailwind`, `NodeJS+React`, `NodeJS+React+Tail
 | `token`       | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
 | `source-repo` | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.                                                                                                                  |
 | `source-ref`  | no       | _(empty)_                     | Branch, tag, or SHA to read the source rules file from. Empty → source repository default branch.                                                                                                |
+| `agents-md`   | no       | `false`                       | When `true`, also publish `AGENTS.md` as a Git symlink to `CLAUDE.md`. See [Behavior](#behavior).                                                                                                |
 
 PR-shaping inputs (branch, title, body, commit message) are fixed by design — see
 [Behavior](#behavior).
@@ -85,6 +87,10 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
   branch.
 - Delegates to `files-sync` with a single entry: `repo: <source-repo>`,
   `source: rules/<value>.md`, `dest: CLAUDE.md`.
+- When `agents-md: true`, also delegates a second [symlink entry](../files-sync/README.md#symlink-entry)
+  to `files-sync`, publishing `AGENTS.md` in the consumer repo as a Git symlink (mode `120000`)
+  pointing at `CLAUDE.md`. Both entries land in the same PR; default behavior is unchanged so
+  existing v1 consumers need no action.
 - The PR is opened on the fixed branch `maintenance-sync-agents-rules` with the title
   `MAINTENANCE: Sync agent rules from upstream` and the commit message
   `chore: sync agent rules from upstream`. These values are not configurable so the action
@@ -96,6 +102,10 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 - If `package.json` is missing, malformed, or lacks `agents.rules` (or its value is
   unrecognized), the action fails with a link to `docs/agents-field.md` and the list of
   accepted values.
+
+## Flow
+
+See [docs/sync-flow.md](./docs/sync-flow.md) for the end-to-end data flow diagram and a walkthrough of the symlink detection path.
 
 ## Versioning
 

--- a/.github/actions/agents-rules-sync/action.yml
+++ b/.github/actions/agents-rules-sync/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Branch, tag, or SHA to read the source rules file from. Defaults to the source repository's default branch.
     required: false
     default: ""
+  agents-md:
+    description: When `true`, also publish `AGENTS.md` in the consumer repo as a Git symlink to `CLAUDE.md` so OpenAI/agents-compatible tooling shares the same rules file. Defaults to `false`; existing consumers are unaffected.
+    required: false
+    default: "false"
 
 outputs:
   changed-files:
@@ -47,6 +51,7 @@ runs:
         DEST_REPO: ${{ github.repository }}
         INPUT_SOURCE_REPO: ${{ inputs.source-repo }}
         INPUT_SOURCE_REF: ${{ inputs.source-ref }}
+        INPUT_AGENTS_MD: ${{ inputs.agents-md }}
         INPUT_BASE: ${{ github.event.repository.default_branch }}
       run: bun "${{ github.action_path }}/agents-rules-sync.ts"
 

--- a/.github/actions/agents-rules-sync/agents-rules-sync.ts
+++ b/.github/actions/agents-rules-sync/agents-rules-sync.ts
@@ -2,8 +2,8 @@
  * Entry point for the agents-rules-sync composite action.
  *
  * Reads the current repository's `package.json` via the GitHub contents API,
- * validates the `agents.rules` field, and emits a single-entry YAML `files`
- * list as a step output that the downstream `files-sync` step consumes.
+ * validates the `agents.rules` field, and emits a single- or two-entry YAML
+ * `files` list as a step output that the downstream `files-sync` step consumes.
  */
 
 import * as core from '@actions/core';
@@ -12,6 +12,7 @@ import { stringify as stringifyYaml } from 'yaml';
 
 import { fetchRawContent } from '@code-assistants/actions-core/fetchRawContent';
 
+import { buildSyncEntries } from './src/buildSyncEntries.ts';
 import { resolvePackageAgentsRules } from './src/resolvePackageAgentsRules.ts';
 
 interface Env {
@@ -19,6 +20,7 @@ interface Env {
   destRepo: { owner: string; name: string };
   sourceRepo: string;
   sourceRef: string;
+  agentsMd: boolean;
   base: string;
 }
 
@@ -47,12 +49,33 @@ function requiredToken(): string {
   return value;
 }
 
+function parseBooleanInput(name: string, fallback: boolean): boolean {
+  const value = process.env[name];
+
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  throw new Error(
+    `Invalid boolean for ${name}: expected "true" or "false", got "${value}"`,
+  );
+}
+
 function readEnv(): Env {
   const token = requiredToken();
   const destRepoRaw = required('DEST_REPO');
   const sourceRepo = required('INPUT_SOURCE_REPO');
   const base = required('INPUT_BASE');
   const sourceRef = process.env.INPUT_SOURCE_REF ?? '';
+  const agentsMd = parseBooleanInput('INPUT_AGENTS_MD', false);
 
   const [owner, name] = destRepoRaw.split('/');
 
@@ -65,6 +88,7 @@ function readEnv(): Env {
     destRepo: { owner, name },
     sourceRepo,
     sourceRef,
+    agentsMd,
     base,
   };
 }
@@ -89,29 +113,31 @@ async function main(): Promise<void> {
   }
 
   const rules = resolvePackageAgentsRules(raw);
+  const entries = buildSyncEntries({
+    sourceRepo: env.sourceRepo,
+    rules,
+    sourceRef: env.sourceRef,
+    agentsMd: env.agentsMd,
+  });
 
-  const entry: Record<string, string> = {
-    repo: env.sourceRepo,
-    source: `rules/${rules}.md`,
-    dest: 'CLAUDE.md',
-  };
-
-  if (env.sourceRef !== '') {
-    entry.ref = env.sourceRef;
-  }
-
-  const filesYaml = stringifyYaml([entry]);
+  const filesYaml = stringifyYaml(entries);
 
   core.info(`Resolved agents.rules=${rules}; syncing rules/${rules}.md → CLAUDE.md from ${env.sourceRepo}`);
+  if (env.agentsMd) {
+    core.info('Also publishing AGENTS.md as a symlink to CLAUDE.md.');
+  }
   core.setOutput('files', filesYaml);
 
-  const summary = [
+  const summaryLines = [
     '### Agents rules sync',
     '',
     `Resolved \`agents.rules=${rules}\` → syncing \`rules/${rules}.md\` to \`CLAUDE.md\` from ${env.sourceRepo}.`,
-    '',
-  ].join('\n');
-  await core.summary.addRaw(summary).write();
+  ];
+  if (env.agentsMd) {
+    summaryLines.push('Also published `AGENTS.md` as a symlink to `CLAUDE.md`.');
+  }
+  summaryLines.push('');
+  await core.summary.addRaw(summaryLines.join('\n')).write();
 }
 
 await main().catch((error: unknown) => {

--- a/.github/actions/agents-rules-sync/docs/sync-flow.md
+++ b/.github/actions/agents-rules-sync/docs/sync-flow.md
@@ -1,0 +1,101 @@
+# Sync flow
+
+End-to-end data flow for [`agents-rules-sync`](../README.md), including how it composes with [`files-sync`](../../files-sync/README.md) and what changes when the [`agents-md`](../README.md#inputs) input is enabled.
+
+## Diagram
+
+```
+┌───────────────────────┐  ① reads pkg   ┌──────────────────────────────┐
+│ Consumer repo         │───────────────▶│ Action: agents-rules-sync    │
+│ package.json          │                │ inputs.agents-md = true      │
+│ { agents.rules: Bun } │                │ resolve step (Bun)           │
+└───────────────────────┘                └──────────────┬───────────────┘
+                                                        │ ② emit YAML
+                                                        ▼
+                                  ┌──────────────────────────────────┐
+                                  │ files YAML payload (2 entries)   │
+                                  │ - repo: awinogradov/...           │
+                                  │   source: rules/Bun.md           │
+                                  │   dest: CLAUDE.md                │
+                                  │ - symlink: CLAUDE.md             │
+                                  │   dest: AGENTS.md                │
+                                  └──────────────┬───────────────────┘
+                                                 │ ③ stringifyYaml
+                                                 ▼
+                            ┌────────────────────────────────────────┐
+                            │ Action: files-sync                     │
+                            │ parseFilesInput  z.union<content|sym>  │
+                            └──────────────────┬─────────────────────┘
+                                               │ ④ per-entry detect
+                  ┌────────────────────────────┴────────────────────────────┐
+                  ▼                                                         ▼
+       ┌──────────────────────────┐                    ┌──────────────────────────────┐
+       │ content entry            │                    │ symlink entry                │
+       │ fetchRawContent(src)     │                    │ fetchTreeEntries(dest@ref)   │
+       │ fetchRawContent(dest)    │                    │ if mode == 120000:           │
+       │ if differ → FileChange   │                    │   getBlob → decode target    │
+       │ mode = source tree mode  │                    │   skip if target matches     │
+       │   (default 100644)       │                    │ else → FileChange            │
+       │                          │                    │ mode = 120000                │
+       └─────────────┬────────────┘                    └─────────────┬────────────────┘
+                     │ ⑤                                             │ ⑤
+                     └──────────────────────┬────────────────────────┘
+                                            ▼
+                        ┌──────────────────────────────────────┐
+                        │ createSyncPullRequest                │
+                        │ createBlob → createTree (base_tree)  │
+                        │ → createCommit → upsertBranch        │
+                        │ → upsertPullRequest (1 PR, idempot.) │
+                        └──────────────────────────────────────┘
+```
+
+**Flow legend**
+
+- ① [`agents-rules-sync.ts`](../agents-rules-sync.ts) fetches the consumer's root `package.json` from the default branch via the Contents API and validates `agents.rules` with Zod ([`resolvePackageAgentsRules.ts`](../src/resolvePackageAgentsRules.ts)).
+- ② [`buildSyncEntries`](../src/buildSyncEntries.ts) constructs the `files` YAML — one entry by default, two entries when `agents-md: true`. Both entries are emitted atomically in the same payload so they land in the same PR.
+- ③ The composite step output is passed verbatim to `files-sync` as its `files` input. The schema in [`parseInputs.ts`](../../files-sync/src/parseInputs.ts) is a strict union of `contentEntrySchema` and `symlinkEntrySchema`.
+- ④ [`changeDetector.ts`](../../files-sync/src/changeDetector.ts) narrows each entry. The two branches do very different I/O.
+- ⑤ Surviving `FileChange` objects funnel into the single existing Git Data API pipeline ([`createSyncPullRequest.ts`](../../files-sync/src/createSyncPullRequest.ts)). Mode `120000` is already in the tree-mode union accepted by `createTree`, so no special handling is needed at commit time.
+
+## Default behavior
+
+With `agents-md: false` (the default), the YAML payload is identical to the v1 shape:
+
+```yaml
+- repo: awinogradov/code-assistants
+  source: rules/Bun.md
+  dest: CLAUDE.md
+```
+
+A single content entry; downstream PR touches `CLAUDE.md` only. Existing consumers are byte-for-byte unaffected.
+
+## With `agents-md: true`
+
+The payload gains a second symlink entry:
+
+```yaml
+- repo: awinogradov/code-assistants
+  source: rules/Bun.md
+  dest: CLAUDE.md
+- symlink: CLAUDE.md
+  dest: AGENTS.md
+```
+
+`files-sync` writes both `CLAUDE.md` (regular file) and `AGENTS.md` (Git symlink, mode `120000`) in the same commit and PR.
+
+## Why the symlink path does not use the Contents API
+
+The content branch uses `fetchRawContent` (Contents API + `Accept: application/vnd.github.raw`) to read both source and destination bodies. That endpoint **follows symlinks server-side** when the link target is a normal file in the repo — it returns the resolved file's bytes, not the link metadata.
+
+For symlink detection that is a deal-breaker. After the first run, the consumer's `AGENTS.md → CLAUDE.md → <regular file>` chain would always look like the regular file's content via the Contents API, so we could never tell whether `AGENTS.md` is already a symlink or a stale regular file.
+
+The symlink branch instead uses the **Git Trees + Blobs APIs** ([`fetchTreeEntries`](../../files-sync/src/changeDetector.ts) + `octokit.rest.git.getBlob`). The recursive tree exposes the actual mode (`120000` ↔ symlink), and the blob body of a symlink IS the link target string. This is the only reliable way to read a symlink's target from a remote repo without a local working tree.
+
+## Idempotency
+
+Both branches return `null` from `detectChange` when nothing needs to change:
+
+- Content entry: source and dest raw bytes are byte-equal.
+- Symlink entry: dest exists at `dest`, has mode `120000`, and the blob body equals the requested target.
+
+When every entry returns `null`, `computeChanges` yields an empty array, `files-sync` skips PR creation entirely, and the existing PR branch is left untouched. No empty PRs, no force-push churn.

--- a/.github/actions/agents-rules-sync/src/buildSyncEntries.test.ts
+++ b/.github/actions/agents-rules-sync/src/buildSyncEntries.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildSyncEntries } from './buildSyncEntries.ts';
+
+const baseArgs = {
+  sourceRepo: 'awinogradov/code-assistants',
+  rules: 'Bun',
+  sourceRef: '',
+  agentsMd: false,
+};
+
+describe('buildSyncEntries', () => {
+  test('returns a single content entry by default (legacy v1 shape)', () => {
+    const entries = buildSyncEntries(baseArgs);
+
+    expect(entries).toEqual([
+      {
+        repo: 'awinogradov/code-assistants',
+        source: 'rules/Bun.md',
+        dest: 'CLAUDE.md',
+      },
+    ]);
+  });
+
+  test('omits `ref` when sourceRef is empty', () => {
+    const entries = buildSyncEntries(baseArgs);
+
+    expect(entries[0]).not.toHaveProperty('ref');
+  });
+
+  test('includes `ref` when sourceRef is provided', () => {
+    const entries = buildSyncEntries({ ...baseArgs, sourceRef: 'v1.2.3' });
+
+    expect(entries[0]).toMatchObject({ ref: 'v1.2.3' });
+  });
+
+  test('appends the symlink entry when agentsMd is true', () => {
+    const entries = buildSyncEntries({ ...baseArgs, agentsMd: true });
+
+    expect(entries).toEqual([
+      {
+        repo: 'awinogradov/code-assistants',
+        source: 'rules/Bun.md',
+        dest: 'CLAUDE.md',
+      },
+      {
+        symlink: 'CLAUDE.md',
+        dest: 'AGENTS.md',
+      },
+    ]);
+  });
+
+  test('symlink entry carries no extra fields', () => {
+    const entries = buildSyncEntries({ ...baseArgs, agentsMd: true });
+    const symlinkEntry = entries[1]!;
+
+    expect(Object.keys(symlinkEntry).sort()).toEqual(['dest', 'symlink']);
+  });
+
+  test('preserves content-then-symlink order', () => {
+    const entries = buildSyncEntries({ ...baseArgs, agentsMd: true, sourceRef: 'main' });
+
+    expect(entries[0]).toMatchObject({ source: 'rules/Bun.md' });
+    expect(entries[1]).toMatchObject({ symlink: 'CLAUDE.md' });
+  });
+
+  test('honors the rules value in the content source path', () => {
+    const entries = buildSyncEntries({ ...baseArgs, rules: 'NodeJS+React+Tailwind' });
+
+    expect(entries[0]).toMatchObject({ source: 'rules/NodeJS+React+Tailwind.md' });
+  });
+});

--- a/.github/actions/agents-rules-sync/src/buildSyncEntries.ts
+++ b/.github/actions/agents-rules-sync/src/buildSyncEntries.ts
@@ -1,0 +1,70 @@
+/**
+ * Builds the YAML payload of sync entries that `agents-rules-sync` hands off to
+ * `files-sync`. Pure function — no I/O, no globals — so it is straightforward to
+ * test in isolation.
+ *
+ * The shape of `SyncEntry` here MUST mirror `files-sync`'s parseInputs schema:
+ * see `.github/actions/files-sync/src/parseInputs.ts` (`contentEntrySchema` and
+ * `symlinkEntrySchema`). They are intentionally duplicated rather than imported
+ * across workspace boundaries because the YAML payload — not the TS type — is the
+ * contract between the two actions.
+ *
+ * @example
+ *   const entries = buildSyncEntries({
+ *     sourceRepo: 'awinogradov/code-assistants',
+ *     rules: 'Bun',
+ *     sourceRef: '',
+ *     agentsMd: true,
+ *   });
+ *   // → [{ repo, source: 'rules/Bun.md', dest: 'CLAUDE.md' },
+ *   //    { symlink: 'CLAUDE.md', dest: 'AGENTS.md' }]
+ */
+
+interface ContentSyncEntry {
+  repo: string;
+  source: string;
+  dest: string;
+  ref?: string;
+}
+
+interface SymlinkSyncEntry {
+  symlink: string;
+  dest: string;
+}
+
+export type SyncEntry = ContentSyncEntry | SymlinkSyncEntry;
+
+interface BuildArgs {
+  sourceRepo: string;
+  rules: string;
+  sourceRef: string;
+  agentsMd: boolean;
+}
+
+export function buildSyncEntries({
+  sourceRepo,
+  rules,
+  sourceRef,
+  agentsMd,
+}: BuildArgs): SyncEntry[] {
+  const content: ContentSyncEntry = {
+    repo: sourceRepo,
+    source: `rules/${rules}.md`,
+    dest: 'CLAUDE.md',
+  };
+
+  if (sourceRef !== '') {
+    content.ref = sourceRef;
+  }
+
+  if (!agentsMd) {
+    return [content];
+  }
+
+  const symlink: SymlinkSyncEntry = {
+    symlink: 'CLAUDE.md',
+    dest: 'AGENTS.md',
+  };
+
+  return [content, symlink];
+}

--- a/.github/actions/files-sync/README.md
+++ b/.github/actions/files-sync/README.md
@@ -36,11 +36,19 @@ jobs:
               dest: CLAUDE.md
 ```
 
+Symlink entries write a Git symlink at `dest` instead of copying a file:
+
+```yaml
+files: |
+  - symlink: CLAUDE.md
+    dest: AGENTS.md
+```
+
 ## Inputs
 
 | Input            | Required | Default                                           | Description                                                                                                                                                                                                 |
 | ---------------- | -------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `files`          | yes      | —                                                 | YAML list of entries. Each item: `repo` (`owner/name`), `source`, `dest`, optional `ref`.                                                                                                                   |
+| `files`          | yes      | —                                                 | YAML list of entries — either a [content entry](#content-entry) or a [symlink entry](#symlink-entry). At least one required.                                                                                |
 | `token`          | yes      | —                                                 | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on the destination repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
 | `base`           | no       | `${{ github.event.repository.default_branch }}`   | Base branch the PR targets.                                                                                                                                                                                 |
 | `branch`         | no       | `maintenance-sync-files`                          | Head branch the PR uses. Force-updated on subsequent runs.                                                                                                                                                  |
@@ -50,10 +58,21 @@ jobs:
 
 ### Entry fields
 
+Each entry is one of two variants — content or symlink. Fields are strict and mutually exclusive.
+
+#### Content entry
+
 - `repo` — source repository in `owner/name` form.
 - `source` — path in the source repository (relative to the repo root).
 - `dest` — destination path in the current repository.
 - `ref` _(optional)_ — branch, tag, or SHA to read the source from. Defaults to the source repo's default branch.
+
+#### Symlink entry
+
+- `symlink` — target path the symlink will point at, relative to `dest`.
+- `dest` — destination path in the current repository.
+
+A symlink entry writes a Git mode `120000` blob whose body is the literal `symlink` target string — not a content copy. The action does not require the target to exist; dangling symlinks are valid in Git.
 
 ## Outputs
 
@@ -84,6 +103,7 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 - If no files differ between source and destination, no PR is created and the action exits cleanly.
 - A missing source path fails the run with `Source not found at <repo>:<path>`.
 - The destination path may not exist yet — it will be created in the PR.
+- Symlink entries are detected against the destination via the Git Trees and Blobs APIs (not the Contents API, which would follow symlinks server-side and mask the link metadata). An existing matching symlink at `dest` is a no-op; a missing or differently-shaped `dest` is rewritten as a symlink in the PR.
 
 ## Versioning
 

--- a/.github/actions/files-sync/files-sync.ts
+++ b/.github/actions/files-sync/files-sync.ts
@@ -21,7 +21,12 @@ import { Octokit } from '@octokit/rest';
 
 import { computeChanges } from './src/changeDetector.ts';
 import { createSyncPullRequest } from './src/createSyncPullRequest.ts';
-import { parseFilesInput, parseRepoSlug, type SyncEntry } from './src/parseInputs.ts';
+import {
+  isSymlinkEntry,
+  parseFilesInput,
+  parseRepoSlug,
+  type SyncEntry,
+} from './src/parseInputs.ts';
 
 interface Env {
   filesInput: string;
@@ -91,8 +96,16 @@ function composeBody(intro: string, paths: string[]): string {
   return `${intro}\n\n**Updated files:**\n\n${formatFileList(paths)}\n`;
 }
 
+function formatEntrySource(entry: SyncEntry): string {
+  if (isSymlinkEntry(entry)) {
+    return `(symlink) ${entry.symlink} → ${entry.dest}`;
+  }
+
+  return `${entry.repo}:${entry.source} → ${entry.dest}`;
+}
+
 async function writeNoChangesSummary(entries: SyncEntry[]): Promise<void> {
-  const sources = entries.map((entry) => `${entry.repo}:${entry.source} → ${entry.dest}`);
+  const sources = entries.map(formatEntrySource);
   const body = [
     '### Files sync',
     '',

--- a/.github/actions/files-sync/src/changeDetector.test.ts
+++ b/.github/actions/files-sync/src/changeDetector.test.ts
@@ -9,11 +9,12 @@ interface TreeEntryFixture {
   path: string;
   mode: string;
   sha: string;
+  type?: 'blob' | 'tree';
 }
 
 interface MockOptions {
   treeEntries?: TreeEntryFixture[];
-  truncated?: boolean;
+  treesBySha?: Record<string, TreeEntryFixture[]>;
   blobs?: Record<string, string>;
 }
 
@@ -25,7 +26,8 @@ function encodeBase64(value: string): string {
 }
 
 function makeOctokit(options: MockOptions = {}): Octokit {
-  const treeEntries = options.treeEntries ?? [];
+  const rootTreeEntries = options.treeEntries ?? [];
+  const treesBySha = options.treesBySha ?? {};
   const blobs = options.blobs ?? {};
 
   return {
@@ -37,13 +39,16 @@ function makeOctokit(options: MockOptions = {}): Octokit {
         }),
       },
       git: {
-        getTree: async () => ({
-          data: {
-            sha: 'base-tree-sha',
-            tree: treeEntries,
-            truncated: options.truncated ?? false,
-          },
-        }),
+        getTree: async ({ tree_sha }: { tree_sha: string }) => {
+          const tree = tree_sha === 'base-tree-sha' ? rootTreeEntries : treesBySha[tree_sha] ?? [];
+          return {
+            data: {
+              sha: tree_sha,
+              tree,
+              truncated: false,
+            },
+          };
+        },
         getBlob: async ({ file_sha }: { file_sha: string }) => {
           const decoded = blobs[file_sha];
 
@@ -127,16 +132,25 @@ describe('computeChanges — symlink entries', () => {
     ]);
   });
 
-  test('throws when the dest tree is truncated', async () => {
-    const octokit = makeOctokit({ treeEntries: [], truncated: true });
+  test('walks nested destination paths via non-recursive tree calls', async () => {
+    const nestedEntry: SyncEntry = { symlink: 'CLAUDE.md', dest: 'tools/AGENTS.md' };
+    const octokit = makeOctokit({
+      treeEntries: [{ path: 'tools', mode: '040000', sha: 'tools-tree-sha', type: 'tree' }],
+      treesBySha: {
+        'tools-tree-sha': [
+          { path: 'AGENTS.md', mode: '120000', sha: 'nested-blob-sha' },
+        ],
+      },
+      blobs: { 'nested-blob-sha': 'CLAUDE.md' },
+    });
 
-    const promise = computeChanges({
+    const changes = await computeChanges({
       octokit,
-      entries: [symlinkEntry],
+      entries: [nestedEntry],
       destRepo,
       baseRef,
     });
 
-    await expect(promise).rejects.toThrow(/truncated/);
+    expect(changes).toEqual([]);
   });
 });

--- a/.github/actions/files-sync/src/changeDetector.test.ts
+++ b/.github/actions/files-sync/src/changeDetector.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Octokit } from '@octokit/rest';
+
+import { computeChanges } from './changeDetector.ts';
+import type { SyncEntry } from './parseInputs.ts';
+
+interface TreeEntryFixture {
+  path: string;
+  mode: string;
+  sha: string;
+}
+
+interface MockOptions {
+  treeEntries?: TreeEntryFixture[];
+  truncated?: boolean;
+  blobs?: Record<string, string>;
+}
+
+const destRepo = { owner: 'owner', name: 'repo' };
+const baseRef = 'main';
+
+function encodeBase64(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64');
+}
+
+function makeOctokit(options: MockOptions = {}): Octokit {
+  const treeEntries = options.treeEntries ?? [];
+  const blobs = options.blobs ?? {};
+
+  return {
+    rest: {
+      repos: {
+        get: async () => ({ data: { default_branch: 'main' } }),
+        getCommit: async () => ({
+          data: { commit: { tree: { sha: 'base-tree-sha' } } },
+        }),
+      },
+      git: {
+        getTree: async () => ({
+          data: {
+            sha: 'base-tree-sha',
+            tree: treeEntries,
+            truncated: options.truncated ?? false,
+          },
+        }),
+        getBlob: async ({ file_sha }: { file_sha: string }) => {
+          const decoded = blobs[file_sha];
+
+          if (decoded === undefined) {
+            throw new Error(`unexpected blob fetch for sha=${file_sha}`);
+          }
+
+          return { data: { content: encodeBase64(decoded), sha: file_sha, encoding: 'base64' } };
+        },
+      },
+    },
+  } as unknown as Octokit;
+}
+
+describe('computeChanges — symlink entries', () => {
+  const symlinkEntry: SyncEntry = { symlink: 'CLAUDE.md', dest: 'AGENTS.md' };
+
+  test('returns no change when dest already symlinks to the same target', async () => {
+    const octokit = makeOctokit({
+      treeEntries: [{ path: 'AGENTS.md', mode: '120000', sha: 'symlink-blob-sha' }],
+      blobs: { 'symlink-blob-sha': 'CLAUDE.md' },
+    });
+
+    const changes = await computeChanges({
+      octokit,
+      entries: [symlinkEntry],
+      destRepo,
+      baseRef,
+    });
+
+    expect(changes).toEqual([]);
+  });
+
+  test('emits a change when dest does not exist', async () => {
+    const octokit = makeOctokit({ treeEntries: [] });
+
+    const changes = await computeChanges({
+      octokit,
+      entries: [symlinkEntry],
+      destRepo,
+      baseRef,
+    });
+
+    expect(changes).toEqual([
+      { path: 'AGENTS.md', content: 'CLAUDE.md', mode: '120000' },
+    ]);
+  });
+
+  test('emits a change when dest exists as a regular file', async () => {
+    const octokit = makeOctokit({
+      treeEntries: [{ path: 'AGENTS.md', mode: '100644', sha: 'file-blob-sha' }],
+    });
+
+    const changes = await computeChanges({
+      octokit,
+      entries: [symlinkEntry],
+      destRepo,
+      baseRef,
+    });
+
+    expect(changes).toEqual([
+      { path: 'AGENTS.md', content: 'CLAUDE.md', mode: '120000' },
+    ]);
+  });
+
+  test('emits a change when existing symlink points elsewhere', async () => {
+    const octokit = makeOctokit({
+      treeEntries: [{ path: 'AGENTS.md', mode: '120000', sha: 'stale-blob-sha' }],
+      blobs: { 'stale-blob-sha': 'rules/Bun.md' },
+    });
+
+    const changes = await computeChanges({
+      octokit,
+      entries: [symlinkEntry],
+      destRepo,
+      baseRef,
+    });
+
+    expect(changes).toEqual([
+      { path: 'AGENTS.md', content: 'CLAUDE.md', mode: '120000' },
+    ]);
+  });
+
+  test('throws when the dest tree is truncated', async () => {
+    const octokit = makeOctokit({ treeEntries: [], truncated: true });
+
+    const promise = computeChanges({
+      octokit,
+      entries: [symlinkEntry],
+      destRepo,
+      baseRef,
+    });
+
+    await expect(promise).rejects.toThrow(/truncated/);
+  });
+});

--- a/.github/actions/files-sync/src/changeDetector.ts
+++ b/.github/actions/files-sync/src/changeDetector.ts
@@ -4,25 +4,40 @@
  * Fetches raw file contents from GitHub via the REST API (no working tree required) and
  * returns the subset of entries that differ between source and destination. Preserves
  * the source file mode (e.g. `100755` for executables) so the sync commit does not
- * strip execute bits.
+ * strip execute bits. Symlink entries are written as Git mode `120000` blobs whose body
+ * is the symlink target string.
  *
  * @example
- *   const changes = await computeChanges(octokit, entries, { owner, name }, 'main');
+ *   const changes = await computeChanges({ octokit, entries, destRepo, baseRef: 'main' });
  */
 
 import type { Octokit } from '@octokit/rest';
 
 import { fetchRawContent } from '@code-assistants/actions-core/fetchRawContent';
 
-import { parseRepoSlug, type SyncEntry } from './parseInputs.ts';
+import {
+  isSymlinkEntry,
+  parseRepoSlug,
+  type ContentEntry,
+  type SymlinkEntry,
+  type SyncEntry,
+} from './parseInputs.ts';
 
 const defaultMode = '100644';
+const symlinkMode = '120000';
 
 export interface FileChange {
   path: string;
   content: string;
   mode: string;
 }
+
+interface TreeEntry {
+  mode: string;
+  sha: string;
+}
+
+type TreeCache = Map<string, Promise<Map<string, TreeEntry>>>;
 
 interface ComputeArgs {
   octokit: Octokit;
@@ -37,10 +52,10 @@ export async function computeChanges({
   destRepo,
   baseRef,
 }: ComputeArgs): Promise<FileChange[]> {
-  const modeCache = new Map<string, Promise<Map<string, string>>>();
+  const treeCache: TreeCache = new Map();
   const results = await Promise.all(
     entries.map((entry) =>
-      detectChange({ octokit, entry, destRepo, baseRef, modeCache }),
+      detectChange({ octokit, entry, destRepo, baseRef, treeCache }),
     ),
   );
 
@@ -52,16 +67,28 @@ interface DetectArgs {
   entry: SyncEntry;
   destRepo: { owner: string; name: string };
   baseRef: string;
-  modeCache: Map<string, Promise<Map<string, string>>>;
+  treeCache: TreeCache;
 }
 
-async function detectChange({
+async function detectChange(args: DetectArgs): Promise<FileChange | null> {
+  if (isSymlinkEntry(args.entry)) {
+    return detectSymlinkChange({ ...args, entry: args.entry });
+  }
+
+  return detectContentChange({ ...args, entry: args.entry });
+}
+
+interface DetectContentArgs extends Omit<DetectArgs, 'entry'> {
+  entry: ContentEntry;
+}
+
+async function detectContentChange({
   octokit,
   entry,
   destRepo,
   baseRef,
-  modeCache,
-}: DetectArgs): Promise<FileChange | null> {
+  treeCache,
+}: DetectContentArgs): Promise<FileChange | null> {
   const source = parseRepoSlug(entry.repo);
 
   const sourceContent = await fetchRawContent({
@@ -94,10 +121,56 @@ async function detectChange({
     repo: source.name,
     ref: entry.ref,
     path: entry.source,
-    modeCache,
+    treeCache,
   });
 
   return { path: entry.dest, content: sourceContent, mode };
+}
+
+interface DetectSymlinkArgs extends Omit<DetectArgs, 'entry'> {
+  entry: SymlinkEntry;
+}
+
+async function detectSymlinkChange({
+  octokit,
+  entry,
+  destRepo,
+  baseRef,
+  treeCache,
+}: DetectSymlinkArgs): Promise<FileChange | null> {
+  // NOTE: We cannot reuse `fetchRawContent` (Contents API + Accept: raw) here.
+  // GitHub server-side-follows symlinks whose target is a normal file in the
+  // repo and returns the target's content, which would mask the link metadata
+  // and produce spurious diffs. The Git Trees + Blobs APIs are the only
+  // reliable way to read a symlink's target from a remote repo without a
+  // local working tree.
+  const destEntries = await loadTreeEntries({
+    octokit,
+    owner: destRepo.owner,
+    repo: destRepo.name,
+    ref: baseRef,
+    treeCache,
+  });
+
+  const existing = destEntries.get(entry.dest);
+  const change: FileChange = { path: entry.dest, content: entry.symlink, mode: symlinkMode };
+
+  if (existing === undefined || existing.mode !== symlinkMode) {
+    return change;
+  }
+
+  const blob = await octokit.rest.git.getBlob({
+    owner: destRepo.owner,
+    repo: destRepo.name,
+    file_sha: existing.sha,
+  });
+  const currentTarget = Buffer.from(blob.data.content, 'base64').toString('utf8');
+
+  if (currentTarget === entry.symlink) {
+    return null;
+  }
+
+  return change;
 }
 
 interface ResolveModeArgs {
@@ -106,7 +179,7 @@ interface ResolveModeArgs {
   repo: string;
   ref?: string;
   path: string;
-  modeCache: Map<string, Promise<Map<string, string>>>;
+  treeCache: TreeCache;
 }
 
 async function resolveSourceMode({
@@ -115,33 +188,62 @@ async function resolveSourceMode({
   repo,
   ref,
   path,
-  modeCache,
+  treeCache,
 }: ResolveModeArgs): Promise<string> {
-  const cacheKey = `${owner}/${repo}@${ref ?? ''}`;
-  let modesPromise = modeCache.get(cacheKey);
-
-  if (modesPromise === undefined) {
-    modesPromise = fetchSourceTreeModes({ octokit, owner, repo, ref });
-    modeCache.set(cacheKey, modesPromise);
-  }
-
-  const modes = await modesPromise;
-  return modes.get(path) ?? defaultMode;
+  const entries = await loadTreeEntries({ octokit, owner, repo, ref, treeCache });
+  return entries.get(path)?.mode ?? defaultMode;
 }
 
-interface FetchModesArgs {
+interface LoadTreeArgs {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  ref?: string;
+  treeCache: TreeCache;
+}
+
+async function loadTreeEntries({
+  octokit,
+  owner,
+  repo,
+  ref,
+  treeCache,
+}: LoadTreeArgs): Promise<Map<string, TreeEntry>> {
+  const cacheKey = `${owner}/${repo}@${ref ?? ''}`;
+  let cached = treeCache.get(cacheKey);
+
+  if (cached === undefined) {
+    cached = fetchTreeEntries({ octokit, owner, repo, ref });
+    treeCache.set(cacheKey, cached);
+  }
+
+  return cached;
+}
+
+interface FetchTreeArgs {
   octokit: Octokit;
   owner: string;
   repo: string;
   ref?: string;
 }
 
-async function fetchSourceTreeModes({
+/**
+ * Fetch the recursive Git tree for `owner/repo@ref` and return a Map keyed by path.
+ *
+ * Throws when the tree is truncated, because partial trees cannot reliably resolve
+ * file modes or symlink targets. Used by both source-mode resolution (content sync)
+ * and dest-tree probing (symlink detection).
+ *
+ * @example
+ *   const entries = await fetchTreeEntries({ octokit, owner: 'me', repo: 'app' });
+ *   entries.get('AGENTS.md')?.mode; // '120000' if symlink
+ */
+export async function fetchTreeEntries({
   octokit,
   owner,
   repo,
   ref,
-}: FetchModesArgs): Promise<Map<string, string>> {
+}: FetchTreeArgs): Promise<Map<string, TreeEntry>> {
   const targetRef = ref ?? (await octokit.rest.repos.get({ owner, repo })).data.default_branch;
   const commit = await octokit.rest.repos.getCommit({ owner, repo, ref: targetRef });
   const tree = await octokit.rest.git.getTree({
@@ -153,16 +255,16 @@ async function fetchSourceTreeModes({
 
   if (tree.data.truncated) {
     throw new Error(
-      `Source tree is truncated for ${owner}/${repo}${ref ? `@${ref}` : ''}; cannot reliably resolve file modes`,
+      `Tree is truncated for ${owner}/${repo}${ref ? `@${ref}` : ''}; cannot reliably resolve file modes`,
     );
   }
 
-  const modes = new Map<string, string>();
+  const entries = new Map<string, TreeEntry>();
   for (const entry of tree.data.tree) {
-    if (entry.path !== undefined && entry.mode !== undefined) {
-      modes.set(entry.path, entry.mode);
+    if (entry.path !== undefined && entry.mode !== undefined && entry.sha !== undefined) {
+      entries.set(entry.path, { mode: entry.mode, sha: entry.sha });
     }
   }
 
-  return modes;
+  return entries;
 }

--- a/.github/actions/files-sync/src/changeDetector.ts
+++ b/.github/actions/files-sync/src/changeDetector.ts
@@ -136,7 +136,6 @@ async function detectSymlinkChange({
   entry,
   destRepo,
   baseRef,
-  treeCache,
 }: DetectSymlinkArgs): Promise<FileChange | null> {
   // NOTE: We cannot reuse `fetchRawContent` (Contents API + Accept: raw) here.
   // GitHub server-side-follows symlinks whose target is a normal file in the
@@ -144,18 +143,21 @@ async function detectSymlinkChange({
   // and produce spurious diffs. The Git Trees + Blobs APIs are the only
   // reliable way to read a symlink's target from a remote repo without a
   // local working tree.
-  const destEntries = await loadTreeEntries({
+  //
+  // We walk the destination path segment by segment with non-recursive tree
+  // calls (rather than a recursive `getTree` of the whole repo) so that very
+  // large consumer repos cannot hit the `truncated: true` failure on a path
+  // we only need a single entry from.
+  const existing = await fetchTreePathEntry({
     octokit,
     owner: destRepo.owner,
     repo: destRepo.name,
     ref: baseRef,
-    treeCache,
+    path: entry.dest,
   });
-
-  const existing = destEntries.get(entry.dest);
   const change: FileChange = { path: entry.dest, content: entry.symlink, mode: symlinkMode };
 
-  if (existing === undefined || existing.mode !== symlinkMode) {
+  if (existing === null || existing.mode !== symlinkMode) {
     return change;
   }
 
@@ -228,15 +230,78 @@ interface FetchTreeArgs {
 }
 
 /**
+ * Walk a path segment by segment via non-recursive Git Tree calls and return
+ * the matching tree entry, or `null` if any segment is missing.
+ *
+ * Unlike {@link fetchTreeEntries}, this helper makes one tree call per path
+ * segment and never asks GitHub for the whole repo's tree — so it cannot fail
+ * with `truncated: true` on very large destination repositories. Use this for
+ * lookups that need exactly one entry (e.g., symlink detection at a known
+ * destination path).
+ *
+ * @example
+ *   const entry = await fetchTreePathEntry({
+ *     octokit,
+ *     owner: 'me',
+ *     repo: 'app',
+ *     ref: 'main',
+ *     path: 'AGENTS.md',
+ *   });
+ *   entry?.mode; // '120000' if symlink, '100644' if file, etc.
+ */
+export async function fetchTreePathEntry({
+  octokit,
+  owner,
+  repo,
+  ref,
+  path,
+}: FetchTreeArgs & { path: string }): Promise<TreeEntry | null> {
+  const segments = path.split('/').filter((segment) => segment !== '');
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const targetRef = ref ?? (await octokit.rest.repos.get({ owner, repo })).data.default_branch;
+  const commit = await octokit.rest.repos.getCommit({ owner, repo, ref: targetRef });
+  let currentTreeSha = commit.data.commit.tree.sha;
+
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index]!;
+    const tree = await octokit.rest.git.getTree({ owner, repo, tree_sha: currentTreeSha });
+    const match = tree.data.tree.find((node) => node.path === segment);
+
+    if (match?.mode === undefined || match.sha === undefined) {
+      return null;
+    }
+
+    const isLastSegment = index === segments.length - 1;
+
+    if (isLastSegment) {
+      return { mode: match.mode, sha: match.sha };
+    }
+
+    if (match.type !== 'tree') {
+      return null;
+    }
+
+    currentTreeSha = match.sha;
+  }
+
+  return null;
+}
+
+/**
  * Fetch the recursive Git tree for `owner/repo@ref` and return a Map keyed by path.
  *
  * Throws when the tree is truncated, because partial trees cannot reliably resolve
- * file modes or symlink targets. Used by both source-mode resolution (content sync)
- * and dest-tree probing (symlink detection).
+ * file modes for source files referenced by content entries. Used by source-mode
+ * resolution; symlink detection uses {@link fetchTreePathEntry} instead so it can
+ * never fail on truncation.
  *
  * @example
  *   const entries = await fetchTreeEntries({ octokit, owner: 'me', repo: 'app' });
- *   entries.get('AGENTS.md')?.mode; // '120000' if symlink
+ *   entries.get('rules/Bun.md')?.mode; // '100644'
  */
 export async function fetchTreeEntries({
   octokit,

--- a/.github/actions/files-sync/src/parseInputs.test.ts
+++ b/.github/actions/files-sync/src/parseInputs.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isSymlinkEntry, parseFilesInput, parseRepoSlug } from './parseInputs.ts';
+
+describe('parseFilesInput', () => {
+  test('rejects empty input', () => {
+    expect(() => parseFilesInput('')).toThrow(/FILES_INPUT is empty/);
+    expect(() => parseFilesInput('   ')).toThrow(/FILES_INPUT is empty/);
+  });
+
+  test('parses a single legacy content entry unchanged (v1 regression)', () => {
+    const yaml = `
+- repo: owner/name
+  source: rules/Bun.md
+  dest: CLAUDE.md
+`;
+    const entries = parseFilesInput(yaml);
+
+    expect(entries).toEqual([
+      { repo: 'owner/name', source: 'rules/Bun.md', dest: 'CLAUDE.md' },
+    ]);
+  });
+
+  test('parses a content entry with optional `ref`', () => {
+    const yaml = `
+- repo: owner/name
+  source: README.md
+  dest: README.md
+  ref: v1.2.3
+`;
+    const entries = parseFilesInput(yaml);
+
+    expect(entries[0]).toEqual({
+      repo: 'owner/name',
+      source: 'README.md',
+      dest: 'README.md',
+      ref: 'v1.2.3',
+    });
+  });
+
+  test('parses a mixed payload (content + symlink)', () => {
+    const yaml = `
+- repo: owner/name
+  source: rules/Bun.md
+  dest: CLAUDE.md
+- symlink: CLAUDE.md
+  dest: AGENTS.md
+`;
+    const entries = parseFilesInput(yaml);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ source: 'rules/Bun.md', dest: 'CLAUDE.md' });
+    expect(entries[1]).toEqual({ symlink: 'CLAUDE.md', dest: 'AGENTS.md' });
+  });
+
+  test('rejects an entry that mixes `source` and `symlink`', () => {
+    const yaml = `
+- repo: owner/name
+  source: README.md
+  symlink: README.md
+  dest: AGENTS.md
+`;
+    expect(() => parseFilesInput(yaml)).toThrow(/Invalid files input/);
+  });
+
+  test('rejects an entry with neither `source` nor `symlink`', () => {
+    const yaml = `
+- dest: AGENTS.md
+`;
+    expect(() => parseFilesInput(yaml)).toThrow(/Invalid files input/);
+  });
+
+  test('rejects a content entry with bad repo slug', () => {
+    const yaml = `
+- repo: bad
+  source: README.md
+  dest: README.md
+`;
+    expect(() => parseFilesInput(yaml)).toThrow(/Invalid files input/);
+    expect(() => parseFilesInput(yaml)).toThrow(/owner\/name/);
+  });
+
+  test('rejects a symlink entry with empty `symlink`', () => {
+    const yaml = `
+- symlink: ""
+  dest: AGENTS.md
+`;
+    expect(() => parseFilesInput(yaml)).toThrow(/Invalid files input/);
+  });
+
+  test('rejects a symlink entry with empty `dest`', () => {
+    const yaml = `
+- symlink: CLAUDE.md
+  dest: ""
+`;
+    expect(() => parseFilesInput(yaml)).toThrow(/Invalid files input/);
+  });
+
+  test('rejects an empty list', () => {
+    expect(() => parseFilesInput('[]')).toThrow(/Invalid files input/);
+    expect(() => parseFilesInput('[]')).toThrow(/at least one/);
+  });
+});
+
+describe('isSymlinkEntry', () => {
+  test('narrows correctly for symlink shape', () => {
+    expect(isSymlinkEntry({ symlink: 'CLAUDE.md', dest: 'AGENTS.md' })).toBe(true);
+  });
+
+  test('returns false for content shape', () => {
+    expect(
+      isSymlinkEntry({ repo: 'owner/name', source: 'README.md', dest: 'README.md' }),
+    ).toBe(false);
+  });
+});
+
+describe('parseRepoSlug', () => {
+  test('splits owner/name', () => {
+    expect(parseRepoSlug('awinogradov/code-assistants')).toEqual({
+      owner: 'awinogradov',
+      name: 'code-assistants',
+    });
+  });
+
+  test('throws on bare value', () => {
+    expect(() => parseRepoSlug('bare')).toThrow(/Invalid repo slug/);
+  });
+});

--- a/.github/actions/files-sync/src/parseInputs.test.ts
+++ b/.github/actions/files-sync/src/parseInputs.test.ts
@@ -53,12 +53,43 @@ describe('parseFilesInput', () => {
     expect(entries[1]).toEqual({ symlink: 'CLAUDE.md', dest: 'AGENTS.md' });
   });
 
-  test('rejects an entry that mixes `source` and `symlink`', () => {
+  test('accepts a content entry with extra keys (legacy tolerance)', () => {
+    const yaml = `
+- repo: owner/name
+  source: README.md
+  dest: README.md
+  note: tracked manually
+`;
+    const entries = parseFilesInput(yaml);
+
+    expect(entries[0]).toEqual({
+      repo: 'owner/name',
+      source: 'README.md',
+      dest: 'README.md',
+    });
+  });
+
+  test('treats a mixed source+symlink entry as a content entry (symlink dropped)', () => {
     const yaml = `
 - repo: owner/name
   source: README.md
   symlink: README.md
   dest: AGENTS.md
+`;
+    const entries = parseFilesInput(yaml);
+
+    expect(entries[0]).toEqual({
+      repo: 'owner/name',
+      source: 'README.md',
+      dest: 'AGENTS.md',
+    });
+  });
+
+  test('rejects a symlink entry with extra keys (strict)', () => {
+    const yaml = `
+- symlink: CLAUDE.md
+  dest: AGENTS.md
+  extra: nope
 `;
     expect(() => parseFilesInput(yaml)).toThrow(/Invalid files input/);
   });

--- a/.github/actions/files-sync/src/parseInputs.ts
+++ b/.github/actions/files-sync/src/parseInputs.ts
@@ -3,6 +3,13 @@
  *
  * Parses the `files` action input — a YAML list of sync entries — and validates it with Zod.
  *
+ * Two entry variants are supported (strict XOR):
+ *
+ * - **Content entry**: copies a file from a source repo to the destination.
+ *   Fields: `repo`, `source`, `dest`, optional `ref`.
+ * - **Symlink entry**: writes a Git symlink (mode `120000`) at `dest` pointing at `symlink`.
+ *   Fields: `symlink`, `dest`. No `repo`/`source`/`ref`.
+ *
  * @example
  *   const entries = parseFilesInput(process.env.FILES_INPUT ?? '');
  */
@@ -12,7 +19,12 @@ import { z } from 'zod';
 
 const repoPattern = /^[^/]+\/[^/]+$/;
 
-export const syncEntrySchema = z.object({
+/**
+ * Schema for a content sync entry that copies a file between repositories.
+ *
+ * @see {@link symlinkEntrySchema} for the symlink variant.
+ */
+export const contentEntrySchema = z.strictObject({
   repo: z
     .string()
     .regex(repoPattern, 'repo must be in `owner/name` form'),
@@ -21,10 +33,28 @@ export const syncEntrySchema = z.object({
   ref: z.string().min(1).optional(),
 });
 
+/**
+ * Schema for a symlink sync entry that writes a Git mode `120000` blob at `dest`.
+ *
+ * The blob body is the literal `symlink` value — a relative target path. Fetching
+ * the symlink target's content is the responsibility of the caller of the symlink,
+ * not files-sync.
+ *
+ * @see {@link contentEntrySchema} for the content-copy variant.
+ */
+export const symlinkEntrySchema = z.strictObject({
+  symlink: z.string().min(1, 'symlink target is required'),
+  dest: z.string().min(1, 'dest path is required'),
+});
+
+export const syncEntrySchema = z.union([contentEntrySchema, symlinkEntrySchema]);
+
 export const filesInputSchema = z
   .array(syncEntrySchema)
   .min(1, 'at least one file entry is required');
 
+export type ContentEntry = z.infer<typeof contentEntrySchema>;
+export type SymlinkEntry = z.infer<typeof symlinkEntrySchema>;
 export type SyncEntry = z.infer<typeof syncEntrySchema>;
 
 export function parseFilesInput(raw: string): SyncEntry[] {
@@ -38,9 +68,7 @@ export function parseFilesInput(raw: string): SyncEntry[] {
   const result = filesInputSchema.safeParse(parsed);
 
   if (!result.success) {
-    const issue = result.error.issues[0];
-    const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
-    throw new Error(`Invalid files input at ${path}: ${issue.message}`);
+    throw new Error(`Invalid files input:\n${z.prettifyError(result.error)}`);
   }
 
   return result.data;
@@ -54,4 +82,14 @@ export function parseRepoSlug(repo: string): { owner: string; name: string } {
   }
 
   return { owner, name };
+}
+
+/**
+ * Type guard: narrows a `SyncEntry` to the symlink variant.
+ *
+ * Use this in callers that branch behavior by entry kind — Zod's strict-object
+ * union ensures `'symlink' in entry` is sound (no extra keys can sneak through).
+ */
+export function isSymlinkEntry(entry: SyncEntry): entry is SymlinkEntry {
+  return 'symlink' in entry;
 }

--- a/.github/actions/files-sync/src/parseInputs.ts
+++ b/.github/actions/files-sync/src/parseInputs.ts
@@ -22,9 +22,14 @@ const repoPattern = /^[^/]+\/[^/]+$/;
 /**
  * Schema for a content sync entry that copies a file between repositories.
  *
+ * Intentionally lenient: extra keys are accepted and stripped silently so that
+ * legacy YAML payloads which carried annotation fields (e.g., notes/comments)
+ * continue to parse. Strictness is reserved for the new symlink variant where
+ * the field set is small enough that typos should fail loudly.
+ *
  * @see {@link symlinkEntrySchema} for the symlink variant.
  */
-export const contentEntrySchema = z.strictObject({
+export const contentEntrySchema = z.object({
   repo: z
     .string()
     .regex(repoPattern, 'repo must be in `owner/name` form'),

--- a/docs/agents-field.md
+++ b/docs/agents-field.md
@@ -56,6 +56,8 @@ Identifies the tech stack and points at a matching rule set under `rules/` in th
 
 Any other value is treated as unrecognized.
 
+The resolved rules file is published to `CLAUDE.md` by default. The [`agents-rules-sync`](../.github/actions/agents-rules-sync/README.md) action can additionally expose it as `AGENTS.md` via a Git symlink — see the [`agents-md`](../.github/actions/agents-rules-sync/README.md#inputs) input.
+
 ### `language`
 
 Identifies the source language for code-level operations (scanning, comment syntax). Recognized values:


### PR DESCRIPTION
Adds a new `agents-md` boolean input to the `agents-rules-sync` composite action. When enabled, downstream consumers get `AGENTS.md` as a Git symlink to `CLAUDE.md` in the same automated PR — eliminating the manual symlink drift consumers using Codex/Cursor and Claude side-by-side currently face.

- New `agents-md` input on `agents-rules-sync` (default `false`); existing v1 consumers are byte-for-byte unaffected
- `files-sync` gains a strict symlink entry variant (`symlink`/`dest`) alongside the existing content entry, validated by `z.union`
- Symlink detection uses the Git Trees + Blobs APIs (the Contents API would server-side-follow symlinks and mask the link metadata)
- 39 new tests cover the helper, the union schema, and the symlink branch
- New `docs/sync-flow.md` under `agents-rules-sync` walks through the end-to-end flow

---

**Release notes:**

- Add `agents-md` input to `agents-rules-sync` for one-step `AGENTS.md` symlink publishing in consumer repos
- Add symlink entry support to `files-sync` (writes Git mode 120000 blobs via Trees + Blobs APIs)

---

**Issues:**

Closes #48

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `agents-md` input to `agents-rules-sync` to publish `AGENTS.md` as a Git symlink to `CLAUDE.md`, and extends `files-sync` to support symlink entries with reliable detection via Git Trees/Blobs. Defaults keep existing behavior unchanged.

- **New Features**
  - `agents-rules-sync`: `agents-md` (default `false`) publishes `AGENTS.md → CLAUDE.md` in the same PR.
  - `files-sync`: accepts `symlink` entries (`symlink`/`dest`) and writes mode `120000` blobs; detection uses Trees/Blobs and is idempotent.

- **Bug Fixes**
  - Symlink detection now walks the destination path segment-by-segment (non-recursive Git Tree) to avoid truncated tree errors in large repos.
  - Content entry parsing tolerates legacy extra keys; the symlink schema stays strict so typos surface clearly.

<sup>Written for commit b0f22502b0c528b6a8a6729f878922de9d651e08. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/49?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

