### PR TITLE
HOTFIX: Allow manual release runs from Actions UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.workflow }}


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to `release.yml` so the release flow can be kicked off manually from the GitHub Actions UI in addition to the automatic `push: main` trigger.

- Add `workflow_dispatch:` alongside `push.branches: [main]` in `.github/workflows/release.yml`
- Useful for re-running create mode after a missed window or for cutting a release on demand without pushing an empty commit