### PR TITLE
Add ticket tables to monorepo member release notes

### DIFF
--- a/.github/actions/release-action/src/monorepo/runCreate.test.ts
+++ b/.github/actions/release-action/src/monorepo/runCreate.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, test } from "bun:test";
 import { $ } from "bun";
 
 import { withTempRepo } from "../testHelpers.ts";
-import { runCreate } from "./runCreate.ts";
+import { emitMemberArtifacts, runCreate } from "./runCreate.ts";
 
 async function writeJson(path: string, value: Record<string, unknown>): Promise<void> {
   await Bun.write(path, `${JSON.stringify(value, null, 2)}\n`);
@@ -125,5 +125,38 @@ describe("runCreate", () => {
       const result = await runCreate({ cwd: repo });
       expect(result.discovery.mode).toBe("standalone");
       expect(result.releases).toEqual([]);
+    }));
+
+  test("emitMemberArtifacts writes member artifacts and skips ticket blocks without ticket env", () =>
+    withTempRepo(async (repo) => {
+      await setupFixture(repo);
+      await $`git tag lib-a@v0.1.0 HEAD`.cwd(repo).quiet();
+      await $`git tag lib-b@v0.1.0 HEAD`.cwd(repo).quiet();
+      await commitInPath(repo, "packages/lib-a", "f1.txt", "feat(lib-a): add foo");
+
+      const result = await runCreate({ cwd: repo });
+      const libA = result.releases.find((r) => r.member.name === "lib-a");
+      if (!libA) throw new Error("expected a lib-a release");
+
+      // Scrub the AI key so runReleaseNotes stays offline; pass no ticket
+      // systems so the ticket pipeline is a no-op (the standalone-parity path).
+      const originalApiKey = process.env.ANTHROPIC_API_KEY;
+      delete process.env.ANTHROPIC_API_KEY;
+      try {
+        await emitMemberArtifacts({ release: libA, cwd: repo });
+      } finally {
+        if (originalApiKey !== undefined) process.env.ANTHROPIC_API_KEY = originalApiKey;
+      }
+
+      const notes = await Bun.file(
+        join(repo, "packages/lib-a", ".release_notes", "0.2.0.md"),
+      ).text();
+      expect(notes).toContain("0.2.0");
+      expect(notes).not.toContain("## GitHub Issues");
+      expect(notes).not.toContain("## Linear");
+
+      const changelog = await Bun.file(join(repo, "packages/lib-a", "CHANGELOG.md")).text();
+      expect(changelog).toContain("# Changelog");
+      expect(changelog).not.toContain("## GitHub Issues");
     }));
 });

--- a/.github/actions/release-action/src/monorepo/runCreate.ts
+++ b/.github/actions/release-action/src/monorepo/runCreate.ts
@@ -22,9 +22,15 @@ import { assemblePrBody } from "../assemble-pr-body.ts";
 import { runReleaseNotes } from "../generateReleaseNotes.ts";
 import { insertReleaseNotes } from "../insert-release-notes.ts";
 import { appendMigratingSection, readBreakingNotes } from "../migrations/migratingAppend.ts";
-import { bumpVersion, generateChangelog } from "../release.ts";
+import {
+  bumpVersion,
+  generateChangelog,
+  insertTicketsInRelease,
+  processTickets,
+} from "../release.ts";
 import { updateVersionFiles } from "../prepareRelease.ts";
 import { refreshReleaseBadge } from "../updateReleaseBadge.ts";
+import type { TicketSystemEntry } from "../tickets/tickets.types.ts";
 import {
   buildDependentsGraph,
   propagateBumps,
@@ -35,6 +41,7 @@ import { discoverMembers, type DiscoveryResult, type Member } from "./discoverMe
 import {
   getLatestMemberTagReachable,
   getLatestMemberVersion,
+  memberTagPattern,
   memberTagPrefix,
   memberVersionTag,
 } from "./memberTags.ts";
@@ -188,6 +195,43 @@ export interface EmitMemberArtifactsOptions {
   release: MemberRelease;
   /** Repository root (used for git operations and path resolution). */
   cwd: string;
+  /** Auto-detected ticket systems; when empty the ticket blocks are skipped. */
+  ticketSystems?: TicketSystemEntry[];
+  /** GitHub owner for ticket links (from GITHUB_REPOSITORY); skipped when absent. */
+  owner?: string;
+  /** GitHub repo for ticket links (from GITHUB_REPOSITORY); skipped when absent. */
+  repo?: string;
+}
+
+/**
+ * Extract the per-system ticket markdown for one member, scoped to the member's
+ * own commit range (its `<name>@v*` tags and directory). The tag glob comes from
+ * {@link memberTagPattern} (NOT {@link memberTagPrefix}) because
+ * `getCommitsSinceLastTag` feeds it to `git describe --match`, which needs a glob.
+ *
+ * Ticket-fetch failures are non-fatal: a GitHub API error for one member degrades
+ * to an empty section plus a warning, so the remaining members in the release
+ * batch still get their PRs instead of the whole run aborting mid-loop.
+ */
+async function extractMemberTickets(
+  member: Member,
+  cwd: string,
+  config: { ticketSystems?: TicketSystemEntry[]; owner?: string; repo?: string },
+): Promise<string> {
+  try {
+    return await processTickets({
+      ticketSystems: config.ticketSystems,
+      owner: config.owner,
+      repo: config.repo,
+      cwd,
+      releaseBotDir: join(member.path, ".release_bot"),
+      scope: { tagPattern: memberTagPattern(member.name), path: member.relPath },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`::warning::Ticket extraction failed for ${member.name}: ${message}`);
+    return "";
+  }
 }
 
 /**
@@ -200,7 +244,7 @@ export interface EmitMemberArtifactsOptions {
  * this orchestrator to cross-pollinate release commits between PRs.
  */
 export async function emitMemberArtifacts(options: EmitMemberArtifactsOptions): Promise<void> {
-  const { release, cwd } = options;
+  const { release, cwd, ticketSystems, owner, repo } = options;
   const { member, previousVersion, newVersion, bumpLevel, natural, branch } = release;
   const tagPrefix = memberTagPrefix(member.name);
 
@@ -212,7 +256,13 @@ export async function emitMemberArtifacts(options: EmitMemberArtifactsOptions): 
     path: member.relPath,
   });
 
-  await Bun.write(join(member.path, ".release_notes", `${newVersion}.md`), log.release, {
+  // Splice the member-scoped ticket tables into the same files the standalone
+  // path produces, BEFORE `runReleaseNotes` so the AI prompt sees tickets.json.
+  // No-op (releaseWithTickets === log.release) when no ticket systems resolve.
+  const ticketsMarkdown = await extractMemberTickets(member, cwd, { ticketSystems, owner, repo });
+  const releaseWithTickets = insertTicketsInRelease(log.release, ticketsMarkdown);
+
+  await Bun.write(join(member.path, ".release_notes", `${newVersion}.md`), releaseWithTickets, {
     createPath: true,
   });
 
@@ -226,7 +276,7 @@ export async function emitMemberArtifacts(options: EmitMemberArtifactsOptions): 
   const history = priorStart !== -1 ? priorContent.substring(priorStart) : "";
   await Bun.write(
     memberChangelogPath,
-    `${log.header}${log.release}${history}`.replace(/\n+$/, "\n"),
+    `${log.header}${releaseWithTickets}${history}`.replace(/\n+$/, "\n"),
   );
 
   await updateVersionFiles(newVersion, member.path);
@@ -251,7 +301,7 @@ export async function emitMemberArtifacts(options: EmitMemberArtifactsOptions): 
   // PR-body skeleton: the changelog body plus a single-line note for
   // dependent-driven bumps so reviewers can see why the member is moving.
   const bodyPrefix = natural ? "" : "_Workspace dependent bump._\n\n";
-  await Bun.write(join(member.path, ".release_bot", "body"), `${bodyPrefix}${log.release}`, {
+  await Bun.write(join(member.path, ".release_bot", "body"), `${bodyPrefix}${releaseWithTickets}`, {
     createPath: true,
   });
 

--- a/.github/actions/release-action/src/monorepo/runCreate.ts
+++ b/.github/actions/release-action/src/monorepo/runCreate.ts
@@ -216,7 +216,7 @@ export interface EmitMemberArtifactsOptions {
 async function extractMemberTickets(
   member: Member,
   cwd: string,
-  config: { ticketSystems?: TicketSystemEntry[]; owner?: string; repo?: string },
+  config: Pick<EmitMemberArtifactsOptions, "ticketSystems" | "owner" | "repo">,
 ): Promise<string> {
   try {
     return await processTickets({

--- a/.github/actions/release-action/src/release.test.ts
+++ b/.github/actions/release-action/src/release.test.ts
@@ -14,6 +14,7 @@ import {
   changelogHeader,
   generateChangelog,
   getCurrentVersion,
+  insertTicketsInRelease,
   main,
   startOfLastReleasePattern,
 } from "./release.ts";
@@ -93,6 +94,37 @@ describe("release CLI", () => {
 
     test("contains conventional commits link", () => {
       expect(changelogHeader).toContain("conventionalcommits.org");
+    });
+  });
+
+  describe("insertTicketsInRelease()", () => {
+    const tickets =
+      "## GitHub Issues\n\n| Issue | PR | Author |\n| --- | --- | --- |\n| #40 | [#42](url) | @dev |\n";
+
+    test("inserts tickets between the version header and the first section", () => {
+      const release = "## [1.1.0] (2025-01-01)\n\n### Features\n\n* feat\n";
+
+      const result = insertTicketsInRelease(release, tickets);
+
+      expect(result).toContain("## GitHub Issues");
+      // header → tickets → changelog sections
+      expect(result.indexOf("## [1.1.0]")).toBeLessThan(result.indexOf("## GitHub Issues"));
+      expect(result.indexOf("## GitHub Issues")).toBeLessThan(result.indexOf("### Features"));
+    });
+
+    test("returns release unchanged when tickets is empty", () => {
+      const release = "## [1.1.0] (2025-01-01)\n\n### Features\n\n* feat\n";
+
+      expect(insertTicketsInRelease(release, "")).toBe(release);
+    });
+
+    test("prepends tickets when there is no version header", () => {
+      const release = "### Features\n\n* feat\n";
+
+      const result = insertTicketsInRelease(release, tickets);
+
+      expect(result.startsWith("## GitHub Issues")).toBe(true);
+      expect(result).toContain("### Features");
     });
   });
 

--- a/.github/actions/release-action/src/release.test.ts
+++ b/.github/actions/release-action/src/release.test.ts
@@ -106,10 +106,7 @@ describe("release CLI", () => {
 
       const result = insertTicketsInRelease(release, tickets);
 
-      expect(result).toContain("## GitHub Issues");
-      // header → tickets → changelog sections
-      expect(result.indexOf("## [1.1.0]")).toBeLessThan(result.indexOf("## GitHub Issues"));
-      expect(result.indexOf("## GitHub Issues")).toBeLessThan(result.indexOf("### Features"));
+      expect(result).toBe(`## [1.1.0] (2025-01-01)\n\n${tickets}\n### Features\n\n* feat\n`);
     });
 
     test("returns release unchanged when tickets is empty", () => {

--- a/.github/actions/release-action/src/release.ts
+++ b/.github/actions/release-action/src/release.ts
@@ -24,7 +24,7 @@ import { ConventionalChangelog } from "conventional-changelog";
 import semver from "semver";
 
 import { listTags } from "./gitTags.ts";
-import type { TicketConfig, TicketSystemEntry } from "./tickets/tickets.types.ts";
+import type { CommitScope, TicketConfig, TicketSystemEntry } from "./tickets/tickets.types.ts";
 import {
   autoDetectTicketSystems,
   generateTicketsSection,
@@ -290,15 +290,22 @@ export async function generateChangelog(
   return { header: changelogHeader, release, history };
 }
 
-/** Generate tickets section and save artifacts if configured */
-async function processTickets(params: {
+/**
+ * Generate tickets section and save artifacts if configured.
+ *
+ * Returns an empty string (no-op) when ticket systems or owner/repo are absent,
+ * so callers can splice the result unconditionally. `scope` restricts the commit
+ * range for monorepo per-member extraction; omit it for the standalone path.
+ */
+export async function processTickets(params: {
   ticketSystems?: TicketSystemEntry[];
   owner?: string;
   repo?: string;
   cwd: string;
   releaseBotDir: string;
+  scope?: CommitScope;
 }): Promise<string> {
-  const { ticketSystems, owner, repo, cwd, releaseBotDir } = params;
+  const { ticketSystems, owner, repo, cwd, releaseBotDir, scope } = params;
 
   if (!ticketSystems || ticketSystems.length === 0 || !owner || !repo) {
     return "";
@@ -310,6 +317,7 @@ async function processTickets(params: {
     config: ticketConfig,
     env,
     cwd,
+    scope,
   });
 
   if (result.tickets.length > 0) {
@@ -426,7 +434,7 @@ function breakingChangesBadge(summary: string): string {
  * @param tickets - Tickets markdown section
  * @returns Release notes with tickets inserted
  */
-function insertTicketsInRelease(release: string, tickets: string): string {
+export function insertTicketsInRelease(release: string, tickets: string): string {
   if (!tickets) {
     return release;
   }

--- a/.github/actions/release-action/src/run.ts
+++ b/.github/actions/release-action/src/run.ts
@@ -23,6 +23,7 @@ import { emitMemberArtifacts, runCreate, type MemberRelease } from "./monorepo/r
 import { readChangedFiles, resolvePublishPlan } from "./monorepo/runPublish.ts";
 import { ensureGitignoreEntry } from "./prepareRelease.ts";
 import { postReleaseNotification } from "./slackNotify.ts";
+import { autoDetectTicketSystems, loadTicketEnv } from "./tickets/tickets.ts";
 
 type Mode = "create" | "publish";
 
@@ -114,6 +115,14 @@ async function resolveBaseRef(cwd: string): Promise<string> {
   return localHead.stdout.toString().trim();
 }
 
+/** Split `owner/repo` out of GITHUB_REPOSITORY for ticket links; empty when unset. */
+function resolveOwnerRepo(): { owner?: string; repo?: string } {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) return {};
+  const [owner, repo] = repository.split("/");
+  return { owner, repo };
+}
+
 async function runMonorepoCreate(cwd: string): Promise<void> {
   await ensureGitignoreEntry(".release_bot", cwd);
   const branchTemplate = resolveBranchTemplate();
@@ -128,13 +137,18 @@ async function runMonorepoCreate(cwd: string): Promise<void> {
   await $`git fetch origin`.cwd(cwd).quiet().nothrow();
   const baseRef = await resolveBaseRef(cwd);
 
+  // Resolve ticket config once from the same env the standalone path reads;
+  // every member shares it (owner/repo are repo-wide, systems are credential-driven).
+  const ticketSystems = autoDetectTicketSystems(loadTicketEnv());
+  const { owner, repo } = resolveOwnerRepo();
+
   const releasedNames: string[] = [];
   for (const release of result.releases) {
     // Reset to the captured base ref BEFORE emitting artifacts so the working
     // tree is clean of any prior member's files. Emit, then commit + push the
     // per-member diff onto the fresh branch.
     await $`git checkout -B ${release.branch} ${baseRef}`.cwd(cwd).quiet();
-    await emitMemberArtifacts({ release, cwd });
+    await emitMemberArtifacts({ release, cwd, ticketSystems, owner, repo });
     await $`git add ${release.member.relPath}`.cwd(cwd).quiet();
     await $`git commit -n -m ${`chore: release ${release.member.name} ${release.newVersion}`}`
       .cwd(cwd)

--- a/.github/actions/release-action/src/tickets/githubClient.test.ts
+++ b/.github/actions/release-action/src/tickets/githubClient.test.ts
@@ -97,4 +97,64 @@ describe("githubClient", () => {
         expect(commits[0]?.message).toBe("feat: new for 0.16.2");
       }));
   });
+
+  describe("getCommitsSinceLastTag() scoping", () => {
+    test("scopes the since-point to a member tag glob", () =>
+      withTempRepo(async (testRepo) => {
+        await createCommit(testRepo, "chore: base");
+        await $`git tag lib-a@v1.0.0`.cwd(testRepo).quiet();
+        await createCommit(testRepo, "feat: after member tag", "file2.txt");
+
+        const scoped = await getCommitsSinceLastTag(testRepo, { tagPattern: "lib-a@v*" });
+        expect(scoped).toHaveLength(1);
+        expect(scoped[0]?.message).toBe("feat: after member tag");
+
+        // No `v*` tag exists, so the default pattern finds none and walks all history.
+        const unscoped = await getCommitsSinceLastTag(testRepo);
+        expect(unscoped).toHaveLength(2);
+      }));
+
+    test("restricts the range to commits touching a path", () =>
+      withTempRepo(async (testRepo) => {
+        await createCommit(testRepo, "feat: lib-a change", "packages/lib-a/x.txt");
+        await createCommit(testRepo, "feat: lib-b change", "packages/lib-b/y.txt");
+
+        const commits = await getCommitsSinceLastTag(testRepo, { path: "packages/lib-a" });
+
+        expect(commits).toHaveLength(1);
+        expect(commits[0]?.message).toBe("feat: lib-a change");
+      }));
+
+    test("combines member tag glob and path filter", () =>
+      withTempRepo(async (testRepo) => {
+        await createCommit(testRepo, "chore: base");
+        await $`git tag lib-a@v1.0.0`.cwd(testRepo).quiet();
+        await createCommit(testRepo, "feat: lib-a after tag", "packages/lib-a/a.txt");
+        await createCommit(testRepo, "feat: lib-b after tag", "packages/lib-b/b.txt");
+
+        const commits = await getCommitsSinceLastTag(testRepo, {
+          tagPattern: "lib-a@v*",
+          path: "packages/lib-a",
+        });
+
+        expect(commits).toHaveLength(1);
+        expect(commits[0]?.message).toBe("feat: lib-a after tag");
+      }));
+
+    test("a non-glob prefix matches no tag and falls back to full history", () =>
+      withTempRepo(async (testRepo) => {
+        // `git describe --match` treats the pattern as an fnmatch glob: the
+        // prefix form `lib-a@v` (no `*`) matches no tag, so callers must pass the
+        // glob `lib-a@v*` (memberTagPattern), not the prefix `lib-a@v`.
+        await createCommit(testRepo, "chore: base");
+        await $`git tag lib-a@v1.0.0`.cwd(testRepo).quiet();
+        await createCommit(testRepo, "feat: after", "file2.txt");
+
+        const prefix = await getCommitsSinceLastTag(testRepo, { tagPattern: "lib-a@v" });
+        expect(prefix).toHaveLength(2);
+
+        const glob = await getCommitsSinceLastTag(testRepo, { tagPattern: "lib-a@v*" });
+        expect(glob).toHaveLength(1);
+      }));
+  });
 });

--- a/.github/actions/release-action/src/tickets/githubClient.ts
+++ b/.github/actions/release-action/src/tickets/githubClient.ts
@@ -7,7 +7,7 @@
  * ```typescript
  * import { getCommitsSinceLastTag, fetchPullRequest } from "./githubClient.ts";
  *
- * const commits = await getCommitsSinceLastTag("v", process.cwd());
+ * const commits = await getCommitsSinceLastTag(process.cwd());
  * const pr = await fetchPullRequest(45, "owner", "repo", "ghp_xxx");
  * ```
  */
@@ -16,36 +16,49 @@ import { $ } from "bun";
 
 import { getLatestReachableTag } from "../gitTags.ts";
 
-import type { CommitInfo, PullRequestInfo } from "./tickets.types.ts";
+import type { CommitInfo, CommitScope, PullRequestInfo } from "./tickets.types.ts";
 import { extractPrNumber } from "./ticketExtractor.ts";
 
 /** GitHub API base URL */
 const githubApiUrl = "https://api.github.com";
 
 /**
- * Get all commits since the last `v*` tag reachable from HEAD.
+ * Get all commits since the last reachable tag, optionally scoped to a member.
  *
  * Uses reachability-based discovery: finds the closest tag reachable from HEAD by commit
  * topology, not version number. This prevents picking a higher-versioned tag that sits on
  * an older commit (e.g. v1.0.0 before v0.16.1).
  *
  * @param cwd - Working directory
+ * @param scope - Optional tag glob + path filter for monorepo per-member extraction.
+ *   `tagPattern` defaults to `"v*"`; when `path` is set the range is restricted to
+ *   commits touching that pathspec (resolved relative to `cwd`).
  * @returns Array of commit info with extracted PR numbers
  *
  * @example
  * ```typescript
  * const commits = await getCommitsSinceLastTag(process.cwd());
  * // → [{ sha: "abc123", message: "feat: add auth (#45)", prNumber: 45 }]
+ *
+ * // Monorepo: only commits touching the member path since its last tag
+ * const memberCommits = await getCommitsSinceLastTag(repoRoot, {
+ *   tagPattern: "release-action@v*",
+ *   path: ".github/actions/release-action",
+ * });
  * ```
  */
-export async function getCommitsSinceLastTag(cwd: string): Promise<CommitInfo[]> {
-  const latestTag = await getLatestReachableTag("v*", cwd);
+export async function getCommitsSinceLastTag(
+  cwd: string,
+  scope: CommitScope = {}
+): Promise<CommitInfo[]> {
+  const latestTag = await getLatestReachableTag(scope.tagPattern ?? "v*", cwd);
 
   // Get commits with format: SHA|message
   const format = "--format=%H|%s";
-  const logResult = latestTag
-    ? await $`git log ${`${latestTag}..HEAD`} ${format}`.cwd(cwd).quiet().nothrow()
-    : await $`git log HEAD ${format}`.cwd(cwd).quiet().nothrow();
+  const range = latestTag ? `${latestTag}..HEAD` : "HEAD";
+  const logResult = scope.path
+    ? await $`git log ${range} ${format} -- ${scope.path}`.cwd(cwd).quiet().nothrow()
+    : await $`git log ${range} ${format}`.cwd(cwd).quiet().nothrow();
 
   const lines = logResult.stdout.toString().trim().split("\n").filter(Boolean);
 

--- a/.github/actions/release-action/src/tickets/tickets.ts
+++ b/.github/actions/release-action/src/tickets/tickets.ts
@@ -432,7 +432,7 @@ export function serializePrDescriptionsToYaml(descriptions: PrDescription[]): st
 export async function generateTicketsSection(
   options: GenerateTicketsSectionOptions
 ): Promise<GenerateTicketsSectionResult> {
-  const { config, env, cwd = process.cwd() } = options;
+  const { config, env, cwd = process.cwd(), scope } = options;
   const warnings: string[] = [];
   const ticketsBySystem = new Map<TicketSystemType, TicketInfo[]>();
 
@@ -457,7 +457,7 @@ export async function generateTicketsSection(
 
   // Get commits and fetch associated PRs by commit SHA
   // This works for all merge strategies (squash, rebase, merge commit)
-  const commits = await getCommitsSinceLastTag(cwd);
+  const commits = await getCommitsSinceLastTag(cwd, scope);
   const commitShas = commits.map((c) => c.sha);
 
   let prDetailsBySha = new Map<string, PullRequestInfo>();

--- a/.github/actions/release-action/src/tickets/tickets.types.ts
+++ b/.github/actions/release-action/src/tickets/tickets.types.ts
@@ -176,6 +176,21 @@ export interface PullRequestInfo {
 }
 
 /**
+ * Commit-range scoping for {@link getCommitsSinceLastTag}.
+ *
+ * In monorepo mode each member release reads only its own slice of history:
+ * `tagPattern` selects the member's `<name>@v*` tags as the "since" point and
+ * `path` restricts commits to those touching the member's directory. Both fall
+ * back to the standalone behaviour (`v*`, no path filter) when omitted.
+ */
+export interface CommitScope {
+  /** Tag glob used to find the latest reachable "since" tag (e.g. `release-action@v*`). Defaults to `"v*"`. */
+  tagPattern?: string;
+  /** Pathspec restricting the commit range to commits touching this path. */
+  path?: string;
+}
+
+/**
  * Options for generating tickets section
  *
  * @see {@link generateTicketsSection}
@@ -187,6 +202,8 @@ export interface GenerateTicketsSectionOptions {
   env: TicketEnvVars;
   /** Working directory */
   cwd?: string;
+  /** Optional commit-range scoping for monorepo per-member extraction. */
+  scope?: CommitScope;
 }
 
 /** Result of generating tickets section */


### PR DESCRIPTION
Monorepo per-member release PRs now carry the same GitHub Issues / Linear / Jira ticket tables the standalone release path already produces, so reviewers can see which issues shipped without scrolling through commit subjects.

- Wire the existing ticket pipeline (processTickets + insertTicketsInRelease) into the monorepo emitMemberArtifacts flow
- Scope ticket extraction to each member's own commit range (its `<name>@v*` tags and directory) so members don't pick up each other's issues
- Auto-detect ticket systems from the same env vars the standalone path reads — no new configuration
- Run before the AI release-notes step so the summary can reference the structured ticket data
- Tolerate per-member GitHub API failures so one member's outage doesn't abort the rest of the release batch

---

**Release notes:**

- Monorepo release PRs now include per-system ticket tables (GitHub Issues, Linear, Jira), matching standalone releases
- Ticket tables are scoped to each member's commits and auto-detected from existing release credentials

---

**Issues:**

Closes #102
