### PR TITLE
HOTFIX: Fix composite actions failing to load from invalid vars expression

### DIFF
--- a/.github/actions/agents-rules-sync/action.yml
+++ b/.github/actions/agents-rules-sync/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
   bot_username:
     description: |
-      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute commits to a dedicated bot identity.
+      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass the `vars.BOT_USERNAME` repository variable to attribute commits to a dedicated bot identity.
     required: false
   source-repo:
     description: Source repository in `owner/name` form that hosts the `rules/<stack>.md` files.

--- a/.github/actions/code-review-sync/action.yml
+++ b/.github/actions/code-review-sync/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
   bot_username:
     description: |
-      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute commits to a dedicated bot identity.
+      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass the `vars.BOT_USERNAME` repository variable to attribute commits to a dedicated bot identity.
     required: false
   source-repo:
     description: Source repository in `owner/name` form that hosts the canonical `.github/workflows/code-review.yml`.

--- a/.github/actions/contributing-sync/action.yml
+++ b/.github/actions/contributing-sync/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
   bot_username:
     description: |
-      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute commits to a dedicated bot identity.
+      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass the `vars.BOT_USERNAME` repository variable to attribute commits to a dedicated bot identity.
     required: false
   source-repo:
     description: Source repository in `owner/name` form that hosts the canonical `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md`.

--- a/.github/actions/files-sync/action.yml
+++ b/.github/actions/files-sync/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
   bot_username:
     description: |
-      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute commits to a dedicated bot identity.
+      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass the `vars.BOT_USERNAME` repository variable to attribute commits to a dedicated bot identity.
     required: false
   base:
     description: Base branch the PR targets.

--- a/.github/actions/release-action/action.yml
+++ b/.github/actions/release-action/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   bot_username:
     description: |
-      Git author/committer login for release commits, tags, and PRs. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute release artifacts to a dedicated bot identity.
+      Git author/committer login for release commits, tags, and PRs. Defaults to `github-actions[bot]` when unset. Pass the `vars.BOT_USERNAME` repository variable to attribute release artifacts to a dedicated bot identity.
     required: false
   npm_token:
     description: |

--- a/.github/actions/repomix-sync/action.yml
+++ b/.github/actions/repomix-sync/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
   bot_username:
     description: |
-      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass `${{ vars.BOT_USERNAME }}` to attribute commits to a dedicated bot identity.
+      Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass the `vars.BOT_USERNAME` repository variable to attribute commits to a dedicated bot identity.
     required: false
   source-repo:
     description: Source repository in `owner/name` form that hosts the canonical `.github/workflows/repomix-pack.yml` and `repomix.config.json`.


### PR DESCRIPTION
Composite actions that consumers reference (`agents-rules-sync`, `contributing-sync`, and others) failed to load because their `bot_username` input description embedded a literal `${{ vars.BOT_USERNAME }}` expression. GitHub evaluates `${{ }}` expressions everywhere in an `action.yml`, and the `vars` context is unavailable in composite manifests, so manifest validation threw `Unrecognized named-value: 'vars'` and the actions could not run.

- Removed the `${{ }}` delimiters around `vars.BOT_USERNAME` in the `bot_username` input description, leaving the example as plain documentation text
- Applied across all 6 affected composite manifests: `agents-rules-sync`, `contributing-sync`, `code-review-sync`, `repomix-sync`, `files-sync`, and `release-action`
- README files keep the `${{ vars.BOT_USERNAME }}` form intentionally — they are not parsed by GitHub's manifest validator

---

**Release notes:**

- Fixed sync/release composite actions failing to load due to an invalid `vars` expression in input descriptions
