### PR TITLE
Include claude-plugins in release-action discovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -83,6 +83,9 @@
         "typescript": "6.0.3",
       },
     },
+    "claude-plugins/autopilot": {
+      "name": "autopilot",
+    },
     "packages/actions-core": {
       "name": "@code-assistants/actions-core",
       "version": "0.0.0",
@@ -274,6 +277,8 @@
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "autopilot": ["autopilot@workspace:claude-plugins/autopilot"],
 
     "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     ".github/actions/agents-rules-sync",
     ".github/actions/release-action",
     ".github/actions/code-review-action",
+    "claude-plugins/*",
     "packages/*"
   ],
   "scripts": {


### PR DESCRIPTION
Lets `release-action` discover `claude-plugins/autopilot` so the autopilot Claude plugin gets release PRs alongside the four `github-action` workspace members. Without this, `discoverMembers` returns `Detected monorepo with 4 member(s)` and the plugin is silently skipped on every create run.

- Add `claude-plugins/*` glob to root `package.json` `workspaces` so the plugin sits inside the workspace discovery path
- The plugin's own `package.json` already declares `release.type: claude-plugin` and `.claude-plugin/plugin.json` carries the version source, so no per-member config changes are needed
- Refresh `bun.lock` for the new workspace member

---

**Issues:**

Closes #82
