### PR TITLE
Stop the AI reviewer from replying to routine acknowledgements

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -331,6 +331,7 @@ runs:
 
         echo "mode=react" >> "$GITHUB_OUTPUT"
         echo "skip=false" >> "$GITHUB_OUTPUT"
+        echo "bot_in_thread=${BOT_IN_THREAD}" >> "$GITHUB_OUTPUT"
 
         if [[ -n "$EVENT_ISSUE_NUMBER" ]]; then
           echo "pr_number=${EVENT_ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
@@ -510,9 +511,20 @@ runs:
 
     # ── React mode ──
 
+    - name: Classify reaction
+      id: classify
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'react'
+      shell: bash
+      env:
+        BOT_IN_THREAD: ${{ steps.ctx.outputs.bot_in_thread }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+        COMMENT_BODY: ${{ steps.ctx.outputs.comment_body }}
+      run: bun run "${{ github.action_path }}/src/classifyReaction.ts"
+
     - name: React to Comment
       id: reaction
-      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'react'
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'react' && steps.classify.outputs.ack_only != 'true'
       continue-on-error: true
       shell: bash
       env:
@@ -533,7 +545,7 @@ runs:
       run: bun run "${{ github.action_path }}/src/runClaude.ts"
 
     - name: Submit Reaction
-      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'react' && always() && (steps.reaction.outcome == 'success' || steps.reaction.outcome == 'failure')
+      if: steps.ctx.outputs.skip != 'true' && steps.ctx.outputs.mode == 'react' && always() && (steps.reaction.outcome == 'success' || steps.reaction.outcome == 'failure' || steps.classify.outputs.ack_only == 'true')
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.bot_token }}
@@ -544,6 +556,7 @@ runs:
         COMMENT_PATH: ${{ steps.ctx.outputs.comment_path }}
         STRUCTURED_OUTPUT: ${{ steps.reaction.outputs.structured_output }}
         EXECUTION_FILE: ${{ steps.reaction.outputs.execution_file }}
+        ACK_ONLY: ${{ steps.classify.outputs.ack_only }}
         RUNNER_TEMP: ${{ runner.temp }}
       run: bun run "${{ github.action_path }}/src/reactToComment.ts"
 

--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -517,7 +517,7 @@ runs:
       shell: bash
       env:
         BOT_IN_THREAD: ${{ steps.ctx.outputs.bot_in_thread }}
-        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
         COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
         COMMENT_BODY: ${{ steps.ctx.outputs.comment_body }}
       run: bun run "${{ github.action_path }}/src/classifyReaction.ts"

--- a/.github/actions/code-review-action/src/actionsOutput.test.ts
+++ b/.github/actions/code-review-action/src/actionsOutput.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the shared GitHub Actions output helper.
+ */
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { setOutput } from "./actionsOutput.ts";
+
+describe("setOutput", () => {
+  let tempDir: string;
+  let outputFile: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "actionsOutput-test-"));
+    outputFile = join(tempDir, "GITHUB_OUTPUT");
+    await Bun.write(outputFile, "");
+    process.env.GITHUB_OUTPUT = outputFile;
+  });
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    await rm(tempDir, { recursive: true });
+  });
+
+  test("writes output with heredoc delimiter", async () => {
+    await setOutput("test_key", "test_value");
+
+    const content = await readFile(outputFile, "utf8");
+    expect(content).toMatch(/^test_key<<EOF_[a-f0-9]+\ntest_value\nEOF_[a-f0-9]+\n$/);
+  });
+
+  test("handles multi-line values", async () => {
+    await setOutput("json", '{"key":"value",\n"nested":true}');
+
+    const content = await readFile(outputFile, "utf8");
+    expect(content).toContain('{"key":"value",\n"nested":true}');
+  });
+
+  test("does nothing without GITHUB_OUTPUT", async () => {
+    delete process.env.GITHUB_OUTPUT;
+    await setOutput("key", "value");
+    // Should not throw
+  });
+
+  test("appends multiple outputs", async () => {
+    await setOutput("key1", "val1");
+    await setOutput("key2", "val2");
+
+    const content = await readFile(outputFile, "utf8");
+    expect(content).toContain("key1<<EOF_");
+    expect(content).toContain("key2<<EOF_");
+  });
+});

--- a/.github/actions/code-review-action/src/actionsOutput.ts
+++ b/.github/actions/code-review-action/src/actionsOutput.ts
@@ -1,0 +1,28 @@
+/**
+ * GitHub Actions step output helper.
+ *
+ * Writes `key=value` pairs to the file referenced by `$GITHUB_OUTPUT` using the
+ * heredoc delimiter form, which is safe for multi-line values. Shared by the
+ * action's entry-point scripts so the write pattern lives in one place.
+ *
+ * @example
+ * await setOutput("skip_review", "false");
+ */
+import { randomUUID } from "node:crypto";
+import { appendFile } from "node:fs/promises";
+
+/**
+ * Append a GitHub Actions output variable, using a heredoc delimiter so values
+ * containing newlines are handled correctly. Warns and no-ops when `GITHUB_OUTPUT`
+ * is unset (e.g. running outside a GitHub Actions runner).
+ */
+export async function setOutput(key: string, value: string): Promise<void> {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) {
+    console.warn(`GITHUB_OUTPUT is not set — skipping output "${key}"`);
+    return;
+  }
+
+  const delimiter = `EOF_${randomUUID().replaceAll("-", "")}`;
+  await appendFile(outputFile, `${key}<<${delimiter}\n${value}\n${delimiter}\n`);
+}

--- a/.github/actions/code-review-action/src/classifyReaction.test.ts
+++ b/.github/actions/code-review-action/src/classifyReaction.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for classifyReaction.ts pure classification helpers.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { isBareAcknowledgement, shouldSkipModelReply } from "./classifyReaction.ts";
+
+describe("isBareAcknowledgement", () => {
+  test("plain 'Fixed' acknowledgement is bare", () => {
+    expect(isBareAcknowledgement("@bot Fixed — removed the unused import.")).toBe(true);
+  });
+
+  test("a question is not bare", () => {
+    expect(isBareAcknowledgement("@bot why is this a problem?")).toBe(false);
+  });
+
+  test("a re-review request is not bare", () => {
+    expect(isBareAcknowledgement("@bot done, please re-review")).toBe(false);
+  });
+
+  test("PTAL is not bare", () => {
+    expect(isBareAcknowledgement("@bot updated. PTAL")).toBe(false);
+  });
+
+  test("keyword matching is case-insensitive", () => {
+    expect(isBareAcknowledgement("@bot Please take Another Look")).toBe(false);
+  });
+
+  test("a question anywhere in a multi-line body is not bare", () => {
+    expect(
+      isBareAcknowledgement("@bot Fixed the first one.\nShould I also change the second?"),
+    ).toBe(false);
+  });
+});
+
+describe("shouldSkipModelReply", () => {
+  const ack: Parameters<typeof shouldSkipModelReply>[0] = {
+    botInThread: true,
+    prAuthor: "alice",
+    commentAuthor: "alice",
+    body: "Fixed — done.",
+  };
+
+  test("PR-author acknowledgement in a bot thread skips the model", () => {
+    expect(shouldSkipModelReply(ack)).toBe(true);
+  });
+
+  test("a comment not in a bot thread never skips", () => {
+    expect(shouldSkipModelReply({ ...ack, botInThread: false })).toBe(false);
+  });
+
+  test("a non-author commenter never skips", () => {
+    expect(shouldSkipModelReply({ ...ack, commentAuthor: "bob" })).toBe(false);
+  });
+
+  test("an empty PR author never skips", () => {
+    expect(shouldSkipModelReply({ ...ack, prAuthor: "", commentAuthor: "" })).toBe(false);
+  });
+
+  test("a question from the author still gets a reply", () => {
+    expect(shouldSkipModelReply({ ...ack, body: "is this really needed?" })).toBe(false);
+  });
+
+  test("a re-review request from the author still gets a reply", () => {
+    expect(shouldSkipModelReply({ ...ack, body: "pushed a fix, please re-review" })).toBe(false);
+  });
+});

--- a/.github/actions/code-review-action/src/classifyReaction.test.ts
+++ b/.github/actions/code-review-action/src/classifyReaction.test.ts
@@ -10,11 +10,34 @@ describe("isBareAcknowledgement", () => {
     expect(isBareAcknowledgement("@bot Fixed — removed the unused import.")).toBe(true);
   });
 
+  test("'Done' / 'Confirmed' acknowledgements are bare", () => {
+    expect(isBareAcknowledgement("@bot Done.")).toBe(true);
+    expect(isBareAcknowledgement("@bot Confirmed, good catch.")).toBe(true);
+  });
+
+  test("substantive pushback without an ack token is not bare", () => {
+    expect(
+      isBareAcknowledgement(
+        "@bot This is intentional — the mutation is required by the cache layer.",
+      ),
+    ).toBe(false);
+  });
+
+  test("an empty body is not a bare acknowledgement", () => {
+    expect(isBareAcknowledgement("")).toBe(false);
+  });
+
+  test("an ack token only matches on a word boundary", () => {
+    // "abandoned" contains "done", "rolled back" contains no ack token.
+    expect(isBareAcknowledgement("@bot I abandoned that approach.")).toBe(false);
+    expect(isBareAcknowledgement("@bot Rolled this back.")).toBe(false);
+  });
+
   test("a question is not bare", () => {
     expect(isBareAcknowledgement("@bot why is this a problem?")).toBe(false);
   });
 
-  test("a re-review request is not bare", () => {
+  test("a re-review request is not bare even with an ack token", () => {
     expect(isBareAcknowledgement("@bot done, please re-review")).toBe(false);
   });
 
@@ -23,7 +46,7 @@ describe("isBareAcknowledgement", () => {
   });
 
   test("keyword matching is case-insensitive", () => {
-    expect(isBareAcknowledgement("@bot Please take Another Look")).toBe(false);
+    expect(isBareAcknowledgement("@bot Fixed it. Please take Another Look")).toBe(false);
   });
 
   test("a question anywhere in a multi-line body is not bare", () => {
@@ -55,6 +78,12 @@ describe("shouldSkipModelReply", () => {
 
   test("an empty PR author never skips", () => {
     expect(shouldSkipModelReply({ ...ack, prAuthor: "", commentAuthor: "" })).toBe(false);
+  });
+
+  test("substantive author pushback still gets a reply", () => {
+    expect(
+      shouldSkipModelReply({ ...ack, body: "this is intentional, the pattern is required" }),
+    ).toBe(false);
   });
 
   test("a question from the author still gets a reply", () => {

--- a/.github/actions/code-review-action/src/classifyReaction.ts
+++ b/.github/actions/code-review-action/src/classifyReaction.ts
@@ -2,9 +2,10 @@
  * Classify a react-mode triggering comment to decide whether it needs a model reply.
  *
  * A PR-author acknowledgement inside a bot-authored thread (e.g. "@bot Fixed — …")
- * that neither asks a question nor requests a re-review warrants no prose reply —
- * answering it just doubles the thread (issue #111). The action reacts with 👍
- * instead and skips the expensive model step entirely.
+ * warrants no prose reply — answering it just doubles the thread (issue #111). The
+ * action reacts with 👍 instead and skips the model step. An acknowledgement is
+ * recognised by a positive ack token, not merely the absence of a question, so
+ * substantive pushback like "this is intentional" still receives a real reply.
  *
  * Run as a GitHub Action step: reads the comment context from env and writes
  * `ack_only=true|false` to `$GITHUB_OUTPUT`.
@@ -13,7 +14,7 @@
  * BOT_IN_THREAD=true PR_AUTHOR=alice COMMENT_AUTHOR=alice COMMENT_BODY="Fixed — done." \
  *   bun run src/classifyReaction.ts   # writes ack_only=true to $GITHUB_OUTPUT
  */
-import { appendFile } from "node:fs/promises";
+import { setOutput } from "./actionsOutput.ts";
 
 /** Phrases that signal the author wants the bot to look again. */
 const reReviewKeywords = [
@@ -26,9 +27,26 @@ const reReviewKeywords = [
   "ptal",
 ];
 
+/** Whole-word signals that a reply positively acknowledges the bot's finding. */
+const acknowledgementPatterns = [
+  /\bfixed\b/,
+  /\bdone\b/,
+  /\baddressed\b/,
+  /\bresolved\b/,
+  /\bupdated\b/,
+  /\bconfirmed\b/,
+  /\backnowledged\b/,
+  /\bgood catch\b/,
+  /\bnice catch\b/,
+  /\bmakes sense\b/,
+  /\bwill do\b/,
+];
+
 /**
- * True when a comment body neither asks a question nor requests a re-review —
- * i.e. it is a bare acknowledgement that warrants no model reply.
+ * True when a comment body is a bare acknowledgement: it carries a positive
+ * acknowledgement signal and neither asks a question nor requests a re-review.
+ * Requiring a positive signal — rather than only the absence of one — keeps
+ * substantive pushback such as "this is intentional" from being silenced.
  */
 export function isBareAcknowledgement(body: string): boolean {
   if (body.includes("?")) {
@@ -36,7 +54,11 @@ export function isBareAcknowledgement(body: string): boolean {
   }
 
   const lower = body.toLowerCase();
-  return !reReviewKeywords.some((keyword) => lower.includes(keyword));
+  if (reReviewKeywords.some((keyword) => lower.includes(keyword))) {
+    return false;
+  }
+
+  return acknowledgementPatterns.some((pattern) => pattern.test(lower));
 }
 
 /** Inputs needed to decide whether a react-mode reply can skip the model. */
@@ -76,10 +98,7 @@ if (import.meta.main) {
     body: process.env.COMMENT_BODY ?? "",
   });
 
-  const outputFile = process.env.GITHUB_OUTPUT;
-  if (outputFile) {
-    await appendFile(outputFile, `ack_only=${ackOnly}\n`);
-  }
+  await setOutput("ack_only", String(ackOnly));
 
   if (ackOnly) {
     console.log("PR-author acknowledgement in bot thread — skipping model reply (issue #111)");

--- a/.github/actions/code-review-action/src/classifyReaction.ts
+++ b/.github/actions/code-review-action/src/classifyReaction.ts
@@ -1,0 +1,87 @@
+/**
+ * Classify a react-mode triggering comment to decide whether it needs a model reply.
+ *
+ * A PR-author acknowledgement inside a bot-authored thread (e.g. "@bot Fixed — …")
+ * that neither asks a question nor requests a re-review warrants no prose reply —
+ * answering it just doubles the thread (issue #111). The action reacts with 👍
+ * instead and skips the expensive model step entirely.
+ *
+ * Run as a GitHub Action step: reads the comment context from env and writes
+ * `ack_only=true|false` to `$GITHUB_OUTPUT`.
+ *
+ * @example
+ * BOT_IN_THREAD=true PR_AUTHOR=alice COMMENT_AUTHOR=alice COMMENT_BODY="Fixed — done." \
+ *   bun run src/classifyReaction.ts   # writes ack_only=true to $GITHUB_OUTPUT
+ */
+import { appendFile } from "node:fs/promises";
+
+/** Phrases that signal the author wants the bot to look again. */
+const reReviewKeywords = [
+  "re-review",
+  "re review",
+  "rereview",
+  "review again",
+  "another look",
+  "look again",
+  "ptal",
+];
+
+/**
+ * True when a comment body neither asks a question nor requests a re-review —
+ * i.e. it is a bare acknowledgement that warrants no model reply.
+ */
+export function isBareAcknowledgement(body: string): boolean {
+  if (body.includes("?")) {
+    return false;
+  }
+
+  const lower = body.toLowerCase();
+  return !reReviewKeywords.some((keyword) => lower.includes(keyword));
+}
+
+/** Inputs needed to decide whether a react-mode reply can skip the model. */
+export interface ReactionClassification {
+  botInThread: boolean;
+  prAuthor: string;
+  commentAuthor: string;
+  body: string;
+}
+
+/**
+ * True when the triggering reply is a PR-author acknowledgement inside a
+ * bot-authored thread, so the model reply can be skipped in favour of a 👍.
+ */
+export function shouldSkipModelReply({
+  botInThread,
+  prAuthor,
+  commentAuthor,
+  body,
+}: ReactionClassification): boolean {
+  if (!botInThread) {
+    return false;
+  }
+
+  if (!prAuthor || commentAuthor !== prAuthor) {
+    return false;
+  }
+
+  return isBareAcknowledgement(body);
+}
+
+if (import.meta.main) {
+  const ackOnly = shouldSkipModelReply({
+    botInThread: process.env.BOT_IN_THREAD === "true",
+    prAuthor: process.env.PR_AUTHOR ?? "",
+    commentAuthor: process.env.COMMENT_AUTHOR ?? "",
+    body: process.env.COMMENT_BODY ?? "",
+  });
+
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    await appendFile(outputFile, `ack_only=${ackOnly}\n`);
+  }
+
+  if (ackOnly) {
+    console.log("PR-author acknowledgement in bot thread — skipping model reply (issue #111)");
+  }
+}

--- a/.github/actions/code-review-action/src/preflightChecks.ts
+++ b/.github/actions/code-review-action/src/preflightChecks.ts
@@ -6,11 +6,10 @@
  * @example
  * GH_TOKEN=xxx REPO=owner/repo PR_NUMBER=123 PR_HEAD_SHA=abc JOB_NAME=review POLL_INTERVAL=10 CHECKS_TIMEOUT=600 PR_AUTHOR=user bun run scripts/preflightChecks.ts
  */
-import { appendFile } from "node:fs/promises";
-
 import { fetchCheckStatuses } from "@code-assistants/actions-core/checkStatus";
 import type { Octokit } from "@octokit/rest";
 
+import { setOutput } from "./actionsOutput.ts";
 import { parseRepoEnv } from "./github/githubReview.ts";
 
 /** Outcome of the preflight polling loop */
@@ -172,14 +171,6 @@ async function postSkipComment(
   console.log("✓ Posted skip comment to PR");
 }
 
-/** Write output to GITHUB_OUTPUT file. */
-async function writeOutput(key: string, value: string): Promise<void> {
-  const outputFile = process.env.GITHUB_OUTPUT;
-  if (outputFile) {
-    await appendFile(outputFile, `${key}=${value}\n`);
-  }
-}
-
 // Main execution
 try {
   const config = parsePreflightEnv();
@@ -191,7 +182,7 @@ try {
 
   if (outcome.status === "passed") {
     console.log("✓ All checks passed, proceeding with review");
-    await writeOutput("skip_review", "false");
+    await setOutput("skip_review", "false");
   } else if (outcome.status === "failed") {
     console.log(`✗ Failed checks: ${outcome.failedNames.join(", ")}`);
     const comment = buildFailureComment(config.prAuthor, outcome.failedNames);
@@ -203,7 +194,7 @@ try {
       config.reviewer,
       comment
     );
-    await writeOutput("skip_review", "true");
+    await setOutput("skip_review", "true");
   } else {
     const timeoutMin = Math.round(config.timeoutMs / 60_000);
     console.log(`✗ Timeout after ${timeoutMin}min, pending: ${outcome.pendingNames.join(", ")}`);
@@ -216,9 +207,9 @@ try {
       config.reviewer,
       comment
     );
-    await writeOutput("skip_review", "true");
+    await setOutput("skip_review", "true");
   }
 } catch (error) {
   console.error("Preflight check error (fail-open, proceeding with review):", error);
-  await writeOutput("skip_review", "false");
+  await setOutput("skip_review", "false");
 }

--- a/.github/actions/code-review-action/src/reactToComment.ts
+++ b/.github/actions/code-review-action/src/reactToComment.ts
@@ -91,9 +91,8 @@ const commentId = process.env.COMMENT_ID;
 const commentPath = process.env.COMMENT_PATH;
 const ackOnly = process.env.ACK_ONLY === "true";
 
-// PR-author acknowledgement in a bot-authored thread (issue #111): the model
-// step was skipped upstream, so there is no reply to post — just react with 👍
-// so the thread shows the bot saw it. A failed reaction must not fail the run.
+// Bare acknowledgement (issue #111): react with 👍 instead of a prose reply.
+// A failed reaction must not fail the run.
 if (ackOnly) {
   if (commentId) {
     try {

--- a/.github/actions/code-review-action/src/reactToComment.ts
+++ b/.github/actions/code-review-action/src/reactToComment.ts
@@ -89,6 +89,31 @@ const { octokit, owner, repoName, pullNumber, reviewer } = parseRepoEnv();
 const structuredOutput = process.env.STRUCTURED_OUTPUT ?? "";
 const commentId = process.env.COMMENT_ID;
 const commentPath = process.env.COMMENT_PATH;
+const ackOnly = process.env.ACK_ONLY === "true";
+
+// PR-author acknowledgement in a bot-authored thread (issue #111): the model
+// step was skipped upstream, so there is no reply to post — just react with 👍
+// so the thread shows the bot saw it. A failed reaction must not fail the run.
+if (ackOnly) {
+  if (commentId) {
+    try {
+      await octokit.rest.reactions.createForPullRequestReviewComment({
+        owner,
+        repo: repoName,
+        comment_id: Number(commentId),
+        content: "+1",
+      });
+      console.log("✓ Acknowledged PR-author reply with 👍 — no model reply needed");
+    } catch (error) {
+      console.warn(
+        `Failed to add 👍 reaction: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  } else {
+    console.log("ACK_ONLY set but no comment ID — nothing to react to");
+  }
+  process.exit(0);
+}
 
 let output = parseReactionOutput(structuredOutput);
 

--- a/.github/actions/code-review-action/src/runClaude.test.ts
+++ b/.github/actions/code-review-action/src/runClaude.test.ts
@@ -15,7 +15,6 @@ import {
   parseConfig,
   resolveClaudeBinary,
   safeParseJson,
-  setOutput,
 } from "./runClaude.ts";
 
 describe("safeParseJson", () => {
@@ -233,52 +232,5 @@ describe("resolveClaudeBinary", () => {
     for (const binary of [darwinArm64, darwinX64]) {
       if (binary !== undefined) expect(binary).toMatch(/claude$/);
     }
-  });
-});
-
-describe("setOutput", () => {
-  let tempDir: string;
-  let outputFile: string;
-  const originalEnv = { ...process.env };
-
-  beforeEach(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "runClaude-test-"));
-    outputFile = join(tempDir, "GITHUB_OUTPUT");
-    await Bun.write(outputFile, "");
-    process.env.GITHUB_OUTPUT = outputFile;
-  });
-
-  afterEach(async () => {
-    process.env = { ...originalEnv };
-    await rm(tempDir, { recursive: true });
-  });
-
-  test("writes output with heredoc delimiter", async () => {
-    await setOutput("test_key", "test_value");
-
-    const content = await readFile(outputFile, "utf8");
-    expect(content).toMatch(/^test_key<<EOF_[a-f0-9]+\ntest_value\nEOF_[a-f0-9]+\n$/);
-  });
-
-  test("handles multi-line values", async () => {
-    await setOutput("json", '{"key":"value",\n"nested":true}');
-
-    const content = await readFile(outputFile, "utf8");
-    expect(content).toContain('{"key":"value",\n"nested":true}');
-  });
-
-  test("does nothing without GITHUB_OUTPUT", async () => {
-    delete process.env.GITHUB_OUTPUT;
-    await setOutput("key", "value");
-    // Should not throw
-  });
-
-  test("appends multiple outputs", async () => {
-    await setOutput("key1", "val1");
-    await setOutput("key2", "val2");
-
-    const content = await readFile(outputFile, "utf8");
-    expect(content).toContain("key1<<EOF_");
-    expect(content).toContain("key2<<EOF_");
   });
 });

--- a/.github/actions/code-review-action/src/runClaude.ts
+++ b/.github/actions/code-review-action/src/runClaude.ts
@@ -10,8 +10,7 @@
  *
  * @see https://docs.anthropic.com/en/docs/agent-sdk/typescript - Agent SDK reference
  */
-import { randomUUID } from "node:crypto";
-import { access, appendFile, mkdir } from "node:fs/promises";
+import { access, mkdir } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 
@@ -20,6 +19,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import pino from "pino";
 import { z } from "zod";
 
+import { setOutput } from "./actionsOutput.ts";
 import { logMessage } from "./logClaudeMessage.ts";
 import { runReviewFanout, type FanoutContext } from "./reviewFanout.ts";
 
@@ -171,15 +171,6 @@ async function writeSettings(settingsJson: string | undefined): Promise<string[]
 
   process.env.CLAUDE_CONFIG_DIR = dir;
   return ["user", "project"];
-}
-
-/** Set a GitHub Actions output variable using heredoc delimiter for multi-line safety. */
-export async function setOutput(key: string, value: string): Promise<void> {
-  const outputFile = process.env.GITHUB_OUTPUT;
-  if (!outputFile) return;
-
-  const delimiter = `EOF_${randomUUID().replaceAll("-", "")}`;
-  await appendFile(outputFile, `${key}<<${delimiter}\n${value}\n${delimiter}\n`);
 }
 
 async function pathExists(path: string): Promise<boolean> {


### PR DESCRIPTION
The code-review-action's react mode replied to every acknowledgement the PR author posted inside a bot review thread, so each resolved finding produced a second bot comment — a feedback cascade that doubled thread volume and spent Anthropic tokens and GitHub Actions minutes for no value. React mode now classifies the triggering reply before the model runs and only responds when the author asks a question or requests a re-review; bare acknowledgements get a 👍 instead.

- Added a classifier (`classifyReaction.ts`) that flags a PR-author reply inside a bot-authored thread with no question and no re-review request
- Added a "Classify reaction" step that skips the reply-generating model call when the reply is a bare acknowledgement
- React with a 👍 on the comment instead of posting a prose reply
- Added unit tests for the classifier (questions, re-review keywords, author and thread gates)

---

**Release notes:**

- The AI code reviewer no longer replies to routine acknowledgements (e.g. "Fixed —") on its own review threads; it adds a 👍 reaction instead, and still answers questions and explicit re-review requests

---

**Issues:**

Closes #111
