### PR TITLE
Distribute AI code-review workflow to downstream repos via a sync action

### DIFF
--- a/.github/actions/code-review-sync/README.md
+++ b/.github/actions/code-review-sync/README.md
@@ -1,0 +1,94 @@
+# Code review sync
+
+Composite GitHub Action that syncs the canonical AI code-review workflow from an upstream
+repository into the current repository and opens a single pull request with the difference.
+The synced set is:
+
+- `.github/workflows/code-review.yml`
+
+The workflow propagates the CI that runs the [`code-review-action`](../code-review-action/README.md)
+on every PR — the action itself stays in the upstream repository and is referenced from the
+synced workflow via `awinogradov/code-assistants/.github/actions/code-review-action@v1`, so
+consumers do not need a local copy.
+
+The action builds the sync list and delegates the diff and PR mechanics to the
+[`files-sync`](../files-sync/README.md) action. It does not require `actions/checkout` and
+never touches the runner's working tree.
+
+## Usage
+
+```yaml
+name: Sync code-review workflow
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: awinogradov/code-assistants/.github/actions/code-review-sync@v1
+        with:
+          token: ${{ secrets.SYNC_PAT }}
+```
+
+## Inputs
+
+| Input         | Required | Default                       | Description                                                                                                                                                                                      |
+| ------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `token`       | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
+| `source-repo` | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the canonical `.github/workflows/code-review.yml`.                                                                                             |
+| `source-ref`  | no       | _(empty)_                     | Branch, tag, or SHA to read the source file from. Empty → source repository default branch.                                                                                                      |
+
+PR-shaping inputs (branch, title, body, commit message) are fixed by design — see
+[Behavior](#behavior).
+
+## Outputs
+
+| Output          | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `changed-files` | Newline-separated list of destination paths that were updated.       |
+| `pr-number`     | Number of the opened or reused PR. Empty when no changes detected.   |
+| `pr-url`        | HTML URL of the opened or reused PR. Empty when no changes detected. |
+
+## Permissions
+
+The `token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever this repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
+
+Pass one of the following:
+
+- A **classic Personal Access Token** with the `repo` scope.
+- A **fine-grained Personal Access Token** scoped to this repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on the source repo.
+- A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
+
+Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
+
+See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and [GitHub App installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
+
+## Behavior
+
+- Delegates to `files-sync` with a fixed sync list — `.github/workflows/code-review.yml` —
+  sourced from `source-repo` at `source-ref`.
+- The PR is opened on the fixed branch `maintenance-sync-code-review` with the title
+  `MAINTENANCE: Sync code-review workflow from upstream` and the commit message
+  `chore: sync code-review workflow from upstream`. These values are not configurable so the
+  action cannot collide with `files-sync`'s default branch and so every consumer gets the
+  same one-line setup.
+- The head branch is force-updated on every run (inherited from `files-sync`); local edits
+  to the synced file will be overwritten when the upstream file changes.
+- If the destination file already matches upstream, no PR is created.
+- A missing source file fails the run with `Source not found at <repo>:<path>`.
+
+## Versioning
+
+Reference the action by tag of the autopilot repo, e.g.:
+
+```yaml
+uses: awinogradov/code-assistants/.github/actions/code-review-sync@v1
+```

--- a/.github/actions/code-review-sync/action.yml
+++ b/.github/actions/code-review-sync/action.yml
@@ -1,0 +1,65 @@
+name: Code review sync
+description: Sync the AI code-review workflow from an upstream repository into the current repository.
+
+inputs:
+  token:
+    description: |
+      PAT (classic with `repo`, or fine-grained with `contents: write` + `pull-requests: write` on this repo) or GitHub App installation token. The workflow's default `GITHUB_TOKEN` is not supported — it cannot create pull requests when the repo/org has "Allow GitHub Actions to create and approve pull requests" disabled, and the resulting 403 is opaque. See README for setup.
+    required: true
+  source-repo:
+    description: Source repository in `owner/name` form that hosts the canonical `.github/workflows/code-review.yml`.
+    required: false
+    default: awinogradov/code-assistants
+  source-ref:
+    description: Branch, tag, or SHA to read the source file from. Defaults to the source repository's default branch.
+    required: false
+    default: ""
+
+outputs:
+  changed-files:
+    description: Newline-separated list of destination paths that were updated. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.changed-files }}
+  pr-number:
+    description: Number of the opened or reused PR. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.pr-number }}
+  pr-url:
+    description: HTML URL of the opened or reused PR. Empty when no changes were detected.
+    value: ${{ steps.sync.outputs.pr-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build files list
+      id: resolve
+      shell: bash
+      env:
+        INPUT_SOURCE_REPO: ${{ inputs.source-repo }}
+        INPUT_SOURCE_REF: ${{ inputs.source-ref }}
+      run: |
+        set -euo pipefail
+        paths=(
+          .github/workflows/code-review.yml
+        )
+        {
+          echo "files<<__EOF__"
+          for path in "${paths[@]}"; do
+            echo "- repo: ${INPUT_SOURCE_REPO}"
+            echo "  source: ${path}"
+            echo "  dest: ${path}"
+            if [ -n "${INPUT_SOURCE_REF}" ]; then
+              echo "  ref: ${INPUT_SOURCE_REF}"
+            fi
+          done
+          echo "__EOF__"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Sync via files-sync
+      id: sync
+      uses: awinogradov/code-assistants/.github/actions/files-sync@main
+      with:
+        files: ${{ steps.resolve.outputs.files }}
+        token: ${{ inputs.token }}
+        branch: maintenance-sync-code-review
+        title: "MAINTENANCE: Sync code-review workflow from upstream"
+        body: Automated code-review workflow sync from upstream.
+        commit-message: "chore: sync code-review workflow from upstream"

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           reviewer: ${{ vars.BOT_USERNAME }}
           bot_token: ${{ secrets.BOT_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_CODE_REVIEW }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,32 @@
+# Source: https://github.com/awinogradov/code-assistants/blob/main/.github/workflows/code-review.yml
+# This file is distributed to downstream repositories by an automated sync.
+# Edits made downstream are overwritten on the next run.
+# To change it, open a pull request against the source file above.
+
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: code-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  ai-review:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: awinogradov/code-assistants/.github/actions/code-review-action@v1
+        with:
+          reviewer: ${{ vars.BOT_USERNAME }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   ai-review:
-    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    if: (github.event_name != 'issue_comment' || github.event.issue.pull_request) && vars.BOT_USERNAME != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: awinogradov/code-assistants/.github/actions/code-review-action@v1
+      - uses: awinogradov/code-assistants/.github/actions/code-review-action@main
         with:
           reviewer: ${{ vars.BOT_USERNAME }}
           bot_token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -30,3 +30,12 @@ jobs:
       - uses: awinogradov/code-assistants/.github/actions/agents-rules-sync@main
         with:
           token: ${{ secrets.GH_TOKEN }}
+
+  sync-code-review:
+    name: Sync code-review workflow
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: awinogradov/code-assistants/.github/actions/code-review-sync@main
+        with:
+          token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Adds the missing distribution path for the AI code-review workflow. Downstream repos can opt into AI review on every PR with a one-line `uses:` and pick up future improvements automatically via the hourly `upstream.yml` cron.

- New composite action `.github/actions/code-review-sync/` mirrors the `contributing-sync` shape (pure inline bash + delegate to `files-sync`, no TypeScript)
- New canonical `.github/workflows/code-review.yml` with upstream source-attribution header, referencing `code-review-action@v1` by absolute repo path so the file is byte-identical in source and downstream
- New `sync-code-review` job in `.github/workflows/upstream.yml` runs the sync on the existing hourly cron alongside `agents-rules-sync`, reusing the `GH_TOKEN` secret

---

**Release notes:**

- Added `code-review-sync` action to distribute the AI code-review workflow to downstream repositories via a one-line `uses:`
- Added canonical `.github/workflows/code-review.yml` that consumers receive automatically via the sync

---

**Issues:**

Closes #60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Distributes the automated code-review workflow to downstream repos via a new `code-review-sync` action and a canonical workflow. Repos can enable review on every PR with a one-line `uses:` and get updates via their hourly `upstream.yml`. Closes #60.

- **New Features**
  - Added `code-review-sync` composite action (inline bash; delegates to `files-sync`; no checkout; requires PAT/App token, not `GITHUB_TOKEN`).
  - Added canonical `.github/workflows/code-review.yml` with PR/comment triggers and concurrency, and an hourly `sync-code-review` job in `upstream.yml` (uses `secrets.GH_TOKEN`).

- **Bug Fixes**
  - Pinned to `awinogradov/code-assistants/.github/actions/code-review-action@main`, gated `ai-review` on `vars.BOT_USERNAME`, and switched `anthropic_api_key` to `secrets.ANTHROPIC_CODE_REVIEW`.

<sup>Written for commit 5d6c1a4608781877642b80f9cd837d0946d0ed92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/61?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

