### PR TITLE
Restrict release runs to dispatch and weekly cron

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,11 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+  schedule:
+    # Mondays at 09:00 UTC — keeps the release PR refreshed weekly without
+    # firing on every push. Trigger sooner via `workflow_dispatch` when needed.
+    - cron: "0 9 * * 1"
 
 concurrency:
   group: release-${{ github.workflow }}


### PR DESCRIPTION
Stops `release.yml` from firing on every push to `main` so the release-action no longer opens or churns a release PR for each unrelated commit. Manual dispatch and a weekly cron stay available for refreshing the release PR.

- Remove `push.branches: [main]` from the `on:` block in `.github/workflows/release.yml`
- Add `schedule.cron: "0 9 * * 1"` so the release PR is refreshed Mondays at 09:00 UTC
- Keep `workflow_dispatch:` for on-demand runs from the Actions UI

---

**Issues:**

Closes #81
