### PR TITLE
Validate monorepo release branch names

### DIFF
--- a/.github/actions/contributing-check/action.yml
+++ b/.github/actions/contributing-check/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Validate branch name
       uses: deepakputhraya/action-branch-name@v1.0.0
       with:
-        regex: '^(issue-\d+-[a-z0-9]+(-[a-z0-9]+)*|(hotfix|trivial|maintenance|proposal)-[a-z0-9]+(-[a-z0-9]+)*|release-\d+\.\d+\.\d+)$'
+        regex: '^(issue-\d+-[a-z0-9]+(-[a-z0-9]+)*|(hotfix|trivial|maintenance|proposal)-[a-z0-9]+(-[a-z0-9]+)*|release-([a-z0-9]+(-[a-z0-9]+)*-)?\d+\.\d+\.\d+)$'
         min_length: 5
         max_length: 100
         ignore: main,master


### PR DESCRIPTION
Lets the contributing-check Validate PR step accept the `release-<member>-<version>` branch names that `release-action`'s monorepo mode produces (e.g., `release-autopilot-0.1.0`, `release-files-sync-action-1.0.0`), while keeping the standalone `release-<version>` form valid. Without this, every release PR fails branch-name validation and the all-checks-green gate cannot be enforced.

- Extend the `release-` alternative in `.github/actions/contributing-check/action.yml` regex with an optional kebab-case `<member>-` prefix
- The `issue-`, `hotfix-`, `trivial-`, `maintenance-`, and `proposal-` alternatives are untouched

---

**Issues:**

Closes #92
