### PR TITLE
Approve release PRs automatically after AI review skip

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -35,6 +35,9 @@ inputs:
   bot_username:
     description: "Bot username for skipping CI-author PRs. When set, PRs authored by this user with the 'ci-skip-review' label are skipped. Falls back to reviewer if omitted."
     required: false
+  release_pr_authors:
+    description: "Comma-separated list of trusted authors whose release-branch PRs get an auto-approval after review is skipped. Empty (default) disables auto-approval; the action still skips review for any release-branch PR. Set this only to identities you trust to open release PRs (e.g., 'github-actions[bot]', 'my-org-bot')."
+    required: false
   bot_token:
     description: "GitHub token for bot operations"
     required: true
@@ -117,6 +120,7 @@ runs:
         INPUT_COMMENT_LINE: ${{ inputs.comment_line }}
         INPUT_REVIEWER: ${{ inputs.reviewer }}
         INPUT_BOT_USERNAME: ${{ inputs.bot_username }}
+        INPUT_RELEASE_PR_AUTHORS: ${{ inputs.release_pr_authors }}
         EVENT_NAME: ${{ github.event_name }}
         EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
         EVENT_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -154,17 +158,23 @@ runs:
           fi
         fi
 
-        # Skip release PRs and auto-approve so they aren't blocked on the
-        # requested-reviewer slot. Only post the approval in review mode — react
-        # mode runs on comment events and shouldn't touch review state.
+        # Skip release PRs. Optionally auto-approve them so they aren't blocked
+        # on the requested-reviewer slot — but only when the author is in the
+        # explicit `release_pr_authors` trust list AND the action is in review
+        # mode. The branch-name check alone is NOT a security boundary; anyone
+        # with push access could open a `release-pwn-1.0.0` PR otherwise.
         if [[ "$EVENT_NAME" == "pull_request" && "$EVENT_PR_HEAD_REF" =~ ^(release-|delivery-) ]]; then
           echo "Skipping: release/delivery branch ($EVENT_PR_HEAD_REF)"
-          if [[ "$INPUT_MODE" == "review" ]]; then
-            gh api -X POST \
-              "repos/${GITHUB_REPOSITORY}/pulls/${EVENT_PR_NUMBER}/reviews" \
-              -f event=APPROVE \
-              -f body="Auto-approved: release branch, AI review skipped per workflow policy." \
-              || echo "Auto-approval skipped (already approved or API error)"
+          if [[ "$INPUT_MODE" == "review" && -n "$INPUT_RELEASE_PR_AUTHORS" ]]; then
+            if [[ ",${INPUT_RELEASE_PR_AUTHORS//[[:space:]]/}," == *",${EVENT_PR_AUTHOR},"* ]]; then
+              gh api -X POST \
+                "repos/${GITHUB_REPOSITORY}/pulls/${EVENT_PR_NUMBER}/reviews" \
+                -f event=APPROVE \
+                -f body="Auto-approved: release branch by trusted author, AI review skipped per workflow policy." \
+                || echo "Auto-approval skipped (already approved or API error)"
+            else
+              echo "Auto-approval skipped: author '$EVENT_PR_AUTHOR' not in release_pr_authors"
+            fi
           fi
           echo "skip=true" >> "$GITHUB_OUTPUT"
           exit 0

--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -197,7 +197,7 @@ runs:
                 if grep -q "Can not approve" "$approve_stderr"; then
                   echo "Auto-approval skipped: PR already approved by bot for current HEAD"
                 else
-                  echo "::warning::Auto-approval failed for '$EVENT_PR_AUTHOR' on release PR ${EVENT_PR_NUMBER}: $(cat "$approve_stderr")"
+                  echo "::error::Auto-approval failed for '$EVENT_PR_AUTHOR' on release PR ${EVENT_PR_NUMBER}: $(cat "$approve_stderr")"
                 fi
               fi
               rm -f "$approve_stderr"

--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -154,9 +154,18 @@ runs:
           fi
         fi
 
-        # Skip release PRs
+        # Skip release PRs and auto-approve so they aren't blocked on the
+        # requested-reviewer slot. Only post the approval in review mode — react
+        # mode runs on comment events and shouldn't touch review state.
         if [[ "$EVENT_NAME" == "pull_request" && "$EVENT_PR_HEAD_REF" =~ ^(release-|delivery-) ]]; then
           echo "Skipping: release/delivery branch ($EVENT_PR_HEAD_REF)"
+          if [[ "$INPUT_MODE" == "review" ]]; then
+            gh api -X POST \
+              "repos/${GITHUB_REPOSITORY}/pulls/${EVENT_PR_NUMBER}/reviews" \
+              -f event=APPROVE \
+              -f body="Auto-approved: release branch, AI review skipped per workflow policy." \
+              || echo "Auto-approval skipped (already approved or API error)"
+          fi
           echo "skip=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi

--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -166,12 +166,41 @@ runs:
         if [[ "$EVENT_NAME" == "pull_request" && "$EVENT_PR_HEAD_REF" =~ ^(release-|delivery-) ]]; then
           echo "Skipping: release/delivery branch ($EVENT_PR_HEAD_REF)"
           if [[ "$INPUT_MODE" == "review" && -n "$INPUT_RELEASE_PR_AUTHORS" ]]; then
-            if [[ ",${INPUT_RELEASE_PR_AUTHORS//[[:space:]]/}," == *",${EVENT_PR_AUTHOR},"* ]]; then
-              gh api -X POST \
+            # Iterate the comma-separated list and compare each entry literally
+            # to the PR author. Quoted RHS in `[[ x == "y" ]]` forces literal
+            # comparison, so GitHub usernames containing glob metacharacters
+            # (e.g. `github-actions[bot]`) are matched as strings, not as
+            # bracket-expression patterns.
+            author_match=false
+            IFS=',' read -ra trusted_authors <<< "$INPUT_RELEASE_PR_AUTHORS"
+            for entry in "${trusted_authors[@]}"; do
+              trimmed="${entry#"${entry%%[![:space:]]*}"}"
+              trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+              if [[ -n "$trimmed" && "$EVENT_PR_AUTHOR" == "$trimmed" ]]; then
+                author_match=true
+                break
+              fi
+            done
+            if [[ "$author_match" == "true" ]]; then
+              approve_stderr="$(mktemp)"
+              if gh api -X POST \
                 "repos/${GITHUB_REPOSITORY}/pulls/${EVENT_PR_NUMBER}/reviews" \
                 -f event=APPROVE \
                 -f body="Auto-approved: release branch by trusted author, AI review skipped per workflow policy." \
-                || echo "Auto-approval skipped (already approved or API error)"
+                2> "$approve_stderr"; then
+                echo "Auto-approval posted for trusted author '$EVENT_PR_AUTHOR'"
+              else
+                # Distinguish the benign "already approved" case (HTTP 422 with
+                # `Can not approve` in the body) from a real misconfiguration
+                # (auth, scope, network) so workflow owners can act on the
+                # latter without grepping every successful run.
+                if grep -q "Can not approve" "$approve_stderr"; then
+                  echo "Auto-approval skipped: PR already approved by bot for current HEAD"
+                else
+                  echo "::warning::Auto-approval failed for '$EVENT_PR_AUTHOR' on release PR ${EVENT_PR_NUMBER}: $(cat "$approve_stderr")"
+                fi
+              fi
+              rm -f "$approve_stderr"
             else
               echo "Auto-approval skipped: author '$EVENT_PR_AUTHOR' not in release_pr_authors"
             fi

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -30,3 +30,4 @@ jobs:
           reviewer: ${{ vars.BOT_USERNAME }}
           bot_token: ${{ secrets.BOT_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_CODE_REVIEW }}
+          release_pr_authors: ${{ vars.RELEASE_PR_AUTHORS }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -2,6 +2,14 @@
 # This file is distributed to downstream repositories by an automated sync.
 # Edits made downstream are overwritten on the next run.
 # To change it, open a pull request against the source file above.
+#
+# Repository variables consumed by this workflow:
+#   - `BOT_USERNAME` (required): GitHub login of the AI reviewer bot. Without this the
+#     `ai-review` job is skipped entirely.
+#   - `RELEASE_PR_AUTHORS` (optional): comma-separated list of trusted authors whose
+#     `release-*` / `delivery-*` branch PRs get an auto-approval after AI review is
+#     skipped. Leave unset to keep the previous skip-only behaviour. Set this only
+#     for identities you trust to open release PRs (e.g. `github-actions[bot]`).
 
 name: AI Code Review
 


### PR DESCRIPTION
Unblocks monorepo release PRs by posting an APPROVE review whenever code-review-action's preflight skips them — gated behind an explicit author trust list so the branch-name pattern alone cannot grant approvals. Today the action correctly detects `^(release-|delivery-)` branches and exits with `Skipping: release/delivery branch`, but never clears the requested-reviewer slot — so `reviewDecision` stays at `REVIEW_REQUIRED` and every release PR needs a human approval click.

- Add a new optional `release_pr_authors` input (comma-separated identities)
- In the `Skip release PRs` branch of `.github/actions/code-review-action/action.yml`, post a `gh api -X POST /pulls/<n>/reviews` with `event=APPROVE` ONLY when (a) `INPUT_MODE == "review"`, (b) `release_pr_authors` is non-empty, AND (c) the PR author matches one of the listed identities
- Use comma-bounded matching with whitespace stripped so `'github-actions'` cannot be matched by a list entry of `'github-actions-bot'`
- Tolerate API errors (already approved on a prior commit, no permission) with `|| echo` so the skip step still succeeds
- When `release_pr_authors` is empty (default), the skip path falls back to the existing skip-only behaviour — no behaviour change for existing consumers
- Wire `vars.RELEASE_PR_AUTHORS` through the canonical `.github/workflows/code-review.yml` so this repo can opt in by setting a repository variable instead of editing the workflow

---

**Issues:**

Closes #93
