### PR TITLE
Auto assign yourself when picking up a GitHub issue

### DIFF
--- a/claude-plugins/autopilot/.claude-plugin/plugin.json
+++ b/claude-plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Autopilot: plan, implement, commit, PR, and monitor — skills and agents for AI-assisted development workflows",
   "author": {
     "name": "Tony Vi",

--- a/claude-plugins/autopilot/README.md
+++ b/claude-plugins/autopilot/README.md
@@ -277,15 +277,15 @@ Specialized review sub-agents launched in parallel by the `pr:review` skill. Eac
 
 Context-isolating workers invoked by other skills to keep the parent conversation small. Each returns a structured summary only.
 
-| Agent                    | Model   | Used by                        | Purpose                                                                       |
-| ------------------------ | ------- | ------------------------------ | ----------------------------------------------------------------------------- |
-| `analyze-pr-commits`     | sonnet  | `pr:create`, `pr:update`       | Summarize branch commits, diff, and linked issue for PR context               |
-| `analyze-staged-changes` | haiku   | `commits:create`               | Categorize staged files and recommend a commit strategy                       |
-| `expert-review`          | inherit | `plan`, `plan-*`               | Score an implementation plan as a domain expert                               |
-| `fetch-pr-reviews`       | sonnet  | `pr:answer`, `pr:resolve`      | Fetch, filter, and categorize PR review comments by severity                  |
-| `resolve-issue-context`  | sonnet  | `plan`, `run`, `branch:create` | Fetch GitHub issue context and auto-assign current user (idempotent) via `gh` |
-| `scan-and-analyze-todos` | sonnet  | `todo-cleanup`                 | Scan codebase for TODOs and check linked GitHub issue statuses                |
-| `search-codebase-todos`  | haiku   | `plan`                         | Search the codebase for TODOs and references to a specific issue              |
+| Agent                    | Model   | Used by                        | Purpose                                                                               |
+| ------------------------ | ------- | ------------------------------ | ------------------------------------------------------------------------------------- |
+| `analyze-pr-commits`     | sonnet  | `pr:create`, `pr:update`       | Summarize branch commits, diff, and linked issue for PR context                       |
+| `analyze-staged-changes` | haiku   | `commits:create`               | Categorize staged files and recommend a commit strategy                               |
+| `expert-review`          | inherit | `plan`, `plan-*`               | Score an implementation plan as a domain expert                                       |
+| `fetch-pr-reviews`       | sonnet  | `pr:answer`, `pr:resolve`      | Fetch, filter, and categorize PR review comments by severity                          |
+| `resolve-issue-context`  | sonnet  | `plan`, `run`, `branch:create` | Fetch GitHub issue context; optionally auto-assign current user (idempotent) via `gh` |
+| `scan-and-analyze-todos` | sonnet  | `todo-cleanup`                 | Scan codebase for TODOs and check linked GitHub issue statuses                        |
+| `search-codebase-todos`  | haiku   | `plan`                         | Search the codebase for TODOs and references to a specific issue                      |
 
 ## Internal Skills (not in slash menu)
 

--- a/claude-plugins/autopilot/README.md
+++ b/claude-plugins/autopilot/README.md
@@ -277,15 +277,15 @@ Specialized review sub-agents launched in parallel by the `pr:review` skill. Eac
 
 Context-isolating workers invoked by other skills to keep the parent conversation small. Each returns a structured summary only.
 
-| Agent                    | Model   | Used by                        | Purpose                                                          |
-| ------------------------ | ------- | ------------------------------ | ---------------------------------------------------------------- |
-| `analyze-pr-commits`     | sonnet  | `pr:create`, `pr:update`       | Summarize branch commits, diff, and linked issue for PR context  |
-| `analyze-staged-changes` | haiku   | `commits:create`               | Categorize staged files and recommend a commit strategy          |
-| `expert-review`          | inherit | `plan`, `plan-*`               | Score an implementation plan as a domain expert                  |
-| `fetch-pr-reviews`       | sonnet  | `pr:answer`, `pr:resolve`      | Fetch, filter, and categorize PR review comments by severity     |
-| `resolve-issue-context`  | sonnet  | `plan`, `run`, `branch:create` | Fetch and format GitHub issue context via `gh`                   |
-| `scan-and-analyze-todos` | sonnet  | `todo-cleanup`                 | Scan codebase for TODOs and check linked GitHub issue statuses   |
-| `search-codebase-todos`  | haiku   | `plan`                         | Search the codebase for TODOs and references to a specific issue |
+| Agent                    | Model   | Used by                        | Purpose                                                                       |
+| ------------------------ | ------- | ------------------------------ | ----------------------------------------------------------------------------- |
+| `analyze-pr-commits`     | sonnet  | `pr:create`, `pr:update`       | Summarize branch commits, diff, and linked issue for PR context               |
+| `analyze-staged-changes` | haiku   | `commits:create`               | Categorize staged files and recommend a commit strategy                       |
+| `expert-review`          | inherit | `plan`, `plan-*`               | Score an implementation plan as a domain expert                               |
+| `fetch-pr-reviews`       | sonnet  | `pr:answer`, `pr:resolve`      | Fetch, filter, and categorize PR review comments by severity                  |
+| `resolve-issue-context`  | sonnet  | `plan`, `run`, `branch:create` | Fetch GitHub issue context and auto-assign current user (idempotent) via `gh` |
+| `scan-and-analyze-todos` | sonnet  | `todo-cleanup`                 | Scan codebase for TODOs and check linked GitHub issue statuses                |
+| `search-codebase-todos`  | haiku   | `plan`                         | Search the codebase for TODOs and references to a specific issue              |
 
 ## Internal Skills (not in slash menu)
 

--- a/claude-plugins/autopilot/agents/resolve-issue-context.md
+++ b/claude-plugins/autopilot/agents/resolve-issue-context.md
@@ -1,11 +1,11 @@
 ---
 name: resolve-issue-context
-description: Fetch GitHub issue context and auto-assign the current user (idempotent). Use when commands need structured issue data without polluting parent context.
+description: Fetch GitHub issue context and optionally auto-assign the current user (idempotent, opt-in via caller flag). Use when commands need structured issue data without polluting parent context.
 tools: Bash, Grep
 model: sonnet
 ---
 
-You are a GitHub issue context resolver. Fetch issue data via the `gh` CLI, auto-assign the authenticated user to the issue (idempotently), and return a structured summary. Do not output intermediate steps — only the final structured block.
+You are a GitHub issue context resolver. Fetch issue data via the `gh` CLI and return a structured summary. When the caller opts in, also auto-assign the authenticated user to the issue (idempotently). Do not output intermediate steps — only the final structured block.
 
 **Constraints:**
 
@@ -18,6 +18,7 @@ The invoking skill provides in the prompt:
 
 - **Issue number** (e.g., `42`)
 - **Repository name** (e.g., `awinogradov/code-assistants`)
+- **Auto-assign current user** (optional, default `false`) — when the prompt contains `Auto-assign current user: true`, run Phase 2 and include the `**Assignee:**` line in the Phase 3 output. Otherwise skip Phase 2 entirely and omit the line. Read-only callers (e.g. `pr:review`) must NOT pass the flag.
 
 ## Phase 1: Fetch Issue
 
@@ -27,7 +28,9 @@ Store the full JSON in `ISSUE_JSON` so Phase 2 can re-read it without another AP
 ISSUE_JSON=$(gh issue view "$NUMBER" -R "$REPO" --json title,body,comments,labels,state,author,createdAt,assignees)
 ```
 
-## Phase 2: Auto-Assign Current User
+## Phase 2: Auto-Assign Current User (opt-in)
+
+Run this phase ONLY when the caller's prompt contains `Auto-assign current user: true`. Otherwise skip directly to Phase 3 and omit the `**Assignee:**` line from the output.
 
 The agent emits exactly one of the status strings below into the Phase 3 `**Assignee:**` line:
 
@@ -65,10 +68,10 @@ Resolve the status with these steps:
    EDIT_EXIT=$?
    ```
 
-5. Post-verify via a fresh read, because `gh issue edit --add-assignee` returns exit 0 even when GitHub silently drops the addition (caller lacks `triage`/`write` permission, or the issue is already at the 10-assignee limit):
+5. Post-verify via a fresh read, because `gh issue edit --add-assignee` returns exit 0 even when GitHub silently drops the addition (caller lacks `triage`/`write` permission, or the issue is already at the 10-assignee limit). `gh --jq` only accepts a single expression and cannot pass `--arg` through to `jq`, so pipe the JSON to `jq` directly:
 
    ```bash
-   VERIFIED=$(gh issue view "$NUMBER" -R "$REPO" --json assignees --jq --arg login "$LOGIN" 'any(.assignees[]; .login == $login)' 2>/dev/null)
+   VERIFIED=$(gh issue view "$NUMBER" -R "$REPO" --json assignees 2>/dev/null | jq -r --arg login "$LOGIN" 'any(.assignees[]; .login == $login)' 2>/dev/null)
    ```
 
    - `EDIT_EXIT == 0` AND `VERIFIED == "true"` → `@<LOGIN> (just assigned)`
@@ -77,7 +80,7 @@ Resolve the status with these steps:
 
 ## Phase 3: Output
 
-Output ONLY the structured block. No preamble or commentary:
+Output ONLY the structured block. No preamble or commentary. Include the `**Assignee:**` line only when Phase 2 ran (caller opted in); omit it entirely for read-only invocations.
 
 ```
 ## Issue Context
@@ -87,7 +90,7 @@ Output ONLY the structured block. No preamble or commentary:
 **Title:** [title]
 **Status:** [state]
 **Labels:** [labels]
-**Assignee:** [status from Phase 2]
+**Assignee:** [status from Phase 2 — include this line ONLY when Phase 2 ran]
 
 ### Description
 [body]

--- a/claude-plugins/autopilot/agents/resolve-issue-context.md
+++ b/claude-plugins/autopilot/agents/resolve-issue-context.md
@@ -1,15 +1,16 @@
 ---
 name: resolve-issue-context
-description: Fetch and format GitHub issue context. Use when commands need structured issue data without polluting parent context.
+description: Fetch GitHub issue context and auto-assign the current user (idempotent). Use when commands need structured issue data without polluting parent context.
 tools: Bash, Grep
 model: sonnet
 ---
 
-You are a GitHub issue context resolver. Fetch issue data via the `gh` CLI and return a structured summary. Do not output intermediate steps — only the final structured block.
+You are a GitHub issue context resolver. Fetch issue data via the `gh` CLI, auto-assign the authenticated user to the issue (idempotently), and return a structured summary. Do not output intermediate steps — only the final structured block.
 
 **Constraints:**
 
 - Use ONLY the `gh` CLI for issue operations.
+- All variable interpolations into shell commands MUST be double-quoted (`"$NUMBER"`, `"$REPO"`, `"$LOGIN"`).
 
 ## Input
 
@@ -20,11 +21,61 @@ The invoking skill provides in the prompt:
 
 ## Phase 1: Fetch Issue
 
+Store the full JSON in `ISSUE_JSON` so Phase 2 can re-read it without another API call:
+
 ```bash
-gh issue view <NUMBER> -R <REPO> --json title,body,comments,labels,state,author,createdAt
+ISSUE_JSON=$(gh issue view "$NUMBER" -R "$REPO" --json title,body,comments,labels,state,author,createdAt,assignees)
 ```
 
-## Phase 2: Output
+## Phase 2: Auto-Assign Current User
+
+The agent emits exactly one of the status strings below into the Phase 3 `**Assignee:**` line:
+
+- `@<login> (just assigned)`
+- `@<login> (already assigned)`
+- `unassigned — gh not authenticated`
+- `unassigned — issue closed`
+- `unassigned — permission denied or assignee limit reached`
+- `unassigned — gh edit error: <first line of stderr>`
+
+Resolve the status with these steps:
+
+1. Resolve the authenticated login, caching the result for 5 minutes:
+
+   ```bash
+   LOGIN=$(gh api user --cache 5m --jq .login 2>/dev/null)
+   ```
+
+   If `LOGIN` is empty, set status to `unassigned — gh not authenticated` and skip to Phase 3. Do NOT attempt an email-based fallback — `gh api search/users` requires `gh` to be working anyway, can match unrelated accounts that expose the same public email, and shares the same auth/rate-limit failure modes.
+
+2. If the Phase 1 issue `state` is `CLOSED`, set status to `unassigned — issue closed` and skip to Phase 3. Planning work on a closed issue is almost always a mistake; surface it instead of silently mutating.
+
+3. Check whether `LOGIN` is already in the assignees array from Phase 1, with an explicit `jq` variable binding:
+
+   ```bash
+   ALREADY=$(printf '%s' "$ISSUE_JSON" | jq -r --arg login "$LOGIN" 'any(.assignees[]; .login == $login)')
+   ```
+
+   If `ALREADY == "true"`, set status to `@<LOGIN> (already assigned)` and skip to Phase 3.
+
+4. Otherwise attempt the assignment with explicit stderr capture:
+
+   ```bash
+   STDERR=$(gh issue edit "$NUMBER" -R "$REPO" --add-assignee "$LOGIN" 2>&1 >/dev/null)
+   EDIT_EXIT=$?
+   ```
+
+5. Post-verify via a fresh read, because `gh issue edit --add-assignee` returns exit 0 even when GitHub silently drops the addition (caller lacks `triage`/`write` permission, or the issue is already at the 10-assignee limit):
+
+   ```bash
+   VERIFIED=$(gh issue view "$NUMBER" -R "$REPO" --json assignees --jq --arg login "$LOGIN" 'any(.assignees[]; .login == $login)' 2>/dev/null)
+   ```
+
+   - `EDIT_EXIT == 0` AND `VERIFIED == "true"` → `@<LOGIN> (just assigned)`
+   - `EDIT_EXIT == 0` AND `VERIFIED != "true"` → `unassigned — permission denied or assignee limit reached`
+   - `EDIT_EXIT != 0` → `unassigned — gh edit error: <first line of $STDERR>`
+
+## Phase 3: Output
 
 Output ONLY the structured block. No preamble or commentary:
 
@@ -36,6 +87,7 @@ Output ONLY the structured block. No preamble or commentary:
 **Title:** [title]
 **Status:** [state]
 **Labels:** [labels]
+**Assignee:** [status from Phase 2]
 
 ### Description
 [body]

--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -109,7 +109,7 @@ Pack codebase (MCP direct call):
 Agent 1 (resolve-issue-context):
   Use the Agent tool with:
   - `subagent_type`: "autopilot:resolve-issue-context"
-  - `prompt`: "Fetch issue context. Input type: github-issue. Issue ID: [id]. Repository: [owner/repo]. Fetch parent/siblings: true."
+  - `prompt`: "Fetch issue context. Input type: github-issue. Issue ID: [id]. Repository: [owner/repo]. Fetch parent/siblings: true. Auto-assign current user: true."
   - `description`: "Resolve issue context"
 
 Agent 2 (search-codebase-todos):

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -114,7 +114,7 @@ Pack codebase (MCP direct call):
 Agent 1 (resolve-issue-context):
   Use the Agent tool with:
   - `subagent_type`: "autopilot:resolve-issue-context"
-  - `prompt`: "Fetch issue context. Input type: github-issue. Issue ID: [id]. Repository: [owner/repo]. Fetch parent/siblings: true."
+  - `prompt`: "Fetch issue context. Input type: github-issue. Issue ID: [id]. Repository: [owner/repo]. Fetch parent/siblings: true. Auto-assign current user: true."
   - `description`: "Resolve issue context"
 
 Agent 2 (search-codebase-todos):


### PR DESCRIPTION
When `/autopilot:plan` or `/autopilot:run` resolves a GitHub issue input, they now pass an `Auto-assign current user: true` flag to the shared `resolve-issue-context` agent, which assigns the authenticated user to that issue (idempotently) so other contributors can see the work is taken. The outcome surfaces as a one-line `**Assignee:**` row inside the existing Issue Context block. Other callers (e.g. `pr:review`) leave the flag off and the agent stays read-only.

- Auto-assignment is opt-in: the agent runs Phase 2 and emits the `**Assignee:**` line only when the caller's prompt contains `Auto-assign current user: true`
- `plan/SKILL.md` and `run/SKILL.md` pass the flag; `pr:review/SKILL.md`'s prompt is unchanged so the review-only workflow does not mutate issues
- Post-verifies the assignment with `gh issue view --json assignees | jq -r --arg login "$LOGIN" ...` (the `gh --jq` flag does not pass `--arg` through to jq, so the JSON is piped through real jq)
- Surfaces silent no-ops as `unassigned — permission denied or assignee limit reached` (missing triage permission, 10-assignee cap)
- Skips cleanly when `gh` is unauthenticated or the issue is closed; deliberately drops the email-fallback search to avoid privacy and rate-limit hazards
- Plugin version bumped to 0.5.0 (minor: new opt-in capability, no breaking changes)

---

**Issues:**

Closes #50