### PR TITLE
Adopt Karpathy guidelines in rules and plan skills

### DIFF
--- a/claude-plugins/autopilot/skills/plan-bun/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-bun/SKILL.md
@@ -148,10 +148,13 @@ Score: [X]/100
 [ASCII diagram(s) generated via Skill(autopilot:ascii-schemas) — architecture, data flow, sequence, topology, UI layout, or component interaction. Omit this section entirely for pure logic/refactor changes.]
 
 ## Implementation Steps
+
+Every step MUST include a `verify:` line — an observable check (test name, command, or behavior).
+
 1. [ ] [Action] in `path/to/file.ts`
-   - verify: [observable check — test name, command, or behavior]
+   - verify: `bun test path/to/file.test.ts` passes
 2. [ ] [Action] in `path/to/file.ts`
-   - verify: [observable check — test name, command, or behavior]
+   - verify: CLI prints the new flag in `--help` output
 
 ## Files
 - `path/to/file.ts:NN` - [what changes]

--- a/claude-plugins/autopilot/skills/plan-bun/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-bun/SKILL.md
@@ -78,13 +78,13 @@ After completing deep analysis, call TaskUpdate to set task 3 ("Analyze codebase
 
 Rate the plan (20 points each dimension = 100 total):
 
-| Dimension        | Criteria                                                     | Score |
-| ---------------- | ------------------------------------------------------------ | ----- |
-| **Alignment**    | Follows CLAUDE.md, project patterns, naming conventions      | /20   |
-| **Completeness** | All requirements addressed, no missing steps                 | /20   |
-| **Type Safety**  | Proper types, Zod schemas, no unsafe `as` assertions         | /20   |
-| **Testability**  | Clear test strategy, edge cases identified                   | /20   |
-| **Simplicity**   | Minimal code, reuses existing functions, no over-engineering | /20   |
+| Dimension        | Criteria                                                                                                                            | Score |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **Alignment**    | Follows CLAUDE.md, project patterns, naming conventions                                                                             | /20   |
+| **Completeness** | All requirements addressed, no missing steps                                                                                        | /20   |
+| **Type Safety**  | Proper types, Zod schemas, no unsafe `as` assertions                                                                                | /20   |
+| **Testability**  | Clear test strategy, edge cases identified                                                                                          | /20   |
+| **Simplicity**   | Minimal code, reuses existing functions, no over-engineering, every change traces to steelmanned intent, no opportunistic refactors | /20   |
 
 ### Auto-Iteration Protocol (Target: 95+)
 
@@ -149,8 +149,9 @@ Score: [X]/100
 
 ## Implementation Steps
 1. [ ] [Action] in `path/to/file.ts`
-   - Test: [inline test description if needed]
+   - verify: [observable check — test name, command, or behavior]
 2. [ ] [Action] in `path/to/file.ts`
+   - verify: [observable check — test name, command, or behavior]
 
 ## Files
 - `path/to/file.ts:NN` - [what changes]

--- a/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
@@ -153,10 +153,13 @@ Score: [X]/100
 [ASCII diagram(s) generated via Skill(autopilot:ascii-schemas) — architecture, data flow, sequence, topology, UI layout, or component interaction. Omit this section entirely for pure logic/refactor changes.]
 
 ## Implementation Steps
+
+Every step MUST include a `verify:` line — an observable check (test name, command, or behavior).
+
 1. [ ] [Action] in `path/to/file.ts`
-   - verify: [observable check — test name, command, or behavior]
+   - verify: `vitest run path/to/file.test.ts` passes
 2. [ ] [Action] in `path/to/file.ts`
-   - verify: [observable check — test name, command, or behavior]
+   - verify: rendered component shows the new label in the page
 
 ## Files
 - `path/to/file.ts:NN` - [what changes]

--- a/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
@@ -78,13 +78,13 @@ After completing deep analysis, call TaskUpdate to set task 3 ("Analyze codebase
 
 Rate the plan (20 points each dimension = 100 total):
 
-| Dimension        | Criteria                                                     | Score |
-| ---------------- | ------------------------------------------------------------ | ----- |
-| **Alignment**    | Follows CLAUDE.md, project patterns, naming conventions      | /20   |
-| **Completeness** | All requirements addressed, no missing steps                 | /20   |
-| **Type Safety**  | Proper types, Zod schemas, no unsafe `as` assertions         | /20   |
-| **Testability**  | Clear test strategy, edge cases identified                   | /20   |
-| **Simplicity**   | Minimal code, reuses existing functions, no over-engineering | /20   |
+| Dimension        | Criteria                                                                                                                            | Score |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **Alignment**    | Follows CLAUDE.md, project patterns, naming conventions                                                                             | /20   |
+| **Completeness** | All requirements addressed, no missing steps                                                                                        | /20   |
+| **Type Safety**  | Proper types, Zod schemas, no unsafe `as` assertions                                                                                | /20   |
+| **Testability**  | Clear test strategy, edge cases identified                                                                                          | /20   |
+| **Simplicity**   | Minimal code, reuses existing functions, no over-engineering, every change traces to steelmanned intent, no opportunistic refactors | /20   |
 
 ### Auto-Iteration Protocol (Target: 95+)
 
@@ -154,8 +154,9 @@ Score: [X]/100
 
 ## Implementation Steps
 1. [ ] [Action] in `path/to/file.ts`
-   - Test: [inline test description if needed]
+   - verify: [observable check — test name, command, or behavior]
 2. [ ] [Action] in `path/to/file.ts`
+   - verify: [observable check — test name, command, or behavior]
 
 ## Files
 - `path/to/file.ts:NN` - [what changes]

--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -156,7 +156,27 @@ Format:
 
 Derive from: the resolved issue title + body (for `github-issue` input), or the task description (for `plain description` input). Do not invent scope the user did not request.
 
-After completing the Issue Context Output and Steelmanned Intent, call TaskUpdate to set task 1 ("Resolve input") to `status: "completed"`.
+### Assumptions & Open Questions
+
+After the Steelmanned Intent, emit two short blocks. This forces interpretive choices into the open instead of letting them propagate silently into the plan.
+
+**Assumptions** — up to 5 bullets. Each names an interpretation being made that the user could disagree with (e.g., "treating this as a read-only API, not a webhook"). If none, write "none".
+
+**Open Questions** — material ambiguities that would change the design. If any open question is load-bearing (the plan's structure depends on the answer), raise it via `AskUserQuestion` BEFORE delegating to the stack skill in Phase 1. If none are load-bearing, state "none" and proceed.
+
+Format:
+
+```
+### Assumptions
+- [interpretation 1]
+- [interpretation 2]
+
+### Open Questions
+- [ambiguity 1] — load-bearing? yes/no
+- [ambiguity 2] — load-bearing? yes/no
+```
+
+After completing the Issue Context Output, Steelmanned Intent, and Assumptions & Open Questions, call TaskUpdate to set task 1 ("Resolve input") to `status: "completed"`.
 
 ## Preflight Check
 

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -35,7 +35,11 @@ Before making any changes:
 - 👤 Every line of code must be used or removed
 - 👤 The fewer lines of code the better
 - 👤 Avoid code duplication - maximize reuse
-- 👤 Do not over-engineer - only make directly requested changes
+- 👤 Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
+- 👤 Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
+- 👤 Define verifiable success criteria before implementing (test, command, or observable behavior)
+- 👤 Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
+- 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - 👤 Be consistent with existing code style
 - 👤 Write failing tests first, then write code to pass tests
 - 👤 Run tests after any code changes

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -35,7 +35,11 @@ Before making any changes:
 - 👤 Every line of code must be used or removed
 - 👤 The fewer lines of code the better
 - 👤 Avoid code duplication - maximize reuse
-- 👤 Do not over-engineer - only make directly requested changes
+- 👤 Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
+- 👤 Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
+- 👤 Define verifiable success criteria before implementing (test, command, or observable behavior)
+- 👤 Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
+- 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - 👤 Be consistent with existing code style
 - 👤 Do not remove existing code/comments unless necessary
 - 👤 Write plan before changes, not report after

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -35,7 +35,11 @@ Before making any changes:
 - 👤 Every line of code must be used or removed
 - 👤 The fewer lines of code the better
 - 👤 Avoid code duplication - maximize reuse
-- 👤 Do not over-engineer - only make directly requested changes
+- 👤 Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
+- 👤 Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
+- 👤 Define verifiable success criteria before implementing (test, command, or observable behavior)
+- 👤 Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
+- 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - 👤 Be consistent with existing code style
 - 👤 Write failing tests first, then write code to pass tests
 - 👤 Run tests after any code changes

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -35,7 +35,11 @@ Before making any changes:
 - 👤 Every line of code must be used or removed
 - 👤 The fewer lines of code the better
 - 👤 Avoid code duplication - maximize reuse
-- 👤 Do not over-engineer - only make directly requested changes
+- 👤 Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
+- 👤 Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
+- 👤 Define verifiable success criteria before implementing (test, command, or observable behavior)
+- 👤 Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
+- 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - 👤 Be consistent with existing code style
 - 👤 Write failing tests first, then write code to pass tests
 - 👤 Run tests after any code changes


### PR DESCRIPTION
Adopts Karpathy's behavioral guidelines for LLM coding agents into `rules/*.md` and the autopilot plan workflow, plugging gaps that let common LLM coding failures (silent interpretation, speculative abstraction, opportunistic refactors, vague success criteria) slip through unchallenged. De-duplicated against existing §1 rules so each new bullet adds real coverage rather than restating what's already there.

- Expanded `Do not over-engineer` in `rules/*.md` §1 with concrete sub-rules (no single-use abstractions, no unrequested configurability, no error handling for impossible scenarios, rewrite 200→50)
- Added four new bullets to `rules/*.md` §1: surface assumptions and ambiguities, define verifiable success criteria, trace every change to the request, only delete orphans your changes created
- Added `Assumptions & Open Questions` block to `plan/SKILL.md` Phase 0 after Steelmanned Intent, with a load-bearing-ambiguity gate that raises via `AskUserQuestion` before stack delegation
- Renamed per-step inline `Test:` to required `verify:` in `plan-bun` and `plan-nodejs-react` Phase 5 implementation step template
- Folded surgical-scope criteria (traces to steelmanned intent, no opportunistic refactors) into the Simplicity row of Phase 3 scoring table in both stack skills

---

**Release notes:**

- Rules now require surfacing assumptions, defining verifiable success criteria before coding, and limiting changes to the scope of the request
- Plan skill lists assumptions and raises load-bearing open questions before generating an implementation plan
- Implementation plans now require a `verify:` line per step (observable check — test name, command, or behavior)

---

**Issues:**

Closes #56

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Karpathy-style guardrails across `rules/*.md` and autopilot plan skills to reduce silent interpretations, over-engineering, and opportunistic refactors; closes #56. Adds assumption surfacing, explicit success checks, and per-step `verify:` with clear examples in implementation templates.

- **New Features**
  - Expanded “Do not over-engineer” with concrete sub-rules: no single-use abstractions, no unrequested configurability, no impossible error handling, rewrite 200→50.
  - New rules: surface assumptions/ambiguities, define verifiable success criteria, trace each change to the request, delete only orphans created by your changes.
  - Added “Assumptions & Open Questions” to `plan/SKILL.md` with a load-bearing ambiguity gate via `AskUserQuestion` before stack delegation.
  - Implementation updates: require per-step `verify:` in `plan-bun` and `plan-nodejs-react`, add an explicit “every step MUST include a verify line” note, and show distinct verify examples (test command + observable behavior/UI); Simplicity scoring enforces trace-to-intent and no opportunistic refactors.

<sup>Written for commit 8dc35e8e152c8fe425ac1b97773709d6bbb950d9. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/57?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

