### PR TITLE
Link review finding rule codes to their source agent files

### DIFF
--- a/.github/actions/code-review-action/src/reviewFanout.test.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.test.ts
@@ -149,8 +149,8 @@ describe("loadReviewAgents", () => {
     const agents = await loadReviewAgents(pluginDir);
     const names = agents.map((a) => a.subagent_type).sort();
 
-    expect(names).toEqual(["platform:pr:review:correctness", "platform:pr:review:surface-naming"]);
-    const correctness = agents.find((a) => a.subagent_type === "platform:pr:review:correctness");
+    expect(names).toEqual(["autopilot:pr:review:correctness", "autopilot:pr:review:surface-naming"]);
+    const correctness = agents.find((a) => a.subagent_type === "autopilot:pr:review:correctness");
     expect(correctness?.model).toBe("sonnet");
     expect(correctness?.body).toBe("correctness body");
   });

--- a/.github/actions/code-review-action/src/reviewFanout.test.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.test.ts
@@ -95,7 +95,7 @@ describe("detectStack", () => {
   test("reads agents.rules from package.json", async () => {
     await writeFile(
       join(dir, "package.json"),
-      JSON.stringify({ agents: { rules: "Bun", language: "typescript" } })
+      JSON.stringify({ agents: { rules: "Bun", language: "typescript" } }),
     );
     expect(await detectStack(dir)).toBe("Bun");
   });
@@ -136,11 +136,11 @@ describe("loadReviewAgents", () => {
   test("loads only pr:review:* files and parses frontmatter", async () => {
     await seed(
       "pr:review:correctness.md",
-      "---\nname: pr:review:correctness\nmodel: sonnet\n---\ncorrectness body"
+      "---\nname: pr:review:correctness\nmodel: sonnet\n---\ncorrectness body",
     );
     await seed(
       "pr:review:surface-naming.md",
-      "---\nname: pr:review:surface-naming\nmodel: haiku\n---\nsurface body"
+      "---\nname: pr:review:surface-naming\nmodel: haiku\n---\nsurface body",
     );
     // Unrelated file must be filtered out
     await seed("pr:review.md", "should be excluded");
@@ -149,7 +149,10 @@ describe("loadReviewAgents", () => {
     const agents = await loadReviewAgents(pluginDir);
     const names = agents.map((a) => a.subagent_type).sort();
 
-    expect(names).toEqual(["autopilot:pr:review:correctness", "autopilot:pr:review:surface-naming"]);
+    expect(names).toEqual([
+      "autopilot:pr:review:correctness",
+      "autopilot:pr:review:surface-naming",
+    ]);
     const correctness = agents.find((a) => a.subagent_type === "autopilot:pr:review:correctness");
     expect(correctness?.model).toBe("sonnet");
     expect(correctness?.body).toBe("correctness body");
@@ -158,7 +161,7 @@ describe("loadReviewAgents", () => {
   test("propagates allowed tools when declared", async () => {
     await seed(
       "pr:review:rfc-compliance.md",
-      "---\nname: pr:review:rfc-compliance\nmodel: sonnet\ntools: Bash(gh *)\n---\nbody"
+      "---\nname: pr:review:rfc-compliance\nmodel: sonnet\ntools: Bash(gh *)\n---\nbody",
     );
     const agents = await loadReviewAgents(pluginDir);
     expect(agents[0]?.allowedTools).toEqual(["Bash(gh *)"]);
@@ -167,10 +170,9 @@ describe("loadReviewAgents", () => {
   test("leaves allowedTools undefined when frontmatter omits tools", async () => {
     await seed(
       "pr:review:correctness.md",
-      "---\nname: pr:review:correctness\nmodel: sonnet\n---\nbody"
+      "---\nname: pr:review:correctness\nmodel: sonnet\n---\nbody",
     );
     const agents = await loadReviewAgents(pluginDir);
     expect(agents[0]?.allowedTools).toBeUndefined();
   });
 });
-

--- a/.github/actions/code-review-action/src/reviewFanout.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.ts
@@ -134,7 +134,7 @@ export async function loadReviewAgents(pluginDir: string): Promise<AgentDefiniti
         model: parsed.model,
         allowedTools: parsed.allowedTools,
       };
-    })
+    }),
   );
 }
 
@@ -210,7 +210,7 @@ function extractFinalText(message: SDKMessage): string | undefined {
 async function runSubagent(
   ctx: FanoutContext,
   agent: AgentDefinition,
-  userPrompt: string
+  userPrompt: string,
 ): Promise<SubagentResult> {
   const childLog = ctx.log.child({ orchestrator_subagent: agent.subagent_type });
   const start = performance.now();
@@ -229,7 +229,7 @@ async function runSubagent(
       query({
         prompt: userPrompt,
         options: buildSubagentOptions(ctx, agent, abortController),
-      })
+      }),
     );
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
@@ -241,7 +241,7 @@ async function runSubagent(
   const durationMs = Math.round(performance.now() - start);
   childLog.info(
     { duration_ms: durationMs, markdown_bytes: markdown.length, error },
-    "Sub-agent query finished."
+    "Sub-agent query finished.",
   );
   return { subagent_type: agent.subagent_type, markdown, duration_ms: durationMs, error };
 }
@@ -249,7 +249,7 @@ async function runSubagent(
 /** Stream SDK messages through the logger; return the last assistant text. */
 async function streamAssistantText(
   log: pino.Logger,
-  stream: AsyncIterable<SDKMessage>
+  stream: AsyncIterable<SDKMessage>,
 ): Promise<string> {
   let markdown = "";
   for await (const message of stream) {
@@ -264,7 +264,7 @@ async function streamAssistantText(
 function buildSubagentOptions(
   ctx: FanoutContext,
   agent: AgentDefinition,
-  abortController: AbortController
+  abortController: AbortController,
 ): Parameters<typeof query>[0]["options"] {
   return {
     model: agent.model ?? ctx.fallbackModel,
@@ -300,7 +300,7 @@ function buildSubagentOptions(
 export async function runReviewFanout(ctx: FanoutContext): Promise<SubagentResult[]> {
   ctx.log.info(
     { repo: ctx.repo, pr_number: ctx.prNumber, plugin_dir: ctx.pluginDir },
-    "Parallel review fan-out starting."
+    "Parallel review fan-out starting.",
   );
 
   const [agents, diff, stack] = await Promise.all([
@@ -311,7 +311,7 @@ export async function runReviewFanout(ctx: FanoutContext): Promise<SubagentResul
 
   ctx.log.info(
     { agent_count: agents.length, diff_bytes: diff.length, stack },
-    "Agent definitions and PR context loaded."
+    "Agent definitions and PR context loaded.",
   );
 
   const userPrompt = buildSubagentPrompt(stack, diff);
@@ -333,7 +333,7 @@ export async function runReviewFanout(ctx: FanoutContext): Promise<SubagentResul
       agent_count: results.length,
       failed_count: failed,
     },
-    "Parallel review fan-out complete."
+    "Parallel review fan-out complete.",
   );
 
   return results;

--- a/.github/actions/code-review-action/src/reviewFanout.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.ts
@@ -128,7 +128,7 @@ export async function loadReviewAgents(pluginDir: string): Promise<AgentDefiniti
       const { fm, body } = splitFrontmatter(content);
       const parsed = parseAgentFrontmatter(fm);
       return {
-        subagent_type: `platform:${filename.replace(/\.md$/, "")}`,
+        subagent_type: `autopilot:${filename.replace(/\.md$/, "")}`,
         filename,
         body: body.trim(),
         model: parsed.model,

--- a/claude-plugins/autopilot/skills/pr:review/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:review/SKILL.md
@@ -279,12 +279,41 @@ Replace `<path>` with the env var value and `<one-line diagnostic>` with the spe
 
 After all review results are available — whether produced in Phase 2.3 (in-model) or Phase 2.4 (pre-computed) — apply the same aggregation pipeline:
 
-1. Parse each review block's structured output (findings with severity emoji, file, line, **rule** code, detail). The rule code is the value of the `- **Rule:**` field (regex anchor: `^- \*\*Rule:\*\* ([A-Z0-9-]+)$`). If an agent omits the field, treat the rule as `UNSPECIFIED`.
+1. Parse each review block's structured output (findings with severity emoji, file, line, **rule** code, detail). The rule code is the value of the `- **Rule:**` field (regex anchor: `^- \*\*Rule:\*\* ([A-Z0-9-]+)$`). If an agent omits the field, the finding has no rule code — do NOT substitute `UNSPECIFIED`; the suffix is simply omitted in step 5.
 2. If a review block indicates the agent failed or timed out (in-model) or had `error` set (pre-computed), skip that dimension — do not block the review.
-3. Deduplicate findings by `(path, line)` — if two agents flag the same location, keep the higher severity (🚧 > 🙋‍♂️ > 💡) and merge descriptions if complementary. Merge rule codes into a single comma-separated list inside one bracket (e.g. `[CHECK-BUG-002, CHECK-AI-002]`).
+3. Deduplicate findings by `(path, line)` — if two agents flag the same location, keep the higher severity (🚧 > 🙋‍♂️ > 💡) and merge descriptions if complementary. Merge rule codes into the linked form inside one bracket pair, comma-separated, where each code keeps its own URL: `[[CHECK-BUG-002](url-a), [CHECK-AI-002](url-b)]`. URLs are resolved via §2.6 Rule-to-URL Mapping.
 4. Merge all findings into a single list ordered by severity: blockers first, then suggestions, then nitpicks.
-5. Propagate the rule code to the final review: append ` [<RULE>]` to the end of each finding line in `reviewComment`, and to the end of each `inlineComments.body`. The emoji stays first so downstream severity filters keep working.
+5. Propagate the rule code to the final review: append ` [<RULE>](<rule-url>)` to the end of each finding line in `reviewComment` and to the end of each `inlineComments.body`, with `<rule-url>` resolved per §2.6 Rule-to-URL Mapping. When the sub-agent emitted no rule code, append nothing (do not emit `[UNSPECIFIED]`). The emoji stays first so downstream severity filters keep working.
 6. Proceed to Phase 3.
+
+### 2.6 Rule-to-URL Mapping
+
+Used in §2.5 steps 3 and 5 to turn a bare rule code into a markdown link to the rule's category in the producing sub-agent file on GitHub.
+
+**Sub-agent → file lookup.** Every review block carries a `subagent_type` (pre-computed entries) or originates from an Agent tool call whose `subagent_type` is known (in-model fan-out). Strip the `autopilot:` prefix and append `.md` to get the agent file path under `claude-plugins/autopilot/agents/`:
+
+| `subagent_type`                           | Agent file                                                         |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| `autopilot:pr:review:correctness`         | `claude-plugins/autopilot/agents/pr:review:correctness.md`         |
+| `autopilot:pr:review:testing`             | `claude-plugins/autopilot/agents/pr:review:testing.md`             |
+| `autopilot:pr:review:complexity`          | `claude-plugins/autopilot/agents/pr:review:complexity.md`          |
+| `autopilot:pr:review:standards`           | `claude-plugins/autopilot/agents/pr:review:standards.md`           |
+| `autopilot:pr:review:architecture`        | `claude-plugins/autopilot/agents/pr:review:architecture.md`        |
+| `autopilot:pr:review:ai-smells`           | `claude-plugins/autopilot/agents/pr:review:ai-smells.md`           |
+| `autopilot:pr:review:common-sense`        | `claude-plugins/autopilot/agents/pr:review:common-sense.md`        |
+| `autopilot:pr:review:pr-hygiene`          | `claude-plugins/autopilot/agents/pr:review:pr-hygiene.md`          |
+| `autopilot:pr:review:surface-correctness` | `claude-plugins/autopilot/agents/pr:review:surface-correctness.md` |
+| `autopilot:pr:review:surface-testing`     | `claude-plugins/autopilot/agents/pr:review:surface-testing.md`     |
+| `autopilot:pr:review:surface-naming`      | `claude-plugins/autopilot/agents/pr:review:surface-naming.md`      |
+
+**Anchor derivation.** Read the producing agent file once via the `Read` tool, find the line containing the rule code (matched as `**<CODE>:`), then walk upward to the nearest `### ` heading. Slugify that heading: lowercase, strip characters other than `[a-z0-9 -]`, replace spaces with `-`, collapse repeats. Example: `### B. Concurrency and Async Issues` → `b-concurrency-and-async-issues`. Cache the heading map per agent file for the run.
+
+**URL template.** `https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/agents/<file-encoded>#<anchor>` — percent-encode `:` as `%3A` in the file segment so markdown parsers do not misinterpret it. Example: `pr:review:correctness.md` → `pr%3Areview%3Acorrectness.md`.
+
+**Edge cases.**
+
+- The sub-agent emitted no rule code: omit the bracket suffix entirely (see §2.5 step 1 and step 5). Do not emit `[UNSPECIFIED]`.
+- Rule code present but not found in the agent file (rename, typo, drift): fall back to bare `[<CODE>]` with no URL. Never block the review.
 
 ---
 
@@ -372,12 +401,12 @@ The `verdict` field drives the GitHub review event. An empty `reviewComment` mea
 ```json
 {
   "verdict": "requestChanges",
-  "reviewComment": "Adds retry logic to the payment webhook handler.\n\n### 🚧 Blockers\n\n1. **Missing idempotency check** - `src/webhooks/payment.ts:45` - Retries can cause duplicate charges [CHECK-BUG-002]\n\n### ⛔ Request Changes\n\nAdd idempotency key validation before processing payment.",
+  "reviewComment": "Adds retry logic to the payment webhook handler.\n\n### 🚧 Blockers\n\n1. **Missing idempotency check** - `src/webhooks/payment.ts:45` - Retries can cause duplicate charges [CHECK-BUG-002](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/agents/pr%3Areview%3Acorrectness.md#b-concurrency-and-async-issues)\n\n### ⛔ Request Changes\n\nAdd idempotency key validation before processing payment.",
   "inlineComments": [
     {
       "path": "src/webhooks/payment.ts",
       "line": 45,
-      "body": "🚧 No idempotency check — retries will duplicate charges [CHECK-BUG-002]"
+      "body": "🚧 No idempotency check — retries will duplicate charges [CHECK-BUG-002](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/agents/pr%3Areview%3Acorrectness.md#b-concurrency-and-async-issues)"
     }
   ]
 }
@@ -388,12 +417,12 @@ The `verdict` field drives the GitHub review event. An empty `reviewComment` mea
 ```json
 {
   "verdict": "approve",
-  "reviewComment": "Adds retry logic to the payment webhook handler.\n\n### 🙋‍♂️ Suggestions\n\n- `src/webhooks/payment.ts:62` - Consider exponential backoff for retries [CHECK-ARCH-002]\n\n### 👍 Approve",
+  "reviewComment": "Adds retry logic to the payment webhook handler.\n\n### 🙋‍♂️ Suggestions\n\n- `src/webhooks/payment.ts:62` - Consider exponential backoff for retries [CHECK-ARCH-002](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/agents/pr%3Areview%3Aarchitecture.md#a-code-reuse-and-duplication)\n\n### 👍 Approve",
   "inlineComments": [
     {
       "path": "src/webhooks/payment.ts",
       "line": 62,
-      "body": "🙋‍♂️ Consider exponential backoff for retries [CHECK-ARCH-002]"
+      "body": "🙋‍♂️ Consider exponential backoff for retries [CHECK-ARCH-002](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/agents/pr%3Areview%3Aarchitecture.md#a-code-reuse-and-duplication)"
     }
   ]
 }
@@ -401,22 +430,22 @@ The `verdict` field drives the GitHub review event. An empty `reviewComment` mea
 
 **reviewComment body template (ONLY when there are findings):**
 
-Every blocker, suggestion, and nitpick line ends with the rule code in square brackets (e.g. `[CHECK-BUG-002]`). If two agents flagged the same `(path, line)`, list all rule codes comma-separated inside a single bracket (e.g. `[CHECK-BUG-002, CHECK-AI-002]`). Use `[UNSPECIFIED]` only when the sub-agent did not emit a `Rule:` field.
+Every blocker, suggestion, and nitpick line ends with the rule code as a markdown link (e.g. `[CHECK-BUG-002](<rule-url>)`). `<rule-url>` is computed via §2.6 Rule-to-URL Mapping. If two agents flagged the same `(path, line)`, list all rule codes comma-separated inside a single bracket pair, each with its own URL (e.g. `[[CHECK-BUG-002](url-a), [CHECK-AI-002](url-b)]`). When the sub-agent emitted no `Rule:` field, omit the bracket suffix entirely.
 
 ```markdown
 [1 factual sentence: what this PR changes — no quality judgment]
 
 ### 🚧 Blockers
 
-1. **[Title]** - `src/path/to/file.py:NN` - [Problem in 1 line] [CHECK-BUG-XXX]
+1. **[Title]** - `src/path/to/file.py:NN` - [Problem in 1 line] [CHECK-BUG-XXX](rule-url)
 
 ### 🙋‍♂️ Suggestions
 
-- `src/path/to/file.py:NN` - [Recommendation in 1 line] [CHECK-AI-XXX]
+- `src/path/to/file.py:NN` - [Recommendation in 1 line] [CHECK-AI-XXX](rule-url)
 
 ### 💡 Nitpicks
 
-- `src/path/to/file.py:NN` - [Optional fix in 1 line] [CHECK-CPLX-XXX]
+- `src/path/to/file.py:NN` - [Optional fix in 1 line] [CHECK-CPLX-XXX](rule-url)
 
 ### ⛔ Request Changes / ### 👍 Approve
 
@@ -431,7 +460,7 @@ Add inline comments for issues with specific code locations:
 - **🙋‍♂️ Suggestion** - Add if location is specific
 - **💡 Nitpicks** - Optional, can be in summary only
 
-Each inline comment: 1-2 sentences, start with severity emoji, end with the rule code in square brackets (e.g. `🚧 No idempotency check — retries will duplicate charges [CHECK-BUG-002]`).
+Each inline comment: 1-2 sentences, start with severity emoji, end with the rule code as a markdown link resolved per §2.6 Rule-to-URL Mapping (e.g. `🚧 No idempotency check — retries will duplicate charges [CHECK-BUG-002](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/agents/pr%3Areview%3Acorrectness.md#b-concurrency-and-async-issues)`).
 
 ### Deduplication Rules
 
@@ -444,7 +473,7 @@ Each inline comment: 1-2 sentences, start with severity emoji, end with the rule
 - ALWAYS full paths for all file references (e.g., `src/history/kafka/consumer.py:66`, NOT `consumer.py:66`)
 - Direct, confident language
 - Clear verdict (rationale only when requesting changes)
-- Rule code as `[<CODE>]` suffix on every finding line (blocker, suggestion, nitpick) and every `inlineComments.body`
+- Rule code as `[<CODE>](<rule-url>)` markdown-link suffix on every finding line (blocker, suggestion, nitpick) and every `inlineComments.body` — URL resolved per §2.6 Rule-to-URL Mapping; omit the suffix entirely when no rule code is available
 
 ### Exclude
 

--- a/claude-plugins/autopilot/skills/pr:review/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:review/SKILL.md
@@ -290,30 +290,38 @@ After all review results are available — whether produced in Phase 2.3 (in-mod
 
 Used in §2.5 steps 3 and 5 to turn a bare rule code into a markdown link to the rule's category in the producing sub-agent file on GitHub.
 
-**Sub-agent → file lookup.** Every review block carries a `subagent_type` (pre-computed entries) or originates from an Agent tool call whose `subagent_type` is known (in-model fan-out). Strip the `autopilot:` prefix and append `.md` to get the agent file path under `claude-plugins/autopilot/agents/`:
+**Sub-agent → file lookup.** Every review block carries a `subagent_type` with the `autopilot:` prefix — in-model fan-out gets it from the Agent tool's `subagent_type` field; pre-computed fan-out gets it from `code-review-action`'s `reviewFanout.ts`. Strip the `autopilot:` prefix and append `.md` to get the bare agent filename:
 
-| `subagent_type`                           | Agent file                                                         |
-| ----------------------------------------- | ------------------------------------------------------------------ |
-| `autopilot:pr:review:correctness`         | `claude-plugins/autopilot/agents/pr:review:correctness.md`         |
-| `autopilot:pr:review:testing`             | `claude-plugins/autopilot/agents/pr:review:testing.md`             |
-| `autopilot:pr:review:complexity`          | `claude-plugins/autopilot/agents/pr:review:complexity.md`          |
-| `autopilot:pr:review:standards`           | `claude-plugins/autopilot/agents/pr:review:standards.md`           |
-| `autopilot:pr:review:architecture`        | `claude-plugins/autopilot/agents/pr:review:architecture.md`        |
-| `autopilot:pr:review:ai-smells`           | `claude-plugins/autopilot/agents/pr:review:ai-smells.md`           |
-| `autopilot:pr:review:common-sense`        | `claude-plugins/autopilot/agents/pr:review:common-sense.md`        |
-| `autopilot:pr:review:pr-hygiene`          | `claude-plugins/autopilot/agents/pr:review:pr-hygiene.md`          |
-| `autopilot:pr:review:surface-correctness` | `claude-plugins/autopilot/agents/pr:review:surface-correctness.md` |
-| `autopilot:pr:review:surface-testing`     | `claude-plugins/autopilot/agents/pr:review:surface-testing.md`     |
-| `autopilot:pr:review:surface-naming`      | `claude-plugins/autopilot/agents/pr:review:surface-naming.md`      |
+| `subagent_type`                           | Agent filename                     |
+| ----------------------------------------- | ---------------------------------- |
+| `autopilot:pr:review:correctness`         | `pr:review:correctness.md`         |
+| `autopilot:pr:review:testing`             | `pr:review:testing.md`             |
+| `autopilot:pr:review:complexity`          | `pr:review:complexity.md`          |
+| `autopilot:pr:review:standards`           | `pr:review:standards.md`           |
+| `autopilot:pr:review:architecture`        | `pr:review:architecture.md`        |
+| `autopilot:pr:review:ai-smells`           | `pr:review:ai-smells.md`           |
+| `autopilot:pr:review:common-sense`        | `pr:review:common-sense.md`        |
+| `autopilot:pr:review:pr-hygiene`          | `pr:review:pr-hygiene.md`          |
+| `autopilot:pr:review:surface-correctness` | `pr:review:surface-correctness.md` |
+| `autopilot:pr:review:surface-testing`     | `pr:review:surface-testing.md`     |
+| `autopilot:pr:review:surface-naming`      | `pr:review:surface-naming.md`      |
 
-**Anchor derivation.** Read the producing agent file once via the `Read` tool, find the line containing the rule code (matched as `**<CODE>:`), then walk upward to the nearest `### ` heading. Slugify that heading: lowercase, strip characters other than `[a-z0-9 -]`, replace spaces with `-`, collapse repeats. Example: `### B. Concurrency and Async Issues` → `b-concurrency-and-async-issues`. Cache the heading map per agent file for the run.
+**Local file path (for reading).** The skill must read the agent file from the installed plugin directory, not the caller's checkout — when `code-review-action` runs in a downstream repo, `claude-plugins/autopilot/agents/` does not exist in the workspace. Resolve the read path in this order:
 
-**URL template.** `https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/agents/<file-encoded>#<anchor>` — percent-encode `:` as `%3A` in the file segment so markdown parsers do not misinterpret it. Example: `pr:review:correctness.md` → `pr%3Areview%3Acorrectness.md`.
+1. If the `CLAUDE_PLUGIN_DIR` env var is set (exposed by `code-review-action`), read from `${CLAUDE_PLUGIN_DIR}/agents/<filename>`.
+2. Otherwise (running inside the autopilot source repo), read from `claude-plugins/autopilot/agents/<filename>` relative to the repository root.
+
+If neither path is readable, fall back per the Edge cases below — never block the review.
+
+**Anchor derivation.** Read the producing agent file once via the `Read` tool (using the local path resolved above), find the line containing the rule code (matched as `**<CODE>:`), then walk upward to the nearest `### ` heading. Slugify that heading: lowercase, strip characters other than `[a-z0-9 -]`, replace spaces with `-`, collapse repeats. Example: `### B. Concurrency and Async Issues` → `b-concurrency-and-async-issues`. Cache the heading map per agent file for the run.
+
+**URL template.** Always emit links to the canonical GitHub source — the local read path is only used for anchor lookup, never as the link target. URL: `https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/agents/<file-encoded>#<anchor>` — percent-encode `:` as `%3A` in the file segment so markdown parsers do not misinterpret it. Example: `pr:review:correctness.md` → `pr%3Areview%3Acorrectness.md`.
 
 **Edge cases.**
 
 - The sub-agent emitted no rule code: omit the bracket suffix entirely (see §2.5 step 1 and step 5). Do not emit `[UNSPECIFIED]`.
 - Rule code present but not found in the agent file (rename, typo, drift): fall back to bare `[<CODE>]` with no URL. Never block the review.
+- Local agent file not readable (neither `$CLAUDE_PLUGIN_DIR/agents/<filename>` nor `claude-plugins/autopilot/agents/<filename>` exists): fall back to bare `[<CODE>]` for every code from that sub-agent. Never block the review.
 
 ---
 


### PR DESCRIPTION
Updates the `pr:review` skill so every rule code in an aggregated review (e.g., `CHECK-BUG-002`) renders as a markdown link to the rule's category in the producing sub-agent file on GitHub. Reviewers and PR authors can now jump from a finding straight to the rule's rationale, severity, and examples.

- Added §2.6 Rule-to-URL Mapping covering sub-agent → file lookup, category-heading anchor derivation, and the canonical URL template
- Updated §2.5 step 3 to merge codes as comma-separated markdown links inside one bracket pair
- Updated §2.5 step 5 to append the linked form to `reviewComment` and `inlineComments.body`, and to omit the suffix entirely when no rule code is emitted
- Updated §2.5 step 1 to drop the `UNSPECIFIED` placeholder
- Updated reviewComment JSON examples, the body template, the inline comment example, and the Include bullet to require the linked form

---

**Release notes:**

- Aggregated `pr:review` findings now link each `[CHECK-…]` rule code to its category section in the source sub-agent file
- Findings emitted without a rule code no longer carry an `[UNSPECIFIED]` placeholder

---

**Issues:**

Closes #58

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links each `[CHECK-…]` rule code in aggregated `pr:review` findings to the matching category in the source sub-agent file on GitHub. Reviewers can jump from a finding to the rule’s rationale, severity, and examples; `[UNSPECIFIED]` is removed.

- New Features
  - Map rule codes to GitHub via sub-agent file lookup, nearest heading anchor, and a canonical URL template (with `:` percent-encoded).
  - Merge duplicate findings’ codes as comma-separated links inside one bracket pair.
  - Append `[CODE](url)` to each finding and inline comment; omit the suffix when no rule code.
  - Align sub-agent IDs to `autopilot:pr:review:<name>` and document `CLAUDE_PLUGIN_DIR`-first agent file lookup, with a safe fallback to bare `[CODE]` when local files aren’t readable.

- Refactors
  - Applied Prettier formatting to fan-out files.

<sup>Written for commit 06a78ca262f2f2ebc4a2b02942b58e20c202e6a8. Summary will update on new commits. <a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/59?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

