### PR TITLE
Add pre-mortem reviewer and steelmanned intent to plan skills

### DIFF
--- a/claude-plugins/autopilot/.claude-plugin/plugin.json
+++ b/claude-plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Autopilot: plan, implement, commit, PR, and monitor — skills and agents for AI-assisted development workflows",
   "author": {
     "name": "Tony Vi",

--- a/claude-plugins/autopilot/agents/expert-review.md
+++ b/claude-plugins/autopilot/agents/expert-review.md
@@ -46,13 +46,13 @@ Repeat until the target is met or you determine the gaps are acceptable trade-of
 
 ## Phase 4: Output
 
-Output ONLY the structured report block. No preamble, no explanation outside this format:
+Output ONLY the structured report block. No preamble, no explanation outside this format. Key findings MUST be capped at 3–5 entries — depth over breadth. Stack minor objections together rather than listing them separately; if you have more than 5 candidate findings, drop the weakest until you are at 5.
 
 ```
 ### [Your Expert Role]
 - Score: [X]/100
 - Verdict: Approved | Needs revision
-- Key findings:
+- Key findings (3–5):
   - [Finding 1]
   - [Finding 2]
   - [Finding 3]

--- a/claude-plugins/autopilot/skills/plan-bun/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-bun/SKILL.md
@@ -101,14 +101,15 @@ After scoring completes, call TaskUpdate to set task 4 ("Validate plan scores") 
 
 **FIRST**, call TaskUpdate to set task 5 ("Review with experts") to `status: "in_progress"`.
 
-**Select 2-3 most relevant experts** based on task scope:
+**Always include the Pre-mortem Analyst**, then select 2-3 additional experts based on task scope:
 
-| Expert                            | When to Include                        | Focus Areas                                         |
-| --------------------------------- | -------------------------------------- | --------------------------------------------------- |
-| **Principal Bun/NodeJS Engineer** | Server-side logic, APIs                | Performance, async, error handling, memory          |
-| **Principal DevOps Engineer**     | GitHub API, GitHub Actions workflows   | Env vars, secrets, scaling, monitoring, CI/CD       |
-| **Principal SRE**                 | Production systems, Kubernetes, Docker | Scalability, metrics, stability, performance        |
-| **Boring Tech Writer**            | User-facing changes                    | README clarity, usage instructions, JSDoc, comments |
+| Expert                            | When to Include                        | Focus Areas                                                                                                        |
+| --------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Pre-mortem Analyst**            | Always (default reviewer)              | Imagine the plan failed 6 months from now — return ranked failure narratives, early warning signs, and mitigations |
+| **Principal Bun/NodeJS Engineer** | Server-side logic, APIs                | Performance, async, error handling, memory                                                                         |
+| **Principal DevOps Engineer**     | GitHub API, GitHub Actions workflows   | Env vars, secrets, scaling, monitoring, CI/CD                                                                      |
+| **Principal SRE**                 | Production systems, Kubernetes, Docker | Scalability, metrics, stability, performance                                                                       |
+| **Boring Tech Writer**            | User-facing changes                    | README clarity, usage instructions, JSDoc, comments                                                                |
 
 For each selected expert, launch a `autopilot:expert-review` sub-agent. Launch all experts **in parallel** (single message, multiple Agent tool calls):
 
@@ -118,6 +119,7 @@ Use the Agent tool with:
 - `prompt`: "You are a [Expert Role]. Review this implementation plan.
   Focus areas: [from table above].
   Scoring target: 95+.
+  Limit your report to the 3–5 strongest findings — depth over breadth.
 
   [full plan text from Phase 5 output]"
 - `description`: "Expert review: [Role]"
@@ -138,6 +140,7 @@ The template below starts with `# <Title>` — see the canonical "Plan File Head
 
 ## Summary
 [1-2 sentences: what and why]
+Steelmanned intent: [verbatim from Phase 0 Steelmanned Intent block]
 Score: [X]/100
 
 <!-- Include the ## Diagrams section only if the change is architectural/visual/UI/flow-related. Generate diagrams via Skill(autopilot:ascii-schemas) per the plan skill's "Visualize with ASCII Schemas" guidance. -->

--- a/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
@@ -101,19 +101,20 @@ After scoring completes, call TaskUpdate to set task 4 ("Validate plan scores") 
 
 **FIRST**, call TaskUpdate to set task 5 ("Review with experts") to `status: "in_progress"`.
 
-**Select 2-3 most relevant experts** based on task scope:
+**Always include the Pre-mortem Analyst**, then select 2-3 additional experts based on task scope:
 
-| Expert                         | When to Include         | Focus Areas                                           |
-| ------------------------------ | ----------------------- | ----------------------------------------------------- |
-| **Principal Node.js Engineer** | Server-side logic, APIs | Performance, async, error handling, memory            |
-| **DBA**                        | Database changes        | Query efficiency, indexes, transactions, migrations   |
-| **Principal DevOps Engineer**  | Infra, env, deployment  | Env vars, scaling, monitoring, CI/CD                  |
-| **Senior Frontend Engineer**   | UI changes              | React patterns, state, UX, accessibility              |
-| **Senior QA Engineer**         | Any code change         | Test coverage, edge cases, regression risk            |
-| **CISO**                       | Auth, data, APIs, infra | Security architecture, OWASP, compliance, reliability |
-| **Principal Designer**         | UI/UX changes           | Fast, beautiful, simple, minimal; design patterns     |
-| **Principal SRE**              | Production systems      | Scalability, metrics, stability, performance          |
-| **Boring Tech Writer**         | User-facing changes     | README clarity, usage instructions, JSDoc, comments   |
+| Expert                         | When to Include           | Focus Areas                                                                                                        |
+| ------------------------------ | ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Pre-mortem Analyst**         | Always (default reviewer) | Imagine the plan failed 6 months from now — return ranked failure narratives, early warning signs, and mitigations |
+| **Principal Node.js Engineer** | Server-side logic, APIs   | Performance, async, error handling, memory                                                                         |
+| **DBA**                        | Database changes          | Query efficiency, indexes, transactions, migrations                                                                |
+| **Principal DevOps Engineer**  | Infra, env, deployment    | Env vars, scaling, monitoring, CI/CD                                                                               |
+| **Senior Frontend Engineer**   | UI changes                | React patterns, state, UX, accessibility                                                                           |
+| **Senior QA Engineer**         | Any code change           | Test coverage, edge cases, regression risk                                                                         |
+| **CISO**                       | Auth, data, APIs, infra   | Security architecture, OWASP, compliance, reliability                                                              |
+| **Principal Designer**         | UI/UX changes             | Fast, beautiful, simple, minimal; design patterns                                                                  |
+| **Principal SRE**              | Production systems        | Scalability, metrics, stability, performance                                                                       |
+| **Boring Tech Writer**         | User-facing changes       | README clarity, usage instructions, JSDoc, comments                                                                |
 
 For each selected expert, launch a `autopilot:expert-review` sub-agent. Launch all experts **in parallel** (single message, multiple Agent tool calls):
 
@@ -123,6 +124,7 @@ Use the Agent tool with:
 - `prompt`: "You are a [Expert Role]. Review this implementation plan.
   Focus areas: [from table above].
   Scoring target: 95+.
+  Limit your report to the 3–5 strongest findings — depth over breadth.
 
   [full plan text from Phase 5 output]"
 - `description`: "Expert review: [Role]"
@@ -143,6 +145,7 @@ The template below starts with `# <Title>` — see the canonical "Plan File Head
 
 ## Summary
 [1-2 sentences: what and why]
+Steelmanned intent: [verbatim from Phase 0 Steelmanned Intent block]
 Score: [X]/100
 
 <!-- Include the ## Diagrams section only if the change is architectural/visual/UI/flow-related. Generate diagrams via Skill(autopilot:ascii-schemas) per the plan skill's "Visualize with ASCII Schemas" guidance. -->

--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -143,7 +143,20 @@ Present the `resolve-issue-context` agent's output along with TODO search result
 [output from search-codebase-todos agent]
 ```
 
-After completing the Issue Context Output, call TaskUpdate to set task 1 ("Resolve input") to `status: "completed"`.
+### Steelmanned Intent
+
+After the issue context and TODOs, emit a single-line **Steelmanned intent**: the user's request restated in its strongest form, with any vague language tightened. One sentence, ≤200 characters. This becomes the stable target for the stack skill's expert reviewers and lands verbatim in the Phase 5 plan file `## Summary` block.
+
+Format:
+
+```
+### Steelmanned Intent
+[one-sentence restatement of what success looks like, in the user's strongest framing]
+```
+
+Derive from: the resolved issue title + body (for `github-issue` input), or the task description (for `plain description` input). Do not invent scope the user did not request.
+
+After completing the Issue Context Output and Steelmanned Intent, call TaskUpdate to set task 1 ("Resolve input") to `status: "completed"`.
 
 ## Preflight Check
 


### PR DESCRIPTION
The autopilot plan skills now run an always-on pre-mortem review pass and carry a steelmanned restatement of the user's intent through to the final plan file, making expert reviews focused and grounded.

- Pre-mortem Analyst added as default Phase 4 reviewer in plan-bun and plan-nodejs-react — imagines the plan failed six months out and returns ranked failure narratives with mitigations
- plan/SKILL.md Phase 0 emits a one-line Steelmanned Intent block (user's request restated in strongest form); both stack skills mirror it into the Phase 5 `## Summary`
- expert-review sub-agent output capped at 3–5 strongest findings so the silent merge-back step into the plan stays manageable

---

**Issues:**

Closes #54

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an always-on Pre‑mortem Analyst reviewer to `plan-bun` and `plan-nodejs-react`. Carried a one‑line Steelmanned Intent from Phase 0 into Phase 5 summaries, capped `autopilot:expert-review` findings to 3–5, and bumped `autopilot` to 0.5.2.

<sup>Written for commit 47edf2974e53e89796ddbc2dd69b879f1b6a6079. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/55?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

