### PR TITLE
Standardize action authentication on bot_token and bot_username

### DIFF
--- a/.github/actions/agents-rules-sync/README.md
+++ b/.github/actions/agents-rules-sync/README.md
@@ -33,7 +33,8 @@ jobs:
     steps:
       - uses: awinogradov/code-assistants/.github/actions/agents-rules-sync@v1
         with:
-          token: ${{ secrets.SYNC_PAT }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
           # agents-md: true  # also publish AGENTS.md → CLAUDE.md symlink
 ```
 
@@ -52,12 +53,13 @@ Accepted values: `Bun`, `Bun+React+Tailwind`, `NodeJS+React`, `NodeJS+React+Tail
 
 ## Inputs
 
-| Input         | Required | Default                       | Description                                                                                                                                                                                      |
-| ------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `token`       | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
-| `source-repo` | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.                                                                                                                  |
-| `source-ref`  | no       | _(empty)_                     | Branch, tag, or SHA to read the source rules file from. Empty → source repository default branch.                                                                                                |
-| `agents-md`   | no       | `false`                       | When `true`, also publish `AGENTS.md` as a Git symlink to `CLAUDE.md`. See [Behavior](#behavior).                                                                                                |
+| Input          | Required | Default                       | Description                                                                                                                                                                                      |
+| -------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bot_token`    | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
+| `bot_username` | no       | `github-actions[bot]`         | Git author/committer login for the sync commit. Pass `${{ vars.BOT_USERNAME }}`. The PR itself is opened by the `bot_token` owner.                                                               |
+| `source-repo`  | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.                                                                                                                  |
+| `source-ref`   | no       | _(empty)_                     | Branch, tag, or SHA to read the source rules file from. Empty → source repository default branch.                                                                                                |
+| `agents-md`    | no       | `false`                       | When `true`, also publish `AGENTS.md` as a Git symlink to `CLAUDE.md`. See [Behavior](#behavior).                                                                                                |
 
 PR-shaping inputs (branch, title, body, commit message) are fixed by design — see
 [Behavior](#behavior).
@@ -72,7 +74,7 @@ PR-shaping inputs (branch, title, body, commit message) are fixed by design — 
 
 ## Permissions
 
-The `token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever this repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
+The `bot_token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever this repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
 
 Pass one of the following:
 
@@ -80,7 +82,7 @@ Pass one of the following:
 - A **fine-grained Personal Access Token** scoped to this repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on the source repo.
 - A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
 
-Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
+Store the token in a secret (e.g., `BOT_TOKEN`) and pass it via `bot_token: ${{ secrets.BOT_TOKEN }}`. Optionally set a `BOT_USERNAME` repository variable to control the commit author identity.
 
 See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and [GitHub App installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
 

--- a/.github/actions/agents-rules-sync/action.yml
+++ b/.github/actions/agents-rules-sync/action.yml
@@ -2,10 +2,14 @@ name: Agents rules sync
 description: Sync the stack-appropriate agent rules file from an upstream repository into the current repository's CLAUDE.md.
 
 inputs:
-  token:
+  bot_token:
     description: |
       PAT (classic with `repo`, or fine-grained with `contents: write` + `pull-requests: write` on this repo) or GitHub App installation token. The workflow's default `GITHUB_TOKEN` is not supported — it cannot create pull requests when the repo/org has "Allow GitHub Actions to create and approve pull requests" disabled, and the resulting 403 is opaque. See README for setup.
     required: true
+  bot_username:
+    description: |
+      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute commits to a dedicated bot identity.
+    required: false
   source-repo:
     description: Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.
     required: false
@@ -47,7 +51,7 @@ runs:
       id: resolve
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.token }}
+        GITHUB_TOKEN: ${{ inputs.bot_token }}
         DEST_REPO: ${{ github.repository }}
         INPUT_SOURCE_REPO: ${{ inputs.source-repo }}
         INPUT_SOURCE_REF: ${{ inputs.source-ref }}
@@ -60,7 +64,8 @@ runs:
       uses: awinogradov/code-assistants/.github/actions/files-sync@main
       with:
         files: ${{ steps.resolve.outputs.files }}
-        token: ${{ inputs.token }}
+        bot_token: ${{ inputs.bot_token }}
+        bot_username: ${{ inputs.bot_username }}
         branch: maintenance-sync-agents-rules
         title: "MAINTENANCE: Sync agent rules from upstream"
         body: Automated agent rules sync from upstream.

--- a/.github/actions/agents-rules-sync/agents-rules-sync.ts
+++ b/.github/actions/agents-rules-sync/agents-rules-sync.ts
@@ -39,7 +39,7 @@ function requiredToken(): string {
 
   if (value === undefined || value === '') {
     throw new Error(
-      'GITHUB_TOKEN is empty. Pass an explicit PAT or GitHub App installation token via the action\'s `token` input — ' +
+      'GITHUB_TOKEN is empty. Pass an explicit PAT or GitHub App installation token via the action\'s `bot_token` input — ' +
         'the workflow\'s default `GITHUB_TOKEN` is not supported because it cannot create pull requests when the repo/org ' +
         'disables "Allow GitHub Actions to create and approve pull requests". ' +
         'See https://github.com/awinogradov/code-assistants/blob/main/.github/actions/agents-rules-sync/README.md#permissions',

--- a/.github/actions/code-review-sync/README.md
+++ b/.github/actions/code-review-sync/README.md
@@ -35,16 +35,18 @@ jobs:
     steps:
       - uses: awinogradov/code-assistants/.github/actions/code-review-sync@v1
         with:
-          token: ${{ secrets.SYNC_PAT }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
 ```
 
 ## Inputs
 
-| Input         | Required | Default                       | Description                                                                                                                                                                                      |
-| ------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `token`       | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
-| `source-repo` | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the canonical `.github/workflows/code-review.yml`.                                                                                             |
-| `source-ref`  | no       | _(empty)_                     | Branch, tag, or SHA to read the source file from. Empty → source repository default branch.                                                                                                      |
+| Input          | Required | Default                       | Description                                                                                                                                                                                      |
+| -------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bot_token`    | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
+| `bot_username` | no       | `github-actions[bot]`         | Git author/committer login for the sync commit. Pass `${{ vars.BOT_USERNAME }}`. The PR itself is opened by the `bot_token` owner.                                                               |
+| `source-repo`  | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the canonical `.github/workflows/code-review.yml`.                                                                                             |
+| `source-ref`   | no       | _(empty)_                     | Branch, tag, or SHA to read the source file from. Empty → source repository default branch.                                                                                                      |
 
 PR-shaping inputs (branch, title, body, commit message) are fixed by design — see
 [Behavior](#behavior).
@@ -59,7 +61,7 @@ PR-shaping inputs (branch, title, body, commit message) are fixed by design — 
 
 ## Permissions
 
-The `token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever this repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
+The `bot_token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever this repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
 
 Pass one of the following:
 
@@ -67,7 +69,7 @@ Pass one of the following:
 - A **fine-grained Personal Access Token** scoped to this repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on the source repo.
 - A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
 
-Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
+Store the token in a secret (e.g., `BOT_TOKEN`) and pass it via `bot_token: ${{ secrets.BOT_TOKEN }}`. Optionally set a `BOT_USERNAME` repository variable to control the commit author identity.
 
 See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and [GitHub App installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
 

--- a/.github/actions/code-review-sync/action.yml
+++ b/.github/actions/code-review-sync/action.yml
@@ -2,10 +2,14 @@ name: Code review sync
 description: Sync the AI code-review workflow from an upstream repository into the current repository.
 
 inputs:
-  token:
+  bot_token:
     description: |
       PAT (classic with `repo`, or fine-grained with `contents: write` + `pull-requests: write` on this repo) or GitHub App installation token. The workflow's default `GITHUB_TOKEN` is not supported — it cannot create pull requests when the repo/org has "Allow GitHub Actions to create and approve pull requests" disabled, and the resulting 403 is opaque. See README for setup.
     required: true
+  bot_username:
+    description: |
+      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute commits to a dedicated bot identity.
+    required: false
   source-repo:
     description: Source repository in `owner/name` form that hosts the canonical `.github/workflows/code-review.yml`.
     required: false
@@ -58,7 +62,8 @@ runs:
       uses: awinogradov/code-assistants/.github/actions/files-sync@main
       with:
         files: ${{ steps.resolve.outputs.files }}
-        token: ${{ inputs.token }}
+        bot_token: ${{ inputs.bot_token }}
+        bot_username: ${{ inputs.bot_username }}
         branch: maintenance-sync-code-review
         title: "MAINTENANCE: Sync code-review workflow from upstream"
         body: Automated code-review workflow sync from upstream.

--- a/.github/actions/contributing-sync/README.md
+++ b/.github/actions/contributing-sync/README.md
@@ -39,16 +39,18 @@ jobs:
     steps:
       - uses: awinogradov/code-assistants/.github/actions/contributing-sync@v1
         with:
-          token: ${{ secrets.SYNC_PAT }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
 ```
 
 ## Inputs
 
-| Input         | Required | Default                       | Description                                                                                                                                                                                      |
-| ------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `token`       | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
-| `source-repo` | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the canonical `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md`.                                                                       |
-| `source-ref`  | no       | _(empty)_                     | Branch, tag, or SHA to read the source files from. Empty → source repository default branch.                                                                                                     |
+| Input          | Required | Default                       | Description                                                                                                                                                                                      |
+| -------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bot_token`    | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
+| `bot_username` | no       | `github-actions[bot]`         | Git author/committer login for the sync commit. Pass `${{ vars.BOT_USERNAME }}`. The PR itself is opened by the `bot_token` owner.                                                               |
+| `source-repo`  | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the canonical `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md`.                                                                       |
+| `source-ref`   | no       | _(empty)_                     | Branch, tag, or SHA to read the source files from. Empty → source repository default branch.                                                                                                     |
 
 PR-shaping inputs (branch, title, body, commit message) are fixed by design — see
 [Behavior](#behavior).
@@ -63,7 +65,7 @@ PR-shaping inputs (branch, title, body, commit message) are fixed by design — 
 
 ## Permissions
 
-The `token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever this repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
+The `bot_token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever this repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
 
 Pass one of the following:
 
@@ -71,7 +73,7 @@ Pass one of the following:
 - A **fine-grained Personal Access Token** scoped to this repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on the source repo.
 - A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
 
-Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
+Store the token in a secret (e.g., `BOT_TOKEN`) and pass it via `bot_token: ${{ secrets.BOT_TOKEN }}`. Optionally set a `BOT_USERNAME` repository variable to control the commit author identity.
 
 See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and [GitHub App installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
 

--- a/.github/actions/contributing-sync/action.yml
+++ b/.github/actions/contributing-sync/action.yml
@@ -2,10 +2,14 @@ name: Contributing sync
 description: Sync CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE.md, and the contributing workflow from an upstream repository into the current repository.
 
 inputs:
-  token:
+  bot_token:
     description: |
       PAT (classic with `repo`, or fine-grained with `contents: write` + `pull-requests: write` on this repo) or GitHub App installation token. The workflow's default `GITHUB_TOKEN` is not supported — it cannot create pull requests when the repo/org has "Allow GitHub Actions to create and approve pull requests" disabled, and the resulting 403 is opaque. See README for setup.
     required: true
+  bot_username:
+    description: |
+      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute commits to a dedicated bot identity.
+    required: false
   source-repo:
     description: Source repository in `owner/name` form that hosts the canonical `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md`.
     required: false
@@ -61,7 +65,8 @@ runs:
       uses: awinogradov/code-assistants/.github/actions/files-sync@main
       with:
         files: ${{ steps.resolve.outputs.files }}
-        token: ${{ inputs.token }}
+        bot_token: ${{ inputs.bot_token }}
+        bot_username: ${{ inputs.bot_username }}
         branch: maintenance-sync-contributing
         title: "MAINTENANCE: Sync contributing files from upstream"
         body: Automated contributing files sync from upstream.

--- a/.github/actions/files-sync/README.md
+++ b/.github/actions/files-sync/README.md
@@ -29,7 +29,8 @@ jobs:
     steps:
       - uses: awinogradov/code-assistants/.github/actions/files-sync@v1
         with:
-          token: ${{ secrets.SYNC_PAT }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
           files: |
             - repo: awinogradov/code-assistants
               source: CONTRIBUTING.md
@@ -52,7 +53,8 @@ files: |
 | Input            | Required | Default                                           | Description                                                                                                                                                                                                 |
 | ---------------- | -------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `files`          | yes      | —                                                 | YAML list of entries — either a [content entry](#content-entry) or a [symlink entry](#symlink-entry). At least one required.                                                                                |
-| `token`          | yes      | —                                                 | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on the destination repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
+| `bot_token`      | yes      | —                                                 | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on the destination repo. The workflow's default `GITHUB_TOKEN` is **not** supported — see [Permissions](#permissions). |
+| `bot_username`   | no       | `github-actions[bot]`                             | Git author/committer login for the sync commit. Pass `${{ vars.BOT_USERNAME }}`. The PR itself is opened by the `bot_token` owner.                                                                          |
 | `base`           | no       | `${{ github.event.repository.default_branch }}`   | Base branch the PR targets.                                                                                                                                                                                 |
 | `branch`         | no       | `maintenance-sync-files`                          | Head branch the PR uses. Force-updated on subsequent runs.                                                                                                                                                  |
 | `title`          | no       | `MAINTENANCE: Sync files from upstream`           | PR title. Uses the `MAINTENANCE:` prefix per CONTRIBUTING.md.                                                                                                                                               |
@@ -87,7 +89,7 @@ A symlink entry writes a Git mode `120000` blob whose body is the literal `symli
 
 ## Permissions
 
-The `token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever the destination repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
+The `bot_token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever the destination repo or its org disables the **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** toggle.
 
 Pass one of the following:
 
@@ -95,7 +97,7 @@ Pass one of the following:
 - A **fine-grained Personal Access Token** scoped to the destination repository with `Contents: Read and write` and `Pull requests: Read and write`. For private source repositories, the same token also needs `Contents: Read` on each source repo.
 - A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
 
-Store the token in a secret (e.g., `SYNC_PAT`) and pass it via `token: ${{ secrets.SYNC_PAT }}`.
+Store the token in a secret (e.g., `BOT_TOKEN`) and pass it via `bot_token: ${{ secrets.BOT_TOKEN }}`. Optionally set a `BOT_USERNAME` repository variable to control the commit author identity.
 
 See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and [GitHub App installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
 

--- a/.github/actions/files-sync/action.yml
+++ b/.github/actions/files-sync/action.yml
@@ -5,10 +5,14 @@ inputs:
   files:
     description: YAML list of sync entries. Each item must define `repo` (owner/name), `source`, `dest`, and optionally `ref`.
     required: true
-  token:
+  bot_token:
     description: |
       PAT (classic with `repo`, or fine-grained with `contents: write` + `pull-requests: write` on the destination repo) or GitHub App installation token. The workflow's default `GITHUB_TOKEN` is not supported — it cannot create pull requests when the destination repo/org has "Allow GitHub Actions to create and approve pull requests" disabled, and the resulting 403 is opaque. See README for setup.
     required: true
+  bot_username:
+    description: |
+      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute commits to a dedicated bot identity.
+    required: false
   base:
     description: Base branch the PR targets.
     required: false
@@ -59,7 +63,8 @@ runs:
       shell: bash
       env:
         FILES_INPUT: ${{ inputs.files }}
-        GITHUB_TOKEN: ${{ inputs.token }}
+        GITHUB_TOKEN: ${{ inputs.bot_token }}
+        INPUT_BOT_USERNAME: ${{ inputs.bot_username }}
         INPUT_BASE: ${{ inputs.base }}
         INPUT_BRANCH: ${{ inputs.branch }}
         INPUT_TITLE: ${{ inputs.title }}

--- a/.github/actions/files-sync/files-sync.ts
+++ b/.github/actions/files-sync/files-sync.ts
@@ -19,6 +19,7 @@
 import * as core from '@actions/core';
 import { Octokit } from '@octokit/rest';
 
+import { resolveBotIdentity, type BotIdentity } from './src/botIdentity.ts';
 import { computeChanges } from './src/changeDetector.ts';
 import { createSyncPullRequest } from './src/createSyncPullRequest.ts';
 import {
@@ -37,6 +38,7 @@ interface Env {
   title: string;
   body: string;
   commitMessage: string;
+  identity: BotIdentity;
 }
 
 function readEnv(): Env {
@@ -48,6 +50,7 @@ function readEnv(): Env {
   const title = required('INPUT_TITLE');
   const body = required('INPUT_BODY');
   const commitMessage = required('INPUT_COMMIT_MESSAGE');
+  const identity = resolveBotIdentity(process.env.INPUT_BOT_USERNAME);
 
   const { owner, name } = parseRepoSlug(repository);
 
@@ -60,6 +63,7 @@ function readEnv(): Env {
     title,
     body,
     commitMessage,
+    identity,
   };
 }
 
@@ -78,7 +82,7 @@ function requiredToken(): string {
 
   if (value === undefined || value === '') {
     throw new Error(
-      'GITHUB_TOKEN is empty. Pass an explicit PAT or GitHub App installation token via the action\'s `token` input — ' +
+      'GITHUB_TOKEN is empty. Pass an explicit PAT or GitHub App installation token via the action\'s `bot_token` input — ' +
         'the workflow\'s default `GITHUB_TOKEN` is not supported because it cannot create pull requests when the destination ' +
         'repo/org disables "Allow GitHub Actions to create and approve pull requests". ' +
         'See https://github.com/awinogradov/code-assistants/blob/main/.github/actions/files-sync/README.md#permissions',
@@ -167,6 +171,8 @@ async function main(): Promise<void> {
   const paths = changes.map((change) => change.path);
   const body = composeBody(env.body, paths);
 
+  core.info(`Authoring sync commit as ${env.identity.name} <${env.identity.email}>`);
+
   const pr = await createSyncPullRequest({
     octokit,
     destRepo: env.destRepo,
@@ -176,6 +182,7 @@ async function main(): Promise<void> {
     body,
     commitMessage: env.commitMessage,
     changes,
+    identity: env.identity,
   });
 
   core.setOutput('changed-files', paths.join('\n'));

--- a/.github/actions/files-sync/files-sync.ts
+++ b/.github/actions/files-sync/files-sync.ts
@@ -19,7 +19,7 @@
 import * as core from '@actions/core';
 import { Octokit } from '@octokit/rest';
 
-import { resolveBotIdentity, type BotIdentity } from './src/botIdentity.ts';
+import { resolveBotIdentity } from './src/botIdentity.ts';
 import { computeChanges } from './src/changeDetector.ts';
 import { createSyncPullRequest } from './src/createSyncPullRequest.ts';
 import {
@@ -38,7 +38,6 @@ interface Env {
   title: string;
   body: string;
   commitMessage: string;
-  identity: BotIdentity;
 }
 
 function readEnv(): Env {
@@ -50,7 +49,6 @@ function readEnv(): Env {
   const title = required('INPUT_TITLE');
   const body = required('INPUT_BODY');
   const commitMessage = required('INPUT_COMMIT_MESSAGE');
-  const identity = resolveBotIdentity(process.env.INPUT_BOT_USERNAME);
 
   const { owner, name } = parseRepoSlug(repository);
 
@@ -63,7 +61,6 @@ function readEnv(): Env {
     title,
     body,
     commitMessage,
-    identity,
   };
 }
 
@@ -148,6 +145,7 @@ async function main(): Promise<void> {
   core.info(`Resolved ${entries.length} sync entr${entries.length === 1 ? 'y' : 'ies'}.`);
 
   const octokit = new Octokit({ auth: env.token });
+  const identity = await resolveBotIdentity(octokit, process.env.INPUT_BOT_USERNAME);
 
   const changes = await computeChanges({
     octokit,
@@ -171,7 +169,7 @@ async function main(): Promise<void> {
   const paths = changes.map((change) => change.path);
   const body = composeBody(env.body, paths);
 
-  core.info(`Authoring sync commit as ${env.identity.name} <${env.identity.email}>`);
+  core.info(`Authoring sync commit as ${identity.name} <${identity.email}>`);
 
   const pr = await createSyncPullRequest({
     octokit,
@@ -182,7 +180,7 @@ async function main(): Promise<void> {
     body,
     commitMessage: env.commitMessage,
     changes,
-    identity: env.identity,
+    identity,
   });
 
   core.setOutput('changed-files', paths.join('\n'));

--- a/.github/actions/files-sync/src/botIdentity.test.ts
+++ b/.github/actions/files-sync/src/botIdentity.test.ts
@@ -1,33 +1,47 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 
 import { resolveBotIdentity } from './botIdentity.ts';
 
+function makeOctokit(
+  getByUsername: (args: { username: string }) => Promise<{ data: { id: number } }>,
+) {
+  return { rest: { users: { getByUsername } } };
+}
+
 describe('resolveBotIdentity', () => {
-  const defaultIdentity = {
-    name: 'github-actions[bot]',
-    email: '41898282+github-actions[bot]@users.noreply.github.com',
-  };
+  test('defaults to github-actions[bot] without a lookup when username is empty', async () => {
+    const getByUsername = mock(async () => ({ data: { id: 999 } }));
+    const octokit = makeOctokit(getByUsername);
+    const expected = {
+      name: 'github-actions[bot]',
+      email: '41898282+github-actions[bot]@users.noreply.github.com',
+    };
 
-  test('falls back to github-actions[bot] when username is undefined', () => {
-    expect(resolveBotIdentity()).toEqual(defaultIdentity);
+    expect(await resolveBotIdentity(octokit)).toEqual(expected);
+    expect(await resolveBotIdentity(octokit, '   ')).toEqual(expected);
+    expect(getByUsername).not.toHaveBeenCalled();
   });
 
-  test('falls back to github-actions[bot] for an empty or whitespace username', () => {
-    expect(resolveBotIdentity('')).toEqual(defaultIdentity);
-    expect(resolveBotIdentity('   ')).toEqual(defaultIdentity);
-  });
+  test('resolves a custom username to its real GitHub user id', async () => {
+    const getByUsername = mock(async ({ username }: { username: string }) => {
+      expect(username).toBe('symbiot-bot');
+      return { data: { id: 123456 } };
+    });
 
-  test('uses the provided username and derives the noreply email', () => {
-    expect(resolveBotIdentity('symbiot-bot')).toEqual({
+    expect(await resolveBotIdentity(makeOctokit(getByUsername), '  symbiot-bot  ')).toEqual({
       name: 'symbiot-bot',
-      email: '41898282+symbiot-bot@users.noreply.github.com',
+      email: '123456+symbiot-bot@users.noreply.github.com',
     });
   });
 
-  test('trims surrounding whitespace from the username', () => {
-    expect(resolveBotIdentity('  symbiot-bot  ')).toEqual({
-      name: 'symbiot-bot',
-      email: '41898282+symbiot-bot@users.noreply.github.com',
+  test('falls back to the github-actions[bot] id when the lookup fails', async () => {
+    const getByUsername = mock(async () => {
+      throw new Error('404');
+    });
+
+    expect(await resolveBotIdentity(makeOctokit(getByUsername), 'ghost-bot')).toEqual({
+      name: 'ghost-bot',
+      email: '41898282+ghost-bot@users.noreply.github.com',
     });
   });
 });

--- a/.github/actions/files-sync/src/botIdentity.test.ts
+++ b/.github/actions/files-sync/src/botIdentity.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveBotIdentity } from './botIdentity.ts';
+
+describe('resolveBotIdentity', () => {
+  const defaultIdentity = {
+    name: 'github-actions[bot]',
+    email: '41898282+github-actions[bot]@users.noreply.github.com',
+  };
+
+  test('falls back to github-actions[bot] when username is undefined', () => {
+    expect(resolveBotIdentity()).toEqual(defaultIdentity);
+  });
+
+  test('falls back to github-actions[bot] for an empty or whitespace username', () => {
+    expect(resolveBotIdentity('')).toEqual(defaultIdentity);
+    expect(resolveBotIdentity('   ')).toEqual(defaultIdentity);
+  });
+
+  test('uses the provided username and derives the noreply email', () => {
+    expect(resolveBotIdentity('symbiot-bot')).toEqual({
+      name: 'symbiot-bot',
+      email: '41898282+symbiot-bot@users.noreply.github.com',
+    });
+  });
+
+  test('trims surrounding whitespace from the username', () => {
+    expect(resolveBotIdentity('  symbiot-bot  ')).toEqual({
+      name: 'symbiot-bot',
+      email: '41898282+symbiot-bot@users.noreply.github.com',
+    });
+  });
+});

--- a/.github/actions/files-sync/src/botIdentity.ts
+++ b/.github/actions/files-sync/src/botIdentity.ts
@@ -1,0 +1,35 @@
+/**
+ * Git author/committer identity for files-sync commits.
+ *
+ * @see https://github.com/awinogradov/code-assistants/blob/main/.github/actions/files-sync/README.md
+ */
+export interface BotIdentity {
+  name: string;
+  email: string;
+}
+
+const defaultUsername = 'github-actions[bot]';
+const defaultUserId = '41898282';
+
+/**
+ * Resolves the git identity used to author sync commits.
+ *
+ * Decouples commit attribution from the `bot_token` owner: regardless of whose PAT
+ * authenticates the Git Data API call, commits are authored by the configured
+ * `bot_username`, falling back to GitHub's native `github-actions[bot]` when unset.
+ *
+ * @param username - The `bot_username` action input (`INPUT_BOT_USERNAME`). Empty or
+ *   whitespace-only values fall back to `github-actions[bot]`.
+ * @returns The resolved `{ name, email }`, where `email` is the `<uid>+<name>` GitHub noreply address.
+ *
+ * @example
+ *   resolveBotIdentity('symbiot-bot');
+ *   // → { name: 'symbiot-bot', email: '41898282+symbiot-bot@users.noreply.github.com' }
+ *   resolveBotIdentity();
+ *   // → { name: 'github-actions[bot]', email: '41898282+github-actions[bot]@users.noreply.github.com' }
+ */
+export function resolveBotIdentity(username?: string): BotIdentity {
+  const name = username?.trim() || defaultUsername;
+
+  return { name, email: `${defaultUserId}+${name}@users.noreply.github.com` };
+}

--- a/.github/actions/files-sync/src/botIdentity.ts
+++ b/.github/actions/files-sync/src/botIdentity.ts
@@ -8,28 +8,50 @@ export interface BotIdentity {
   email: string;
 }
 
+/** Minimal Octokit surface needed to resolve a GitHub user's numeric id. */
+interface UserLookup {
+  rest: {
+    users: {
+      getByUsername: (args: { username: string }) => Promise<{ data: { id: number } }>;
+    };
+  };
+}
+
 const defaultUsername = 'github-actions[bot]';
 const defaultUserId = '41898282';
 
+function buildIdentity(name: string, userId: string): BotIdentity {
+  return { name, email: `${userId}+${name}@users.noreply.github.com` };
+}
+
 /**
- * Resolves the git identity used to author sync commits.
+ * Resolves the git identity used to author sync commits, decoupling attribution
+ * from the `bot_token` owner.
  *
- * Decouples commit attribution from the `bot_token` owner: regardless of whose PAT
- * authenticates the Git Data API call, commits are authored by the configured
- * `bot_username`, falling back to GitHub's native `github-actions[bot]` when unset.
+ * The numeric id in the noreply email is read from the live GitHub API so a custom
+ * `bot_username` links to its real account. `github-actions[bot]` uses its well-known
+ * id without a lookup, and any lookup failure falls back to that id.
  *
- * @param username - The `bot_username` action input (`INPUT_BOT_USERNAME`). Empty or
- *   whitespace-only values fall back to `github-actions[bot]`.
- * @returns The resolved `{ name, email }`, where `email` is the `<uid>+<name>` GitHub noreply address.
+ * @param octokit - Authenticated client used to look up the user id.
+ * @param username - The `bot_username` action input. Empty/whitespace falls back to `github-actions[bot]`.
  *
  * @example
- *   resolveBotIdentity('symbiot-bot');
- *   // → { name: 'symbiot-bot', email: '41898282+symbiot-bot@users.noreply.github.com' }
- *   resolveBotIdentity();
+ *   await resolveBotIdentity(octokit, 'symbiot-bot');
+ *   // → { name: 'symbiot-bot', email: '123456+symbiot-bot@users.noreply.github.com' }
+ *   await resolveBotIdentity(octokit);
  *   // → { name: 'github-actions[bot]', email: '41898282+github-actions[bot]@users.noreply.github.com' }
  */
-export function resolveBotIdentity(username?: string): BotIdentity {
+export async function resolveBotIdentity(octokit: UserLookup, username?: string): Promise<BotIdentity> {
   const name = username?.trim() || defaultUsername;
 
-  return { name, email: `${defaultUserId}+${name}@users.noreply.github.com` };
+  if (name === defaultUsername) {
+    return buildIdentity(name, defaultUserId);
+  }
+
+  try {
+    const { data } = await octokit.rest.users.getByUsername({ username: name });
+    return buildIdentity(name, String(data.id));
+  } catch {
+    return buildIdentity(name, defaultUserId);
+  }
 }

--- a/.github/actions/files-sync/src/createSyncPullRequest.test.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.test.ts
@@ -2,12 +2,17 @@ import { describe, expect, test } from 'bun:test';
 
 import type { Octokit } from '@octokit/rest';
 
+import type { BotIdentity } from './botIdentity.ts';
 import type { FileChange } from './changeDetector.ts';
 import { createSyncPullRequest } from './createSyncPullRequest.ts';
 
 interface MockOverrides {
   listOpenPrs?: () => Promise<{ data: Array<{ number: number; html_url: string }> }>;
   createPr?: () => Promise<{ data: { number: number; html_url: string } }>;
+  createCommit?: (args: {
+    author: BotIdentity;
+    committer: BotIdentity;
+  }) => Promise<{ data: { sha: string } }>;
 }
 
 function makeOctokit(overrides: MockOverrides = {}): Octokit {
@@ -15,6 +20,7 @@ function makeOctokit(overrides: MockOverrides = {}): Octokit {
   const createPr =
     overrides.createPr ??
     (async () => ({ data: { number: 42, html_url: 'https://github.com/owner/repo/pull/42' } }));
+  const createCommit = overrides.createCommit ?? (async () => ({ data: { sha: 'new-commit-sha' } }));
 
   return {
     rest: {
@@ -23,7 +29,7 @@ function makeOctokit(overrides: MockOverrides = {}): Octokit {
         getCommit: async () => ({ data: { tree: { sha: 'base-tree-sha' } } }),
         createBlob: async () => ({ data: { sha: 'blob-sha' } }),
         createTree: async () => ({ data: { sha: 'new-tree-sha' } }),
-        createCommit: async () => ({ data: { sha: 'new-commit-sha' } }),
+        createCommit,
         createRef: async () => ({ data: {} }),
         updateRef: async () => ({ data: {} }),
       },
@@ -43,6 +49,10 @@ const baseArgs = {
   body: 'body',
   commitMessage: 'chore: sync',
   changes: [{ path: 'CLAUDE.md', content: 'hello', mode: '100644' }] satisfies FileChange[],
+  identity: {
+    name: 'github-actions[bot]',
+    email: '41898282+github-actions[bot]@users.noreply.github.com',
+  },
 };
 
 describe('createSyncPullRequest', () => {
@@ -52,6 +62,25 @@ describe('createSyncPullRequest', () => {
     const pr = await createSyncPullRequest({ octokit, ...baseArgs });
 
     expect(pr).toEqual({ number: 42, htmlUrl: 'https://github.com/owner/repo/pull/42' });
+  });
+
+  test('authors and commits as the resolved bot identity', async () => {
+    let captured: { author: BotIdentity; committer: BotIdentity } | undefined;
+    const octokit = makeOctokit({
+      createCommit: async (args) => {
+        captured = args;
+        return { data: { sha: 'new-commit-sha' } };
+      },
+    });
+    const identity = {
+      name: 'symbiot-bot',
+      email: '41898282+symbiot-bot@users.noreply.github.com',
+    };
+
+    await createSyncPullRequest({ ...baseArgs, octokit, identity });
+
+    expect(captured?.author).toEqual(identity);
+    expect(captured?.committer).toEqual(identity);
   });
 
   test('rethrows 403 from pulls.create with PAT / GitHub App guidance and README link', async () => {

--- a/.github/actions/files-sync/src/createSyncPullRequest.test.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.test.ts
@@ -79,6 +79,7 @@ describe('createSyncPullRequest', () => {
 
     await createSyncPullRequest({ ...baseArgs, octokit, identity });
 
+    expect(captured).toBeDefined();
     expect(captured?.author).toEqual(identity);
     expect(captured?.committer).toEqual(identity);
   });

--- a/.github/actions/files-sync/src/createSyncPullRequest.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.ts
@@ -11,6 +11,7 @@
 import type { Octokit } from '@octokit/rest';
 import type { RequestError } from '@octokit/request-error';
 
+import type { BotIdentity } from './botIdentity.ts';
 import type { FileChange } from './changeDetector.ts';
 
 interface CreateArgs {
@@ -22,6 +23,7 @@ interface CreateArgs {
   body: string;
   commitMessage: string;
   changes: FileChange[];
+  identity: BotIdentity;
 }
 
 export interface SyncPullRequest {
@@ -38,6 +40,7 @@ export async function createSyncPullRequest({
   body,
   commitMessage,
   changes,
+  identity,
 }: CreateArgs): Promise<SyncPullRequest> {
   const { owner, name: repo } = destRepo;
 
@@ -84,6 +87,8 @@ export async function createSyncPullRequest({
     message: commitMessage,
     tree: newTree.data.sha,
     parents: [baseCommitSha],
+    author: identity,
+    committer: identity,
   });
 
   await upsertBranch({ octokit, owner, repo, branch, sha: newCommit.data.sha });
@@ -188,7 +193,7 @@ async function upsertPullRequest({
     if (requestError.status === 403) {
       throw new Error(
         `Refused to create pull request in ${owner}/${repo}: ${requestError.message}. ` +
-          'Confirm the `token` input is a PAT or GitHub App installation token with `contents: write` + `pull-requests: write` ' +
+          'Confirm the `bot_token` input is a PAT or GitHub App installation token with `contents: write` + `pull-requests: write` ' +
           `on ${owner}/${repo} (not the workflow's default \`GITHUB_TOKEN\`). ` +
           'See https://github.com/awinogradov/code-assistants/blob/main/.github/actions/files-sync/README.md#permissions',
         { cause: error },

--- a/.github/actions/release-action/README.md
+++ b/.github/actions/release-action/README.md
@@ -34,7 +34,8 @@ jobs:
       - uses: awinogradov/code-assistants/.github/actions/release-action@v1
         with:
           mode: create
-          github_token: ${{ secrets.GH_TOKEN }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_RELEASE_KEY }}
           linear_api_key: ${{ secrets.LINEAR_API_KEY }}
           linear_keys: ${{ vars.LINEAR_KEYS }}
@@ -64,28 +65,30 @@ jobs:
       - uses: awinogradov/code-assistants/.github/actions/release-action@v1
         with:
           mode: publish
-          github_token: ${{ secrets.GH_TOKEN }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
           npm_token: ${{ secrets.NPM_TOKEN }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
 ```
 
 ## Inputs
 
-| Input               | Required | Default             | Description                                                                                                     |
-| ------------------- | -------- | ------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `mode`              | yes      | —                   | `create` or `publish`.                                                                                          |
-| `github_token`      | yes      | —                   | PAT or App installation token with `contents: write` + `pull-requests: write`. See [Permissions](#permissions). |
-| `npm_token`         | no       | —                   | NPM token. Required for `publish` with `lib-nodejs` or `lib-bun` release types.                                 |
-| `anthropic_api_key` | no       | —                   | Anthropic API key. When set, generates human-readable release-note summaries.                                   |
-| `name`              | no       | —                   | Service or library name for PR titles (e.g. `Dialog Manager` → `Release Dialog Manager 1.2.0`).                 |
-| `branch`            | no       | `release-{version}` | Release branch template. `{version}` is substituted. `create` mode only.                                        |
-| `linear_api_key`    | no       | —                   | Linear API key for ticket integration.                                                                          |
-| `linear_keys`       | no       | —                   | Comma-separated Linear key prefixes (e.g. `TEAM,PROJ`).                                                         |
-| `jira_base_url`     | no       | —                   | Jira instance base URL (used with `jira_email` + `jira_api_token`).                                             |
-| `jira_email`        | no       | —                   | Jira authentication email.                                                                                      |
-| `jira_api_token`    | no       | —                   | Jira API token.                                                                                                 |
-| `jira_keys`         | no       | —                   | Comma-separated Jira key prefixes.                                                                              |
-| `slack_token`       | no       | —                   | Slack bot token. Required to post release notifications.                                                        |
+| Input               | Required | Default               | Description                                                                                                     |
+| ------------------- | -------- | --------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `mode`              | yes      | —                     | `create` or `publish`.                                                                                          |
+| `bot_token`         | yes      | —                     | PAT or App installation token with `contents: write` + `pull-requests: write`. See [Permissions](#permissions). |
+| `bot_username`      | no       | `github-actions[bot]` | Git author/committer login for release commits, tags, and PRs. Pass `${{ vars.BOT_USERNAME }}`.                 |
+| `npm_token`         | no       | —                     | NPM token. Required for `publish` with `lib-nodejs` or `lib-bun` release types.                                 |
+| `anthropic_api_key` | no       | —                     | Anthropic API key. When set, generates human-readable release-note summaries.                                   |
+| `name`              | no       | —                     | Service or library name for PR titles (e.g. `Dialog Manager` → `Release Dialog Manager 1.2.0`).                 |
+| `branch`            | no       | `release-{version}`   | Release branch template. `{version}` is substituted. `create` mode only.                                        |
+| `linear_api_key`    | no       | —                     | Linear API key for ticket integration.                                                                          |
+| `linear_keys`       | no       | —                     | Comma-separated Linear key prefixes (e.g. `TEAM,PROJ`).                                                         |
+| `jira_base_url`     | no       | —                     | Jira instance base URL (used with `jira_email` + `jira_api_token`).                                             |
+| `jira_email`        | no       | —                     | Jira authentication email.                                                                                      |
+| `jira_api_token`    | no       | —                     | Jira API token.                                                                                                 |
+| `jira_keys`         | no       | —                     | Comma-separated Jira key prefixes.                                                                              |
+| `slack_token`       | no       | —                     | Slack bot token. Required to post release notifications.                                                        |
 
 ## Outputs
 
@@ -135,7 +138,7 @@ Extract ticket IDs from PR titles and commit messages, then fetch details via AP
 | ------------- | ---------- | ----------------------------------------------- |
 | Linear        | `TEAM-123` | `LINEAR_API_KEY`                                |
 | Jira          | `PROJ-456` | `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN` |
-| GitHub Issues | `#123`     | `GH_TOKEN`                                      |
+| GitHub Issues | `#123`     | `BOT_TOKEN`                                     |
 
 Optional key filtering via `LINEAR_KEYS` / `JIRA_KEYS` (e.g. `TEAM,PROJ`). When multiple ticket systems are configured, prefix keys are required so the action can route each ticket to the right system.
 
@@ -156,7 +159,7 @@ Then pass `slack_token` to the publish workflow. The bot token needs the `chat:w
 
 ## Permissions
 
-The `github_token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever the repo or its org disables **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**.
+The `bot_token` input is **required**. The workflow's default `GITHUB_TOKEN` is not supported, because creating pull requests with it can fail with an opaque 403 (`GitHub Actions is not permitted to create or approve pull requests`) whenever the repo or its org disables **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**.
 
 Pass one of:
 
@@ -164,9 +167,9 @@ Pass one of:
 - A **fine-grained Personal Access Token** scoped to the repo with `Contents: Read and write` and `Pull requests: Read and write`.
 - A **GitHub App installation token** with the same `contents: write` + `pull-requests: write` permissions. (App tokens are not subject to the workflow-permissions toggle above — that toggle gates `GITHUB_TOKEN` only.)
 
-Store the token as a secret (e.g. `GH_TOKEN`) and pass it via `github_token: ${{ secrets.GH_TOKEN }}`.
+Store the token as a secret (e.g. `BOT_TOKEN`) and pass it via `bot_token: ${{ secrets.BOT_TOKEN }}`.
 
-The Configure Git step inside the action commits as `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`.
+The Configure Git step inside the action commits as the `bot_username` input, defaulting to `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`. Pass `bot_username: ${{ vars.BOT_USERNAME }}` to author releases as a dedicated bot identity.
 
 ## Monorepo mode
 
@@ -231,7 +234,8 @@ jobs:
       - uses: awinogradov/code-assistants/.github/actions/release-action@v1
         with:
           mode: publish
-          github_token: ${{ secrets.GH_TOKEN }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
           npm_token: ${{ secrets.NPM_TOKEN }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
         env:

--- a/.github/actions/release-action/action.yml
+++ b/.github/actions/release-action/action.yml
@@ -107,11 +107,17 @@ runs:
       shell: bash
       env:
         INPUT_BOT_USERNAME: ${{ inputs.bot_username }}
+        GH_TOKEN: ${{ inputs.bot_token }}
       run: |
         bot_user="${INPUT_BOT_USERNAME:-github-actions[bot]}"
+        if [ "$bot_user" = "github-actions[bot]" ]; then
+          bot_uid=41898282
+        else
+          bot_uid=$(gh api "users/${bot_user}" --jq '.id' 2>/dev/null || echo 41898282)
+        fi
         git config --global user.name "$bot_user"
-        git config --global user.email "41898282+${bot_user}@users.noreply.github.com"
-        echo "Authoring as: $bot_user <41898282+${bot_user}@users.noreply.github.com>"
+        git config --global user.email "${bot_uid}+${bot_user}@users.noreply.github.com"
+        echo "Authoring as: $bot_user <${bot_uid}+${bot_user}@users.noreply.github.com>"
 
     - name: Detect release type
       id: detect-type

--- a/.github/actions/release-action/action.yml
+++ b/.github/actions/release-action/action.yml
@@ -8,11 +8,15 @@ inputs:
       - create — generate changelog and open a release PR
       - publish — tag and publish the release
     required: true
-  github_token:
+  bot_token:
     description: |
       GitHub token with contents:write and pull-requests:write permissions.
       Required for all modes.
     required: true
+  bot_username:
+    description: |
+      Git author/committer login for release commits, tags, and PRs. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute release artifacts to a dedicated bot identity.
+    required: false
   npm_token:
     description: |
       NPM token for publishing packages.
@@ -101,9 +105,13 @@ runs:
 
     - name: Configure Git
       shell: bash
+      env:
+        INPUT_BOT_USERNAME: ${{ inputs.bot_username }}
       run: |
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --global user.name "github-actions[bot]"
+        bot_user="${INPUT_BOT_USERNAME:-github-actions[bot]}"
+        git config --global user.name "$bot_user"
+        git config --global user.email "41898282+${bot_user}@users.noreply.github.com"
+        echo "Authoring as: $bot_user <41898282+${bot_user}@users.noreply.github.com>"
 
     - name: Detect release type
       id: detect-type
@@ -117,7 +125,7 @@ runs:
       shell: bash
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
-        GH_TOKEN: ${{ inputs.github_token }}
+        GH_TOKEN: ${{ inputs.bot_token }}
         LINEAR_API_KEY: ${{ inputs.linear_api_key }}
         LINEAR_KEYS: ${{ inputs.linear_keys }}
         JIRA_BASE_URL: ${{ inputs.jira_base_url }}
@@ -147,7 +155,7 @@ runs:
         JIRA_EMAIL: ${{ inputs.jira_email }}
         JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
         JIRA_KEYS: ${{ inputs.jira_keys }}
-        GH_TOKEN: ${{ inputs.github_token }}
+        GH_TOKEN: ${{ inputs.bot_token }}
       run: bun "${{ github.action_path }}/src/release.ts"
 
     - name: Update Version Files
@@ -201,7 +209,7 @@ runs:
       if: inputs.mode == 'create' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        GH_TOKEN: ${{ inputs.bot_token }}
         INPUT_NAME: ${{ inputs.name }}
       run: |
         VERSION=$(cat version)
@@ -299,7 +307,7 @@ runs:
       if: inputs.mode == 'publish' && steps.detect-type.outputs.mode == 'standalone'
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        GH_TOKEN: ${{ inputs.bot_token }}
         TAG: ${{ steps.determine-version.outputs.tag }}
         VERSION: ${{ steps.determine-version.outputs.version }}
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,9 @@
+# Requires repo secrets and variables:
+#   - `BOT_TOKEN` (secret): PAT or App installation token with `contents: write` and
+#     `pull-requests: write`, used to read PR files and publish the release.
+#   - `BOT_USERNAME` (variable, optional): git author login for release tags and the
+#     GitHub Release. Defaults to `github-actions[bot]` when unset.
+
 name: Publish
 
 on:
@@ -26,7 +32,7 @@ jobs:
 
       - name: Resolve changed files
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           {
@@ -38,4 +44,5 @@ jobs:
       - uses: awinogradov/code-assistants/.github/actions/release-action@main
         with:
           mode: publish
-          github_token: ${{ secrets.GH_TOKEN }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
-# Requires repo secrets:
-#   - `GH_TOKEN`: PAT or App installation token with `contents: write` and
+# Requires repo secrets and variables:
+#   - `BOT_TOKEN` (secret): PAT or App installation token with `contents: write` and
 #     `pull-requests: write`. The default `GITHUB_TOKEN` cannot create PRs.
 #     See `.github/actions/release-action/README.md` for the rationale.
-#   - `ANTHROPIC_RELEASE`: Anthropic API key used to generate human-readable
+#   - `BOT_USERNAME` (variable, optional): git author login for release commits, tags,
+#     and PRs. Defaults to `github-actions[bot]` when unset.
+#   - `ANTHROPIC_RELEASE` (secret): Anthropic API key used to generate human-readable
 #     release-note summaries from the changelog (optional but recommended).
 
 name: Release
@@ -34,5 +36,6 @@ jobs:
       - uses: awinogradov/code-assistants/.github/actions/release-action@main
         with:
           mode: create
-          github_token: ${{ secrets.GH_TOKEN }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_RELEASE }}

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,7 +1,9 @@
-# Requires repo secret `GH_TOKEN`: a PAT (classic with `repo`, or fine-grained
+# Requires repo secret `BOT_TOKEN`: a PAT (classic with `repo`, or fine-grained
 # with `contents: write` + `pull-requests: write`) or a GitHub App installation
 # token. The default `GITHUB_TOKEN` is not supported — see the action README
 # in `.github/actions/agents-rules-sync` for the rationale.
+# Optional repo variable `BOT_USERNAME`: git author login for sync commits.
+# Defaults to `github-actions[bot]` when unset.
 
 name: Upstream
 
@@ -29,7 +31,8 @@ jobs:
     steps:
       - uses: awinogradov/code-assistants/.github/actions/agents-rules-sync@main
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
 
   sync-code-review:
     name: Sync code-review workflow
@@ -38,4 +41,5 @@ jobs:
     steps:
       - uses: awinogradov/code-assistants/.github/actions/code-review-sync@main
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}


### PR DESCRIPTION
Unifies token and bot-identity wiring across every composite action and internal workflow onto a single pair — `bot_token` (required) and `bot_username` (optional, defaulting to `github-actions[bot]`) — so consumers configure one secret and one variable instead of a different knob per action. Release and sync commits now attribute to the configured bot identity rather than a hardcoded `github-actions[bot]` or whichever PAT owner ran the action.

- Rename the `token`/`github_token` inputs to `bot_token` in files-sync, agents-rules-sync, code-review-sync, contributing-sync, and release-action
- Add an optional `bot_username` input that resolves the git author/committer identity, defaulting to `github-actions[bot]`
- files-sync now sets the commit author/committer via a new `resolveBotIdentity` helper instead of inheriting the token owner
- release-action derives its `git config` identity from `bot_username` instead of the hardcoded `github-actions[bot]`
- Switch the release, publish, and upstream workflows to `secrets.BOT_TOKEN` and `vars.BOT_USERNAME`
- code-review-action and contributing-check are unchanged (already conformant / read-only on the default token)

---

**Release notes:**

- BREAKING: Action inputs `token` and `github_token` are renamed to `bot_token` — update your `with:` blocks
- Added an optional `bot_username` input to set the git author for sync and release commits (defaults to `github-actions[bot]`)
- Internal workflows now read `secrets.BOT_TOKEN` and `vars.BOT_USERNAME` instead of `secrets.GH_TOKEN`

---

**Issues:**

Closes #96
