### PR TITLE
Generate AI release notes for monorepo members

### DIFF
--- a/.github/actions/release-action/src/generateReleaseNotes.test.ts
+++ b/.github/actions/release-action/src/generateReleaseNotes.test.ts
@@ -10,6 +10,8 @@ import { withTempDir } from "./testHelpers.ts";
 import {
   type AnthropicMessages,
   callAnthropicApi,
+  generateWithApi,
+  runReleaseNotes,
   verifyReleaseNotes,
 } from "./generateReleaseNotes.ts";
 import {
@@ -368,4 +370,57 @@ describe("callAnthropicApi", () => {
       callAnthropicApi("test-key", "test prompt", "system", mockMessages)
     ).rejects.toThrow("Anthropic API returned no text content");
   });
+});
+
+describe("runReleaseNotes", () => {
+  const originalApiKey = process.env.ANTHROPIC_API_KEY;
+
+  test("falls back to .release_bot/body inside the supplied cwd when no API key", () =>
+    withTempDir(async (dir) => {
+      delete process.env.ANTHROPIC_API_KEY;
+      try {
+        await Bun.write(join(dir, ".release_bot/body"), "## member changelog body");
+
+        await runReleaseNotes(dir);
+
+        const notes = await Bun.file(join(dir, ".release_bot/release_notes.md")).text();
+        expect(notes).toContain("member changelog body");
+      } finally {
+        if (originalApiKey !== undefined) process.env.ANTHROPIC_API_KEY = originalApiKey;
+      }
+    }));
+
+  test("resolves paths under cwd, not process.cwd()", () =>
+    withTempDir(async (dir) => {
+      delete process.env.ANTHROPIC_API_KEY;
+      try {
+        await Bun.write(join(dir, ".release_bot/body"), "isolated body");
+
+        await runReleaseNotes(dir);
+
+        const memberNotes = Bun.file(join(dir, ".release_bot/release_notes.md"));
+        expect(await memberNotes.exists()).toBe(true);
+
+        const cwdNotes = Bun.file(join(process.cwd(), ".release_bot/release_notes.md"));
+        expect(await cwdNotes.exists()).toBe(false);
+      } finally {
+        if (originalApiKey !== undefined) process.env.ANTHROPIC_API_KEY = originalApiKey;
+      }
+    }));
+});
+
+describe("generateWithApi", () => {
+  test("swallows errors and reads paths relative to the supplied cwd", () =>
+    withTempDir(async (dir) => {
+      // Missing body file exercises the catch branch — the function must not
+      // throw and the notes file must not appear. The bodyPath is supplied
+      // absolutely (mirroring runReleaseNotes), so cwd only governs the lookup
+      // of tickets.json / pr_descriptions.yml / service-context files.
+      const notesPath = join(dir, "release_notes.md");
+      const bodyPath = join(dir, "missing-body");
+
+      await generateWithApi("fake-key", notesPath, bodyPath, dir);
+
+      expect(await Bun.file(notesPath).exists()).toBe(false);
+    }));
 });

--- a/.github/actions/release-action/src/generateReleaseNotes.test.ts
+++ b/.github/actions/release-action/src/generateReleaseNotes.test.ts
@@ -3,7 +3,7 @@
  */
 import { join } from "node:path";
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { withTempDir } from "./testHelpers.ts";
 
@@ -373,43 +373,76 @@ describe("callAnthropicApi", () => {
 });
 
 describe("runReleaseNotes", () => {
-  const originalApiKey = process.env.ANTHROPIC_API_KEY;
+  let savedApiKey: string | undefined;
+
+  beforeEach(() => {
+    savedApiKey = process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = savedApiKey;
+    }
+  });
 
   test("falls back to .release_bot/body inside the supplied cwd when no API key", () =>
     withTempDir(async (dir) => {
       delete process.env.ANTHROPIC_API_KEY;
-      try {
-        await Bun.write(join(dir, ".release_bot/body"), "## member changelog body");
+      await Bun.write(join(dir, ".release_bot/body"), "## member changelog body");
 
-        await runReleaseNotes(dir);
+      await runReleaseNotes(dir);
 
-        const notes = await Bun.file(join(dir, ".release_bot/release_notes.md")).text();
-        expect(notes).toContain("member changelog body");
-      } finally {
-        if (originalApiKey !== undefined) process.env.ANTHROPIC_API_KEY = originalApiKey;
-      }
+      const notes = await Bun.file(join(dir, ".release_bot/release_notes.md")).text();
+      expect(notes).toContain("member changelog body");
     }));
 
   test("resolves paths under cwd, not process.cwd()", () =>
     withTempDir(async (dir) => {
       delete process.env.ANTHROPIC_API_KEY;
-      try {
-        await Bun.write(join(dir, ".release_bot/body"), "isolated body");
+      await Bun.write(join(dir, ".release_bot/body"), "isolated body");
 
-        await runReleaseNotes(dir);
+      await runReleaseNotes(dir);
 
-        const memberNotes = Bun.file(join(dir, ".release_bot/release_notes.md"));
-        expect(await memberNotes.exists()).toBe(true);
+      const memberNotes = Bun.file(join(dir, ".release_bot/release_notes.md"));
+      expect(await memberNotes.exists()).toBe(true);
 
-        const cwdNotes = Bun.file(join(process.cwd(), ".release_bot/release_notes.md"));
-        expect(await cwdNotes.exists()).toBe(false);
-      } finally {
-        if (originalApiKey !== undefined) process.env.ANTHROPIC_API_KEY = originalApiKey;
-      }
+      const cwdNotes = Bun.file(join(process.cwd(), ".release_bot/release_notes.md"));
+      expect(await cwdNotes.exists()).toBe(false);
+    }));
+
+  test("writes AI summary when API key is set and the call succeeds", () =>
+    withTempDir(async (dir) => {
+      process.env.ANTHROPIC_API_KEY = "test-key";
+      await Bun.write(join(dir, ".release_bot/body"), "### Features\n\n- new endpoint");
+
+      const mockMessages: AnthropicMessages = {
+        create: async () => ({ content: [{ type: "text", text: "AI-summarized release" }] }),
+      };
+
+      await runReleaseNotes(dir, mockMessages);
+
+      const notes = await Bun.file(join(dir, ".release_bot/release_notes.md")).text();
+      expect(notes).toContain("AI-summarized release");
     }));
 });
 
 describe("generateWithApi", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(() => {
+    savedApiKey = process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = savedApiKey;
+    }
+  });
+
   test("swallows errors and reads paths relative to the supplied cwd", () =>
     withTempDir(async (dir) => {
       // Missing body file exercises the catch branch — the function must not
@@ -422,5 +455,47 @@ describe("generateWithApi", () => {
       await generateWithApi("fake-key", notesPath, bodyPath, dir);
 
       expect(await Bun.file(notesPath).exists()).toBe(false);
+    }));
+
+  test("writes notes file on the happy path", () =>
+    withTempDir(async (dir) => {
+      const notesPath = join(dir, "release_notes.md");
+      const bodyPath = join(dir, "body.md");
+      await Bun.write(bodyPath, "### Features\n\n- new endpoint");
+
+      const mockMessages: AnthropicMessages = {
+        create: async () => ({ content: [{ type: "text", text: "Summary" }] }),
+      };
+
+      await generateWithApi("test-key", notesPath, bodyPath, dir, mockMessages);
+
+      const notes = await Bun.file(notesPath).text();
+      expect(notes).toBe("Summary");
+    }));
+
+  test("forwards tickets.json and pr_descriptions.yml from cwd into the user message", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, ".release_bot/tickets.json"), '{"MEM-1":"first ticket"}');
+      await Bun.write(join(dir, ".release_bot/pr_descriptions.yml"), "pr1: described");
+      await Bun.write(join(dir, "body.md"), "### Features\n\n- thing");
+
+      let captured: string | undefined;
+      const mockMessages: AnthropicMessages = {
+        create: async (params) => {
+          captured = params.messages[0]?.content;
+          return { content: [{ type: "text", text: "ok" }] };
+        },
+      };
+
+      await generateWithApi(
+        "test-key",
+        join(dir, "notes.md"),
+        join(dir, "body.md"),
+        dir,
+        mockMessages,
+      );
+
+      expect(captured).toContain("first ticket");
+      expect(captured).toContain("pr1: described");
     }));
 });

--- a/.github/actions/release-action/src/generateReleaseNotes.ts
+++ b/.github/actions/release-action/src/generateReleaseNotes.ts
@@ -10,6 +10,8 @@
  * ANTHROPIC_API_KEY=sk-... bun src/generateReleaseNotes.ts
  * ```
  */
+import { join } from "node:path";
+
 import Anthropic from "@anthropic-ai/sdk";
 
 import {
@@ -102,17 +104,22 @@ export async function verifyReleaseNotes(notesPath: string, bodyPath: string): P
   await Bun.write(notesPath, "- See changelog for detailed changes\n");
 }
 
-async function generateWithApi(apiKey: string, notesPath: string, bodyPath: string): Promise<void> {
+export async function generateWithApi(
+  apiKey: string,
+  notesPath: string,
+  bodyPath: string,
+  cwd = process.cwd(),
+): Promise<void> {
   try {
     const changelog = await Bun.file(bodyPath).text();
 
-    const ticketsFile = Bun.file(".release_bot/tickets.json");
+    const ticketsFile = Bun.file(join(cwd, ".release_bot/tickets.json"));
     const tickets = (await ticketsFile.exists()) ? await ticketsFile.text() : undefined;
 
-    const prDescFile = Bun.file(".release_bot/pr_descriptions.yml");
+    const prDescFile = Bun.file(join(cwd, ".release_bot/pr_descriptions.yml"));
     const prDescriptions = (await prDescFile.exists()) ? await prDescFile.text() : undefined;
 
-    const serviceContext = await readServiceContext();
+    const serviceContext = await readServiceContext(cwd);
 
     if (serviceContext) console.log("Found service documentation context");
     if (tickets) console.log("Found tickets.json with context");
@@ -130,16 +137,29 @@ async function generateWithApi(apiKey: string, notesPath: string, bodyPath: stri
   }
 }
 
-async function main(): Promise<void> {
+/**
+ * Generate and verify release notes for a given working directory. Reads the
+ * full changelog from `<cwd>/.release_bot/body`, writes the AI summary to
+ * `<cwd>/.release_bot/release_notes.md`, and falls back to the full changelog
+ * when the API key is missing or the call fails.
+ *
+ * Used by the standalone `main()` (cwd = repo root) and by the monorepo
+ * `emitMemberArtifacts` (cwd = member path).
+ */
+export async function runReleaseNotes(cwd = process.cwd()): Promise<void> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
-  const notesPath = ".release_bot/release_notes.md";
-  const bodyPath = ".release_bot/body";
+  const notesPath = join(cwd, ".release_bot/release_notes.md");
+  const bodyPath = join(cwd, ".release_bot/body");
 
   if (apiKey) {
-    await generateWithApi(apiKey, notesPath, bodyPath);
+    await generateWithApi(apiKey, notesPath, bodyPath, cwd);
   }
 
   await verifyReleaseNotes(notesPath, bodyPath);
+}
+
+async function main(): Promise<void> {
+  await runReleaseNotes();
 }
 
 if (import.meta.main) {

--- a/.github/actions/release-action/src/generateReleaseNotes.ts
+++ b/.github/actions/release-action/src/generateReleaseNotes.ts
@@ -109,6 +109,7 @@ export async function generateWithApi(
   notesPath: string,
   bodyPath: string,
   cwd = process.cwd(),
+  messages?: AnthropicMessages,
 ): Promise<void> {
   try {
     const changelog = await Bun.file(bodyPath).text();
@@ -127,7 +128,7 @@ export async function generateWithApi(
 
     const filtered = filterChangelogForAi(changelog);
     const userMessage = buildUserMessage(filtered, serviceContext, tickets, prDescriptions);
-    const notes = await callAnthropicApi(apiKey, userMessage, systemPrompt);
+    const notes = await callAnthropicApi(apiKey, userMessage, systemPrompt, messages);
 
     await Bun.write(notesPath, notes, { createPath: true });
     console.log("Release notes generated");
@@ -146,13 +147,16 @@ export async function generateWithApi(
  * Used by the standalone `main()` (cwd = repo root) and by the monorepo
  * `emitMemberArtifacts` (cwd = member path).
  */
-export async function runReleaseNotes(cwd = process.cwd()): Promise<void> {
+export async function runReleaseNotes(
+  cwd = process.cwd(),
+  messages?: AnthropicMessages,
+): Promise<void> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   const notesPath = join(cwd, ".release_bot/release_notes.md");
   const bodyPath = join(cwd, ".release_bot/body");
 
   if (apiKey) {
-    await generateWithApi(apiKey, notesPath, bodyPath, cwd);
+    await generateWithApi(apiKey, notesPath, bodyPath, cwd, messages);
   }
 
   await verifyReleaseNotes(notesPath, bodyPath);

--- a/.github/actions/release-action/src/generateReleaseNotes.ts
+++ b/.github/actions/release-action/src/generateReleaseNotes.ts
@@ -158,12 +158,8 @@ export async function runReleaseNotes(cwd = process.cwd()): Promise<void> {
   await verifyReleaseNotes(notesPath, bodyPath);
 }
 
-async function main(): Promise<void> {
-  await runReleaseNotes();
-}
-
 if (import.meta.main) {
-  main().catch((error: Error) => {
+  runReleaseNotes().catch((error: Error) => {
     console.log(`::error::${error.message}`);
     process.exit(1);
   });

--- a/.github/actions/release-action/src/insert-release-notes.test.ts
+++ b/.github/actions/release-action/src/insert-release-notes.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for {@link insertReleaseNotes}.
+ *
+ * Covers the happy path (notes spliced into both CHANGELOG.md and the per-version
+ * release-notes file under the version header) and the silently-skipping paths
+ * (missing source notes, empty source notes, missing version header).
+ */
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { insertReleaseNotes } from "./insert-release-notes.ts";
+import { withTempDir } from "./testHelpers.ts";
+
+describe("insertReleaseNotes", () => {
+  test("splices notes into CHANGELOG.md and .release_notes/<v>.md under the version header", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, ".release_bot/release_notes.md"), "- Faster startup\n");
+      await Bun.write(
+        join(dir, "CHANGELOG.md"),
+        "# Changelog\n\n## 1.2.0 (2026-01-01)\n\n### Features\n\n- thing\n",
+      );
+      await Bun.write(
+        join(dir, ".release_notes/1.2.0.md"),
+        "## 1.2.0 (2026-01-01)\n\n### Features\n\n- thing\n",
+      );
+
+      await insertReleaseNotes({ cwd: dir, version: "1.2.0" });
+
+      const changelog = await Bun.file(join(dir, "CHANGELOG.md")).text();
+      const noteFile = await Bun.file(join(dir, ".release_notes/1.2.0.md")).text();
+
+      expect(changelog).toContain("## Release Notes");
+      expect(changelog).toContain("Faster startup");
+      expect(noteFile).toContain("## Release Notes");
+      expect(noteFile).toContain("Faster startup");
+    }));
+
+  test("no-ops silently when .release_bot/release_notes.md is missing", () =>
+    withTempDir(async (dir) => {
+      const original = "# Changelog\n\n## 1.2.0 (2026-01-01)\n\n- thing\n";
+      await Bun.write(join(dir, "CHANGELOG.md"), original);
+
+      await insertReleaseNotes({ cwd: dir, version: "1.2.0" });
+
+      const after = await Bun.file(join(dir, "CHANGELOG.md")).text();
+      expect(after).toBe(original);
+    }));
+
+  test("no-ops silently when notes file is empty whitespace", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, ".release_bot/release_notes.md"), "   \n");
+      const original = "# Changelog\n\n## 1.2.0 (2026-01-01)\n\n- thing\n";
+      await Bun.write(join(dir, "CHANGELOG.md"), original);
+
+      await insertReleaseNotes({ cwd: dir, version: "1.2.0" });
+
+      const after = await Bun.file(join(dir, "CHANGELOG.md")).text();
+      expect(after).toBe(original);
+    }));
+
+  test("leaves CHANGELOG.md untouched when the version header is absent", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, ".release_bot/release_notes.md"), "- Some notes\n");
+      const original = "# Changelog\n\n## 0.9.0 (2025-12-01)\n\n- earlier\n";
+      await Bun.write(join(dir, "CHANGELOG.md"), original);
+
+      await insertReleaseNotes({ cwd: dir, version: "1.2.0" });
+
+      const after = await Bun.file(join(dir, "CHANGELOG.md")).text();
+      expect(after).toBe(original);
+    }));
+
+  test("prepends notes when the per-version file lacks the version header", () =>
+    withTempDir(async (dir) => {
+      await Bun.write(join(dir, ".release_bot/release_notes.md"), "- Hot fix\n");
+      await Bun.write(
+        join(dir, ".release_notes/1.2.0.md"),
+        "### Bug Fixes\n\n- patch the thing\n",
+      );
+
+      await insertReleaseNotes({ cwd: dir, version: "1.2.0" });
+
+      const noteFile = await Bun.file(join(dir, ".release_notes/1.2.0.md")).text();
+      // No version header means the notes are prepended verbatim.
+      expect(noteFile.startsWith("## Release Notes")).toBe(true);
+      expect(noteFile).toContain("Hot fix");
+      expect(noteFile).toContain("patch the thing");
+    }));
+});

--- a/.github/actions/release-action/src/monorepo/runCreate.ts
+++ b/.github/actions/release-action/src/monorepo/runCreate.ts
@@ -19,6 +19,8 @@ import { join } from "node:path";
 import semver from "semver";
 
 import { assemblePrBody } from "../assemble-pr-body.ts";
+import { runReleaseNotes } from "../generateReleaseNotes.ts";
+import { insertReleaseNotes } from "../insert-release-notes.ts";
 import { appendMigratingSection, readBreakingNotes } from "../migrations/migratingAppend.ts";
 import { bumpVersion, generateChangelog } from "../release.ts";
 import { updateVersionFiles } from "../prepareRelease.ts";
@@ -252,6 +254,14 @@ export async function emitMemberArtifacts(options: EmitMemberArtifactsOptions): 
   await Bun.write(join(member.path, ".release_bot", "body"), `${bodyPrefix}${log.release}`, {
     createPath: true,
   });
+
+  // AI-summarize the changelog into <member>/.release_bot/release_notes.md, then
+  // splice the summary as "## Release Notes" into <member>/CHANGELOG.md and
+  // <member>/.release_notes/<version>.md so the create PR body carries it.
+  // Mirrors the standalone path's `Generate Release Notes` + `Update Release
+  // Notes File` action.yml steps, which never ran in monorepo mode.
+  await runReleaseNotes(member.path);
+  await insertReleaseNotes({ cwd: member.path, version: newVersion });
 
   await assemblePrBody({
     cwd: member.path,


### PR DESCRIPTION
Wires the AI release-note generation into the monorepo create path so per-member release PRs ship with a populated `## Release Notes` block instead of blank space. Until now `runCreate.ts` only wrote the raw changelog to `<member>/.release_notes/<version>.md`; the `Generate Release Notes` action.yml step was gated on `mode == 'standalone'` and never ran for monorepo members.

- Extract `runReleaseNotes(cwd)` from `generateReleaseNotes.ts`'s `main()` so the same orchestration (API call + verify-with-fallback) can be reused from anywhere
- Parameterize `generateWithApi` with `cwd` so `tickets.json`, `pr_descriptions.yml`, and `serviceContext` resolve under the member directory in monorepo mode instead of always the repo root
- Call `runReleaseNotes(member.path)` and `insertReleaseNotes({ cwd: member.path, version })` inside `emitMemberArtifacts` after `.release_bot/body` is written, mirroring the standalone `Generate Release Notes` + `Update Release Notes File` action.yml step sequence
- `runReleaseNotes` falls back to the full changelog when `ANTHROPIC_API_KEY` is missing or the API call fails, so the existing test fixtures that omit the key still emit non-empty notes

---

**Release notes:**

- Monorepo release PRs now include the AI-summarized release notes for every member, matching standalone-mode behaviour

---

**Issues:**

Closes #83
