### PR TITLE
HOTFIX: Unblock AI code review on PRs

### DIFF
--- a/.github/actions/code-review-action/src/runClaude.ts
+++ b/.github/actions/code-review-action/src/runClaude.ts
@@ -28,7 +28,9 @@ const longRunMs = 5 * 60 * 1000;
 
 /** Create pino logger configured per platform logging standard. */
 async function createLogger(): Promise<pino.Logger> {
-  const version = (await Bun.file(`${import.meta.dirname}/../version`).text()).trim();
+  const { version } = (await Bun.file(`${import.meta.dirname}/../package.json`).json()) as {
+    version: string;
+  };
 
   return pino(
     {


### PR DESCRIPTION
The code-review-action workflow currently fails on every PR with ENOENT because runClaude.ts reads a version file that only exists transiently while release-action runs in create mode. Reading version from the committed package.json fixes this.

- Replace Bun.file('../version').text() with package.json.version lookup in createLogger
- package.json is committed, always present, and kept in sync by release-action's prepareRelease step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing code-review workflow by reading the version from `package.json` instead of a transient `version` file. This unblocks AI code review on all PRs.

- Bug Fixes
  - In `runClaude.ts`, read the logger version from `package.json` (via `Bun.file(...).json()`) instead of `Bun.file('../version').text()`.
  - Removes dependency on the release-only version artifact, preventing ENOENT and ensuring `pino` logs include a valid version on all branches.

<sup>Written for commit 9c585c3f58b6ec1391bfe27226f028c48a856461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/69?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

