### PR TITLE
HOTFIX: Resolve Claude binary in Bun isolated install

### DIFF
--- a/.github/actions/code-review-action/src/runClaude.ts
+++ b/.github/actions/code-review-action/src/runClaude.ts
@@ -218,7 +218,21 @@ async function tryResolveBinary(pkg: string, binary: string): Promise<string | u
   try {
     const packageJson = require.resolve(`${pkg}/package.json`);
     const binPath = join(packageJson, "..", binary);
-    return (await pathExists(binPath)) ? binPath : undefined;
+    if (await pathExists(binPath)) return binPath;
+  } catch {
+    // Standard resolution failed — fall through to the Bun isolated-install lookup.
+  }
+
+  // Bun's isolated linker keeps optional platform subpackages in `.bun/` without
+  // symlinking them into the consumer's node_modules. Locate the cache via the
+  // already-resolvable SDK package and compute the flat path directly.
+  try {
+    const sdkPkgPath = require.resolve("@anthropic-ai/claude-agent-sdk/package.json");
+    const bunRoot = join(sdkPkgPath, "..", "..", "..", "..", "..");
+    const { version } = (await Bun.file(sdkPkgPath).json()) as { version: string };
+    const flatName = pkg.replace("/", "+");
+    const candidate = join(bunRoot, `${flatName}@${version}`, "node_modules", pkg, binary);
+    return (await pathExists(candidate)) ? candidate : undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
The code-review-action workflow fails on every PR with "Claude Code native binary not found" because Bun's isolated linker keeps optional platform subpackages of @anthropic-ai/claude-agent-sdk in .bun/ without symlinking them into the workspace node_modules. require.resolve fails on CI runners, our resolveClaudeBinary returns undefined, the SDK's internal resolver falls back to musl on the glibc Ubuntu runner, and execution crashes.

- Extend tryResolveBinary with a fallback that walks up from the SDK package.json to the .bun root and constructs node_modules/.bun/<scope>+<name>@<version>/node_modules/<scope>/<name>/<binary> directly
- Reuse the SDK package's own version for the platform subpackage lookup (both are pinned to the same release)
- Standard require.resolve path is still tried first, so non-isolated installs behave unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI failures (“Claude Code native binary not found”) under Bun’s isolated install by resolving the platform binary directly from Bun’s `.bun` cache. Prevents the SDK from falling back to `musl` on glibc runners and crashing.

- **Bug Fixes**
  - Try `require.resolve` first; behavior unchanged for non-isolated installs.
  - Fallback reads `@anthropic-ai/claude-agent-sdk` version and builds the `.bun/<scope>+<name>@<version>/node_modules/<scope>/<name>/<binary>` path to locate the binary.

<sup>Written for commit 366fc53bdbb360532d314860b40cb6edb6208022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/awinogradov/code-assistants/pull/70?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

