### PR TITLE
Require an H1 title at the top of every generated plan file

### DIFF
--- a/claude-plugins/autopilot/skills/plan-bun/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-bun/SKILL.md
@@ -131,7 +131,11 @@ After all expert reviews complete, call TaskUpdate to set task 5 ("Review with e
 
 **FIRST**, call TaskUpdate to set task 6 ("Output final plan") to `status: "in_progress"`.
 
+The template below starts with `# <Title>` — see the canonical "Plan File Header (MANDATORY)" rule in `plan/SKILL.md` `## Common Instructions` for title derivation and section ordering.
+
 ```
+# <Title>
+
 ## Summary
 [1-2 sentences: what and why]
 Score: [X]/100

--- a/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
@@ -136,7 +136,11 @@ After all expert reviews complete, call TaskUpdate to set task 5 ("Review with e
 
 **FIRST**, call TaskUpdate to set task 6 ("Output final plan") to `status: "in_progress"`.
 
+The template below starts with `# <Title>` — see the canonical "Plan File Header (MANDATORY)" rule in `plan/SKILL.md` `## Common Instructions` for title derivation and section ordering.
+
 ```
+# <Title>
+
 ## Summary
 [1-2 sentences: what and why]
 Score: [X]/100

--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -195,6 +195,29 @@ Run multiple `resolve-library-id` calls in parallel, then multiple `query-docs` 
 
 Use all available documentation sources. If a source is unavailable or returns no results, continue with remaining sources. Each tool provides different information (structured docs, official references, real-world patterns, reasoning).
 
+### Plan File Header (MANDATORY)
+
+Every plan file written by any stack skill MUST begin with a single `# <Title>` line on line 1, followed by a blank line. This rule is stack-agnostic and supersedes any stack-specific Phase 5 template that omits the header.
+
+**Title derivation:**
+
+- For `github-issue` inputs: use the GitHub issue title verbatim as resolved in Phase 0 (no `#<n>` prefix, no truncation).
+- For `plain description` inputs: paraphrase the user's task description into a single sentence (≤80 characters), sentence case.
+
+**Section ordering** when a `## Pre-Implementation` block is also emitted (see Phase 2):
+
+```
+# <Title>
+
+## Pre-Implementation
+...
+
+## Summary
+...
+```
+
+When no Pre-Implementation block is emitted, the order is `# <Title>` → blank line → `## Summary` → rest of plan.
+
 ### CLAUDE.md Compliance
 
 Map each planned change to project rules defined in CLAUDE.md.
@@ -270,7 +293,7 @@ Tool parameters:
 
 ### If on `main` branch OR `worktreeNeedsBranch` is true
 
-Add `## Pre-Implementation` as the FIRST section of the plan file (before `## Summary`). The block content depends on input type from Phase 0.
+Insert `## Pre-Implementation` directly below the `# <Title>` line (which per the Plan File Header rule above must already be line 1) and above `## Summary`. The block content depends on input type from Phase 0.
 
 #### Input type is `github-issue` (bare number, `#`-prefixed number, or GitHub issue URL)
 


### PR DESCRIPTION
Makes the H1 title line mandatory in every plan file produced by the autopilot plan skills, so downstream renderers (e.g. the symbiot ExitPlanMode viewer) always have an authoritative document title to surface instead of falling back to filesystem-derived identifiers. The rule is stack-agnostic and lives in the dispatcher skill, so all current and future stack skills inherit it.

- Add a new stack-agnostic Plan File Header (MANDATORY) section in plan/SKILL.md Common Instructions that mandates the # <Title> line on line 1, defines title derivation for github-issue and plain-description inputs, and pins section ordering with Pre-Implementation between the H1 and ## Summary
- Rewrite the Phase 2 wording in plan/SKILL.md so ## Pre-Implementation is inserted directly below the H1 instead of being declared the FIRST section, which previously displaced the H1
- Prepend # <Title> to the Phase 5 fenced output templates in plan-bun/SKILL.md and plan-nodejs-react/SKILL.md and cross-reference the canonical rule

---

**Issues:**

Closes #52

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a mandatory H1 title on line 1 of every generated plan so viewers always have a reliable document title. Standardizes title derivation and section order across all stack skills.

- **New Features**
  - Add stack-agnostic “Plan File Header (MANDATORY)” in `plan/SKILL.md`: require `# <Title>` at line 1, define title derivation for `github-issue` and plain description, and pin ordering with `## Pre-Implementation` above `## Summary`.
  - Update Phase 2 instructions to place `## Pre-Implementation` directly under the H1.
  - Prepend `# <Title>` in Phase 5 templates for `plan-bun` and `plan-nodejs-react`, with a reference to the canonical rule.

<sup>Written for commit 10448534e081fa1db275c80cc4a32cff1e8a4e62. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/53?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

