### PR TITLE
HOTFIX: Pin third-party actions with floating semver tags

### DIFF
--- a/.github/actions/agents-rules-sync/action.yml
+++ b/.github/actions/agents-rules-sync/action.yml
@@ -34,7 +34,7 @@ runs:
   using: composite
   steps:
     - name: Setup Bun
-      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      uses: oven-sh/setup-bun@v2
       with:
         bun-version: 1.x
 

--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -322,7 +322,7 @@ runs:
 
     - name: Setup Bun
       if: steps.ctx.outputs.skip != 'true'
-      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      uses: oven-sh/setup-bun@v2
       with:
         bun-version: 1.x
 

--- a/.github/actions/contributing-check/action.yml
+++ b/.github/actions/contributing-check/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Validate branch name
-      uses: deepakputhraya/action-branch-name@e0f8db53a8e289f1ae6f6c3e8dc70a3d366fd876 # v1.0.0
+      uses: deepakputhraya/action-branch-name@v1.0.0
       with:
         regex: '^(issue-\d+-[a-z0-9]+(-[a-z0-9]+)*|(hotfix|trivial|maintenance|proposal)-[a-z0-9]+(-[a-z0-9]+)*|release-\d+\.\d+\.\d+)$'
         min_length: 5
@@ -13,18 +13,18 @@ runs:
         ignore: main,master
 
     - name: Checkout
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Validate commit messages
-      uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
+      uses: wagoid/commitlint-github-action@v6
       with:
         configFile: ./commitlint.config.mjs
         failOnWarnings: false
 
     - name: Validate PR title (semantic)
-      uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      uses: amannn/action-semantic-pull-request@v6
       env:
         GITHUB_TOKEN: ${{ github.token }}
       with:

--- a/.github/actions/files-sync/action.yml
+++ b/.github/actions/files-sync/action.yml
@@ -45,7 +45,7 @@ runs:
   using: composite
   steps:
     - name: Setup Bun
-      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      uses: oven-sh/setup-bun@v2
       with:
         bun-version: 1.x
 

--- a/.github/actions/release-action/action.yml
+++ b/.github/actions/release-action/action.yml
@@ -90,7 +90,7 @@ runs:
     # ── Shared Setup ──
 
     - name: Setup Bun
-      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      uses: oven-sh/setup-bun@v2
       with:
         bun-version: 1.x
 


### PR DESCRIPTION
The upstream sync workflow failed because the pinned `oven-sh/setup-bun` commit no longer resolves bun release tags (`https://api.github.com/repos/oven-sh/bun/git/refs/tags` → 404). Switching third-party action pins from commit SHAs to floating semver tags keeps consumers on the latest published release in each major and avoids similar breakage when an action's pinned commit ages out.

- `oven-sh/setup-bun` → `@v2` in `agents-rules-sync`, `code-review-action`, `files-sync`, and `release-action`
- `actions/checkout` → `@v4`, `wagoid/commitlint-github-action` → `@v6`, and `amannn/action-semantic-pull-request` → `@v6` in `contributing-check`
- `deepakputhraya/action-branch-name` → `@v1.0.0` in `contributing-check` (only published tag — no floating major available)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing workflows by switching third-party GitHub Actions from SHA pins to semver tags. Restores Bun setup and keeps us on the latest compatible major to avoid future breakage.

- **Dependencies**
  - `oven-sh/setup-bun` → `@v2` in `agents-rules-sync`, `code-review-action`, `files-sync`, `release-action`
  - `contributing-check`: `actions/checkout` → `@v4`, `wagoid/commitlint-github-action` → `@v6`, `amannn/action-semantic-pull-request` → `@v6`, `deepakputhraya/action-branch-name` → `@v1.0.0` (only published tag)

<sup>Written for commit afb23391cd5e3e0746adab63040562859f0f79fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/66?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

