### PR TITLE
Automate releases via release.yml and publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+on:
+  pull_request_target:
+    types: [closed]
+    paths:
+      - "**/.release_notes/**"
+
+concurrency:
+  group: publish-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish release
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve changed files
+        id: changed
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo 'files<<EOF'
+            gh pr view "$PR_NUMBER" --json files --jq '.files[].path'
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: awinogradov/code-assistants/.github/actions/release-action@main
+        with:
+          mode: publish
+          github_token: ${{ secrets.GH_TOKEN }}
+        env:
+          PR_CHANGED_FILES: ${{ steps.changed.outputs.files }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,22 +21,21 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Resolve changed files
-        id: changed
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           {
-            echo 'files<<EOF'
-            gh pr view "$PR_NUMBER" --json files --jq '.files[].path'
+            echo 'PR_CHANGED_FILES<<EOF'
+            gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename'
             echo EOF
-          } >> "$GITHUB_OUTPUT"
+          } >> "$GITHUB_ENV"
 
       - uses: awinogradov/code-assistants/.github/actions/release-action@main
         with:
           mode: publish
           github_token: ${{ secrets.GH_TOKEN }}
-        env:
-          PR_CHANGED_FILES: ${{ steps.changed.outputs.files }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,10 @@
+# Requires repo secrets:
+#   - `GH_TOKEN`: PAT or App installation token with `contents: write` and
+#     `pull-requests: write`. The default `GITHUB_TOKEN` cannot create PRs.
+#     See `.github/actions/release-action/README.md` for the rationale.
+#   - `ANTHROPIC_RELEASE`: Anthropic API key used to generate human-readable
+#     release-note summaries from the changelog (optional but recommended).
+
 name: Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Create release PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: awinogradov/code-assistants/.github/actions/release-action@main
+        with:
+          mode: create
+          github_token: ${{ secrets.GH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_RELEASE }}


### PR DESCRIPTION
Wires the previously vendored release-action (#25) into two workflows so releases stop being a manual task. release.yml runs on push to main and opens per-member release PRs; publish.yml triggers when a release PR is merged and creates tags, GitHub Releases, and the floating major-version tag for action members.

- Add .github/workflows/release.yml invoking release-action@main in create mode with GH_TOKEN and ANTHROPIC_RELEASE
- Add .github/workflows/publish.yml invoking release-action@main in publish mode, gated on pull_request_target.closed + merged == true + path filter **/.release_notes/**
- Include a Resolve changed files step that supplies PR_CHANGED_FILES so the action can resolve which monorepo member to publish

---

**Issues:**

Closes #67

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates releases with two GitHub Actions so publishing is no longer manual. `release.yml` opens per-member release PRs on push to `main`, and `publish.yml` publishes when those PRs merge. Closes #67.

- **New Features**
  - Add `.github/workflows/release.yml` using `awinogradov/code-assistants/.github/actions/release-action@main` in create mode. Runs on push to `main` with concurrency and required permissions, uses `actions/checkout@v6` (full history), and wires `GH_TOKEN`/`ANTHROPIC_RELEASE`. Documents required secrets in a header.
  - Add `.github/workflows/publish.yml` in publish mode. Triggers on `pull_request_target.closed` when merged and only if `**/.release_notes/**` changed. Resolves changed files via `gh api ... --paginate`, writes `PR_CHANGED_FILES` directly to `$GITHUB_ENV`, and pins checkout to `github.event.pull_request.merge_commit_sha`.

<sup>Written for commit ffc24f6f98320318ba5519501823a3117ffe97a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/68?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

