### PR TITLE
Stop dropping bot mentions when PR comments arrive in quick succession

### DIFF
--- a/.github/actions/code-review-action/README.md
+++ b/.github/actions/code-review-action/README.md
@@ -25,7 +25,9 @@ on:
     types: [created]
 
 concurrency:
-  group: code-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  # comment.id gives each comment its own group so bursty replies aren't cancelled;
+  # it's empty for pull_request events, which stay grouped per-PR (event_name + number).
+  group: code-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event.comment.id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -22,7 +22,9 @@ on:
     types: [created]
 
 concurrency:
-  group: code-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  # comment.id gives each comment its own group so bursty replies aren't cancelled;
+  # it's empty for pull_request events, which stay grouped per-PR (event_name + number).
+  group: code-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event.comment.id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The AI code-review workflow keys its concurrency group per-PR with cancel-in-progress, so a burst of PR comments cancels every run but the last and silently drops the @bot mentions in the cancelled ones. This scopes the group per comment so every mention is processed.

- Append github.event.comment.id to the concurrency group key so each comment event runs in its own group
- pull_request events keep their per-PR scope (comment.id is empty), so a new push still supersedes an in-flight review
- Mirror the change in the code-review-action README usage example so downstream setups don't copy the buggy pattern

---

**Release notes:**

- Fixed the code review bot silently ignoring @-mentions when several PR comments are posted in quick succession

---

**Issues:**

Closes #71
