### PR TITLE
Make release auto-merge an opt-in per-repo setting

### DIFF
--- a/.github/actions/release-action/package.json
+++ b/.github/actions/release-action/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.92.0",
+    "@code-assistants/actions-core": "workspace:*",
     "@slack/web-api": "7.15.1",
     "conventional-changelog": "7.2.0",
     "conventional-changelog-conventionalcommits": "9.3.1",

--- a/.github/actions/release-action/src/detectReleaseType.ts
+++ b/.github/actions/release-action/src/detectReleaseType.ts
@@ -15,8 +15,9 @@
  */
 import { appendFile } from "node:fs/promises";
 
+import { readReleaseField } from "@code-assistants/actions-core/releaseField";
+
 import { discoverMembers } from "./monorepo/discoverMembers.ts";
-import { readReleaseField } from "./releaseField.ts";
 
 const DOCS_LINK = "docs/release-field.md";
 const PACKAGE_JSON = "package.json";

--- a/.github/actions/release-action/src/monorepo/discoverMembers.ts
+++ b/.github/actions/release-action/src/monorepo/discoverMembers.ts
@@ -16,9 +16,8 @@
  */
 import { join, relative } from "node:path";
 
+import { readReleaseField, readRootRelease, type ReleaseType } from "@code-assistants/actions-core/releaseField";
 import { Glob } from "bun";
-
-import { readReleaseField, readRootRelease, type ReleaseType } from "../releaseField.ts";
 
 /** Workspace member eligible for an independent release. */
 export interface Member {

--- a/.github/actions/release-action/src/slackNotify.ts
+++ b/.github/actions/release-action/src/slackNotify.ts
@@ -12,9 +12,9 @@
  * SLACK_TOKEN=xoxb-... bun src/slackNotify.ts
  * ```
  */
+import { readReleaseField } from "@code-assistants/actions-core/releaseField";
 import { WebClient } from "@slack/web-api";
 
-import { readReleaseField } from "./releaseField.ts";
 import { changelogSectionNames } from "./release.ts";
 
 /** Heading prefix used by conventional changelog sections in release notes files */

--- a/.github/actions/release-automerge/README.md
+++ b/.github/actions/release-automerge/README.md
@@ -8,9 +8,18 @@ A PR is merged only when **all** of the following hold:
 
 - the head ref matches `^release-`,
 - the PR is open,
+- the repo opted in via `release.automerge === true` in the root `package.json`
+  (read at the PR head SHA; default `false`),
 - every sibling check is green (a failed check skips; a still-pending check skips),
   and
 - the PR's `reviewDecision` is `APPROVED`.
+
+> **Opt-in (default off).** Auto-merge is disabled unless the repo-root
+> `package.json` declares `release.automerge: true` (see the
+> [`release` field spec](../../../docs/release-field.md)). Because consumers
+> reference this action via `@main`, adopting the synced workflow alone does
+> **not** enable auto-merge — each repo must add the flag, or its release PRs
+> stay approved-but-unmerged for a human to merge.
 
 The merge is pinned to the triggering head commit, so a push that lands during
 evaluation is rejected rather than merged unreviewed. The check aggregation reuses
@@ -92,6 +101,9 @@ Store the token in a secret (e.g., `BOT_TOKEN`) and pass it via
 
 - Resolves the open release PR from the triggering commit via the
   commit-associated-PRs API, then bails unless its head ref matches `^release-`.
+- Reads the repo-root `package.json` at the head SHA and skips unless
+  `release.automerge === true`. A missing `package.json` is a clean skip; a
+  malformed one fails closed (no merge). A non-boolean `automerge` is rejected.
 - Aggregates check runs and commit statuses in a single snapshot (no polling):
   any failed check or any still-pending check skips the merge until a later event.
 - Reads `reviewDecision` and merges only when it is `APPROVED`.

--- a/.github/actions/release-automerge/src/automerge.test.ts
+++ b/.github/actions/release-automerge/src/automerge.test.ts
@@ -7,7 +7,12 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import { isApprovedDecision, pickReleasePr, selectMergeMethod } from "./automerge.ts";
+import {
+  isApprovedDecision,
+  isAutomergeEnabled,
+  pickReleasePr,
+  selectMergeMethod,
+} from "./automerge.ts";
 
 describe("pickReleasePr", () => {
   test("picks the open release PR", () => {
@@ -68,5 +73,29 @@ describe("isApprovedDecision", () => {
     expect(isApprovedDecision("CHANGES_REQUESTED")).toBe(false);
     expect(isApprovedDecision("REVIEW_REQUIRED")).toBe(false);
     expect(isApprovedDecision(null)).toBe(false);
+  });
+});
+
+describe("isAutomergeEnabled", () => {
+  test("true when release.automerge is true", () => {
+    expect(isAutomergeEnabled({ release: { automerge: true } })).toBe(true);
+  });
+
+  test("true alongside a monorepo members root", () => {
+    expect(isAutomergeEnabled({ release: { members: ["packages/*"], automerge: true } })).toBe(
+      true
+    );
+  });
+
+  test("false when release.automerge is false", () => {
+    expect(isAutomergeEnabled({ release: { automerge: false } })).toBe(false);
+  });
+
+  test("false when release.automerge is absent", () => {
+    expect(isAutomergeEnabled({ release: { type: "github-action" } })).toBe(false);
+  });
+
+  test("false when there is no release field", () => {
+    expect(isAutomergeEnabled({ name: "x" })).toBe(false);
   });
 });

--- a/.github/actions/release-automerge/src/automerge.test.ts
+++ b/.github/actions/release-automerge/src/automerge.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   isApprovedDecision,
-  isAutomergeEnabled,
+  parseAutomergeOptIn,
   pickReleasePr,
   selectMergeMethod,
 } from "./automerge.ts";
@@ -40,26 +40,26 @@ describe("pickReleasePr", () => {
 
 describe("selectMergeMethod", () => {
   test("prefers rebase when allowed", () => {
-    expect(
-      selectMergeMethod({ allowRebase: true, allowSquash: true, allowMerge: true })
-    ).toBe("rebase");
+    expect(selectMergeMethod({ allowRebase: true, allowSquash: true, allowMerge: true })).toBe(
+      "rebase",
+    );
   });
 
   test("falls back to squash when rebase disabled", () => {
-    expect(
-      selectMergeMethod({ allowRebase: false, allowSquash: true, allowMerge: true })
-    ).toBe("squash");
+    expect(selectMergeMethod({ allowRebase: false, allowSquash: true, allowMerge: true })).toBe(
+      "squash",
+    );
   });
 
   test("falls back to merge when only merge allowed", () => {
-    expect(
-      selectMergeMethod({ allowRebase: false, allowSquash: false, allowMerge: true })
-    ).toBe("merge");
+    expect(selectMergeMethod({ allowRebase: false, allowSquash: false, allowMerge: true })).toBe(
+      "merge",
+    );
   });
 
   test("returns null when no method allowed", () => {
     expect(
-      selectMergeMethod({ allowRebase: false, allowSquash: false, allowMerge: false })
+      selectMergeMethod({ allowRebase: false, allowSquash: false, allowMerge: false }),
     ).toBeNull();
   });
 });
@@ -76,26 +76,53 @@ describe("isApprovedDecision", () => {
   });
 });
 
-describe("isAutomergeEnabled", () => {
-  test("true when release.automerge is true", () => {
-    expect(isAutomergeEnabled({ release: { automerge: true } })).toBe(true);
+describe("parseAutomergeOptIn", () => {
+  const source = "owner/repo:package.json@abc1234";
+
+  test("false when raw content is null (missing file)", () => {
+    expect(parseAutomergeOptIn(null, source)).toBe(false);
   });
 
-  test("true alongside a monorepo members root", () => {
-    expect(isAutomergeEnabled({ release: { members: ["packages/*"], automerge: true } })).toBe(
-      true
+  test("true when release.automerge is true", () => {
+    expect(parseAutomergeOptIn(JSON.stringify({ release: { automerge: true } }), source)).toBe(
+      true,
     );
   });
 
+  test("true alongside a monorepo members root", () => {
+    expect(
+      parseAutomergeOptIn(
+        JSON.stringify({ release: { members: ["packages/*"], automerge: true } }),
+        source,
+      ),
+    ).toBe(true);
+  });
+
   test("false when release.automerge is false", () => {
-    expect(isAutomergeEnabled({ release: { automerge: false } })).toBe(false);
+    expect(parseAutomergeOptIn(JSON.stringify({ release: { automerge: false } }), source)).toBe(
+      false,
+    );
   });
 
   test("false when release.automerge is absent", () => {
-    expect(isAutomergeEnabled({ release: { type: "github-action" } })).toBe(false);
+    expect(
+      parseAutomergeOptIn(JSON.stringify({ release: { type: "github-action" } }), source),
+    ).toBe(false);
   });
 
   test("false when there is no release field", () => {
-    expect(isAutomergeEnabled({ name: "x" })).toBe(false);
+    expect(parseAutomergeOptIn(JSON.stringify({ name: "x" }), source)).toBe(false);
+  });
+
+  test("throws naming the source when JSON is malformed", () => {
+    expect(() => parseAutomergeOptIn("{ not json", source)).toThrow(
+      /Failed to read auto-merge opt-in from owner\/repo:package\.json@abc1234/,
+    );
+  });
+
+  test("throws when release.automerge is not a boolean", () => {
+    expect(() =>
+      parseAutomergeOptIn(JSON.stringify({ release: { automerge: "yes" } }), source),
+    ).toThrow(/'release\.automerge'.*must be a boolean/);
   });
 });

--- a/.github/actions/release-automerge/src/automerge.ts
+++ b/.github/actions/release-automerge/src/automerge.ts
@@ -3,16 +3,21 @@
  *
  * Re-evaluated on every relevant event (check_suite, status, review), the action
  * merges a PR only when ALL of these hold: the head ref matches `^release-`, the
- * PR is open, every sibling check is green, and the review decision is APPROVED.
- * Any unmet condition or unexpected error is fail-closed — the action never
- * merges on doubt. The merge is pinned to the triggering head SHA so a push that
- * lands mid-evaluation cannot be merged unreviewed.
+ * PR is open, the repo-root `package.json` opts in via `release.automerge === true`,
+ * every sibling check is green, and the review decision is APPROVED. The opt-in is
+ * read from the root `package.json` at the triggering head SHA, so the policy
+ * travels with the release branch. Any unmet condition or unexpected error is
+ * fail-closed — the action never merges on doubt. The merge is pinned to the
+ * triggering head SHA so a push that lands mid-evaluation cannot be merged
+ * unreviewed.
  *
  * @example
  * GH_TOKEN=xxx REPO=owner/repo HEAD_SHA=abc JOB_NAME=automerge bun run src/automerge.ts
  */
 import { fetchCheckStatuses } from "@code-assistants/actions-core/checkStatus";
+import { fetchRawContent } from "@code-assistants/actions-core/fetchRawContent";
 import { parseRepo } from "@code-assistants/actions-core/parseRepo";
+import { readRootRelease } from "@code-assistants/actions-core/releaseField";
 import { Octokit } from "@octokit/rest";
 
 /** Minimal PR shape needed to pick the release PR for a commit. */
@@ -33,6 +38,8 @@ export interface MergeMethodFlags {
 export type MergeMethod = "rebase" | "squash" | "merge";
 
 const releaseBranch = /^release-/;
+// Repo-wide auto-merge opt-in lives in the root package.json's `release` object.
+const rootPackageJsonPath = "package.json";
 // GitHub merge-API responses that mean "nothing to do" rather than a real error:
 // 405 not mergeable / already merged, 409 head SHA moved (sha mismatch), 422 unprocessable.
 const idempotentMergeStatuses = new Set([405, 409, 422]);
@@ -84,6 +91,44 @@ export function selectMergeMethod(flags: MergeMethodFlags): MergeMethod | null {
 /** True only for an explicit APPROVED review decision. */
 export function isApprovedDecision(decision: string | null): boolean {
   return decision === "APPROVED";
+}
+
+/**
+ * Repo-wide auto-merge opt-in: true only when the root `package.json` declares
+ * `release.automerge === true`. Any other value — including an absent field —
+ * leaves auto-merge disabled, so the action no-ops and a human merges instead.
+ */
+export function isAutomergeEnabled(rootPackageJson: unknown): boolean {
+  return readRootRelease(rootPackageJson).automerge === true;
+}
+
+/**
+ * Read the root `package.json` at the triggering head SHA and decide whether
+ * the repo opted into auto-merge. A missing file is a clean "disabled" (no-op);
+ * a malformed file throws so the fail-closed wrapper never merges on doubt.
+ */
+async function fetchAutomergeOptIn(config: AutomergeConfig): Promise<boolean> {
+  const { octokit, owner, repo, headSha } = config;
+  const raw = await fetchRawContent({
+    octokit,
+    owner,
+    repo,
+    path: rootPackageJsonPath,
+    ref: headSha,
+  });
+
+  if (raw === null) {
+    return false;
+  }
+
+  try {
+    return isAutomergeEnabled(JSON.parse(raw));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to read auto-merge opt-in from ${owner}/${repo}:${rootPackageJsonPath}@${headSha.slice(0, 7)}: ${detail}`
+    );
+  }
 }
 
 /** Fetch the PR's aggregate review decision via GraphQL. */
@@ -166,6 +211,13 @@ async function run(config: AutomergeConfig): Promise<void> {
 
   if (!pr) {
     console.log(`Skip: no open release PR for ${headSha.slice(0, 7)}`);
+    return;
+  }
+
+  if (!(await fetchAutomergeOptIn(config))) {
+    console.log(
+      "Skip: auto-merge disabled — set release.automerge:true in the root package.json (see docs/release-automerge.md)"
+    );
     return;
   }
 

--- a/.github/actions/release-automerge/src/automerge.ts
+++ b/.github/actions/release-automerge/src/automerge.ts
@@ -94,19 +94,27 @@ export function isApprovedDecision(decision: string | null): boolean {
 }
 
 /**
- * Repo-wide auto-merge opt-in: true only when the root `package.json` declares
- * `release.automerge === true`. Any other value — including an absent field —
- * leaves auto-merge disabled, so the action no-ops and a human merges instead.
+ * Decide auto-merge opt-in from the raw root `package.json` content.
+ *
+ * Repo-wide opt-in holds only when `release.automerge === true`; any other value
+ * — including an absent field — disables it. A `null` `raw` (missing file) is a
+ * clean "disabled". Malformed JSON or an invalid `release` object throws, naming
+ * `source`, so the fail-closed caller never merges on doubt.
  */
-export function isAutomergeEnabled(rootPackageJson: unknown): boolean {
-  return readRootRelease(rootPackageJson).automerge === true;
+export function parseAutomergeOptIn(raw: string | null, source: string): boolean {
+  if (raw === null) {
+    return false;
+  }
+
+  try {
+    return readRootRelease(JSON.parse(raw)).automerge === true;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read auto-merge opt-in from ${source}: ${detail}`);
+  }
 }
 
-/**
- * Read the root `package.json` at the triggering head SHA and decide whether
- * the repo opted into auto-merge. A missing file is a clean "disabled" (no-op);
- * a malformed file throws so the fail-closed wrapper never merges on doubt.
- */
+/** Fetch the root `package.json` at the triggering head SHA and decide opt-in. */
 async function fetchAutomergeOptIn(config: AutomergeConfig): Promise<boolean> {
   const { octokit, owner, repo, headSha } = config;
   const raw = await fetchRawContent({
@@ -117,18 +125,7 @@ async function fetchAutomergeOptIn(config: AutomergeConfig): Promise<boolean> {
     ref: headSha,
   });
 
-  if (raw === null) {
-    return false;
-  }
-
-  try {
-    return isAutomergeEnabled(JSON.parse(raw));
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Failed to read auto-merge opt-in from ${owner}/${repo}:${rootPackageJsonPath}@${headSha.slice(0, 7)}: ${detail}`
-    );
-  }
+  return parseAutomergeOptIn(raw, `${owner}/${repo}:${rootPackageJsonPath}@${headSha.slice(0, 7)}`);
 }
 
 /** Fetch the PR's aggregate review decision via GraphQL. */
@@ -136,7 +133,7 @@ async function fetchReviewDecision(
   octokit: Octokit,
   owner: string,
   repo: string,
-  pullNumber: number
+  pullNumber: number,
 ): Promise<string | null> {
   const result = await octokit.graphql<{
     repository: { pullRequest: { reviewDecision: string | null } };
@@ -146,7 +143,7 @@ async function fetchReviewDecision(
         pullRequest(number: $number) { reviewDecision }
       }
     }`,
-    { owner, repo, number: pullNumber }
+    { owner, repo, number: pullNumber },
   );
 
   return result.repository.pullRequest.reviewDecision;
@@ -156,7 +153,7 @@ async function fetchReviewDecision(
 async function fetchMergeMethodFlags(
   octokit: Octokit,
   owner: string,
-  repo: string
+  repo: string,
 ): Promise<MergeMethodFlags> {
   const { data } = await octokit.rest.repos.get({ owner, repo });
   return {
@@ -191,7 +188,9 @@ async function mergeRelease(config: AutomergeConfig, pullNumber: number): Promis
   } catch (error) {
     const status = (error as { status?: number }).status;
     if (status && idempotentMergeStatuses.has(status)) {
-      console.log(`Skip: PR #${pullNumber} not mergeable now (HTTP ${status}) — head moved or already merged`);
+      console.log(
+        `Skip: PR #${pullNumber} not mergeable now (HTTP ${status}) — head moved or already merged`,
+      );
       return;
     }
     throw error;
@@ -216,7 +215,7 @@ async function run(config: AutomergeConfig): Promise<void> {
 
   if (!(await fetchAutomergeOptIn(config))) {
     console.log(
-      "Skip: auto-merge disabled — set release.automerge:true in the root package.json (see docs/release-automerge.md)"
+      "Skip: auto-merge disabled — set release.automerge:true in the root package.json (see docs/release-automerge.md)",
     );
     return;
   }

--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "0.92.0",
+        "@code-assistants/actions-core": "workspace:*",
         "@slack/web-api": "7.15.1",
         "conventional-changelog": "7.2.0",
         "conventional-changelog-conventionalcommits": "9.3.1",

--- a/docs/release-automerge.md
+++ b/docs/release-automerge.md
@@ -30,14 +30,15 @@ the merge with no manual step.
  │ on: check_suite[completed] · pull_request_review[submitted]│
  └───────────────────────────┬───────────────────────────────┘
                              ▼
-   ┌─────────────────────────────────────────────────┐
-   │ release-automerge action                         │
-   │ 1. resolve open PR for the head SHA              │
-   │ 2. head ref ~ ^release-  AND  state == open ?    │
-   │ 3. all checks green? (shared aggregation)        │
-   │ 4. reviewDecision == APPROVED ?                  │
-   │ 5. merge (sha-pinned) with an allowed method     │
-   └───────────────────────────┬─────────────────────┘
+   ┌───────────────────────────────────────────────────┐
+   │ release-automerge action                          │
+   │ 1. resolve open PR for the head SHA               │
+   │ 2. head ref ~ ^release-  AND  state == open ?     │
+   │ 3. root package.json release.automerge === true ? │
+   │ 4. all checks green? (shared aggregation)         │
+   │ 5. reviewDecision == APPROVED ?                   │
+   │ 6. merge (sha-pinned) with an allowed method      │
+   └───────────────────────────┬───────────────────────┘
                   ▼ all true                ▼ any false / any error
             merge PR                   no-op (never merge)
                   │
@@ -56,10 +57,21 @@ the merge with no manual step.
   approval already re-evaluates commit statuses, so dropping it avoids running on
   non-release PRs without losing meaningful coverage.)
 - **Merge conditions (all must hold):** the head ref matches `^release-`, the PR
-  is open, every sibling check is green (failed → skip; still pending → skip), and
-  `reviewDecision == APPROVED`. The check aggregation reuses the same logic as the
-  AI-review preflight (see [the shared `checkStatus` helper][checkstatus]),
-  deduplicated by name and excluding the action's own job.
+  is open, the repo opted in via `release.automerge === true`, every sibling check
+  is green (failed → skip; still pending → skip), and `reviewDecision == APPROVED`.
+  The check aggregation reuses the same logic as the AI-review preflight (see
+  [the shared `checkStatus` helper][checkstatus]), deduplicated by name and
+  excluding the action's own job.
+- **Opt-in gate (default off):** the action reads the repo-root `package.json` at
+  the triggering head SHA and merges only when `release.automerge === true` (see
+  the [`release` field spec](./release-field.md)). The flag travels with the
+  release branch — a PR that toggles it changes its own merge eligibility. A
+  missing `package.json` is a clean skip; a malformed one fails closed (no merge);
+  a non-boolean `automerge` is rejected. **Migration:** because downstream repos
+  reference the action via `@main`, this gate ships as a behavior change — every
+  repo that relied on auto-merge must add `release.automerge: true` to its root
+  `package.json`, or its release PRs will stay approved-but-unmerged until a human
+  merges them.
 - **Merge method:** the action reads the repository's allowed merge methods
   (`allow_rebase_merge` / `allow_squash_merge` / `allow_merge_commit`) and prefers
   `rebase`, falling back to `squash` then `merge`. The merge is pinned to the

--- a/docs/release-field.md
+++ b/docs/release-field.md
@@ -44,12 +44,15 @@ interface RootReleaseConfig {
   members?: string[]; // monorepo: explicit member paths (mutually exclusive with `type`)
   type?: ReleaseType; // standalone: same shape as ReleaseConfig
   slack?: string;
+  automerge?: boolean; // root-only opt-in for release-automerge (default false)
 }
 ```
 
 `type` is required on **member** manifests. `slack` is optional — when omitted, `release-action` skips the Slack notification step. When present, it must be a non-empty string.
 
 At the **root** of a monorepo, `release.members` declares the workspace paths to release; `type` is omitted on the root in that case. When neither `members` nor `type` is present, `release-action` falls back to expanding the root's `workspaces` globs and using only members that declare their own `release.type`.
+
+`automerge` is a **root-only**, repo-wide boolean consumed only by [`release-automerge`](../.github/actions/release-automerge/README.md) (default `false`). It opts the repository into auto-merging approved, all-green release PRs; it is independent of `members`/`type` and is never read per member. It is **not** a `release.type` value, so it does not appear in the recognized-`type` table below and does not follow the type-extension workflow.
 
 ### Recognized `type` values
 
@@ -67,10 +70,11 @@ Any other value is treated as unrecognized and fails the action.
 
 ## Consumers
 
-| Tool                                                            | Reads           | Behavior                                                                                                             | Source                                                    |
-| --------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| [`release-action`](../.github/actions/release-action/README.md) | `release.type`  | Selects version source, npm-publish step, GitHub Release step, and major-version tag based on the value's table row. | `.github/actions/release-action/src/detectReleaseType.ts` |
-| [`release-action`](../.github/actions/release-action/README.md) | `release.slack` | When present, posts a Slack notification to this channel after publish. When absent, the Slack step is skipped.      | `.github/actions/release-action/src/slackNotify.ts`       |
+| Tool                                                                  | Reads               | Behavior                                                                                                                                                                  | Source                                                    |
+| --------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [`release-action`](../.github/actions/release-action/README.md)       | `release.type`      | Selects version source, npm-publish step, GitHub Release step, and major-version tag based on the value's table row.                                                      | `.github/actions/release-action/src/detectReleaseType.ts` |
+| [`release-action`](../.github/actions/release-action/README.md)       | `release.slack`     | When present, posts a Slack notification to this channel after publish. When absent, the Slack step is skipped.                                                           | `.github/actions/release-action/src/slackNotify.ts`       |
+| [`release-automerge`](../.github/actions/release-automerge/README.md) | `release.automerge` | Merges an approved, all-green release PR only when `true` (read from the repo-root `package.json` at the PR head SHA). When `false` or absent, leaves the PR for a human. | `packages/actions-core/src/releaseField.ts`               |
 
 ## Detection algorithm
 
@@ -81,7 +85,7 @@ Any other value is treated as unrecognized and fails the action.
 5. Validate `release.slack` is a non-empty string if present.
 6. **No fallback** — missing `release`, missing `release.type`, or an unrecognized value fails the action with a message pointing back to this document.
 
-The reference implementation is `.github/actions/release-action/src/releaseField.ts` (`readReleaseField`). The entry script `detectReleaseType.ts` wires the `type` to the action; `slackNotify.ts` reads `slack` from the same parsed config.
+The reference implementation is `packages/actions-core/src/releaseField.ts` (`readReleaseField` / `readRootRelease`), shared by `release-action` and `release-automerge`. The entry script `detectReleaseType.ts` wires the `type` to the action; `slackNotify.ts` reads `slack` from the same parsed config; `release-automerge` reads `release.automerge` via `readRootRelease`.
 
 ## Examples
 
@@ -146,10 +150,24 @@ Version source switches to `plugin.json`; npm publish is skipped; GitHub Release
 
 `release-action` runs once per member with the per-member `release.type` driving artifacts. Per-member tags use the form `<name>@v<version>` (e.g. `release-action@v1.2.0`) and the floating major tag becomes `<name>@v1`. When `release.members` is omitted, the action falls back to the root `workspaces` array and skips any member that does not declare its own `release` field.
 
+### Repo opting into auto-merge
+
+```json
+{
+  "name": "monorepo",
+  "workspaces": [".github/actions/*", "packages/*"],
+  "release": {
+    "automerge": true
+  }
+}
+```
+
+`release-automerge` merges approved, all-green `release-*` PRs without a manual click. Because `members`/`type` are omitted, `release-action` still discovers members via the `workspaces` fallback — `automerge` only governs the merge step and is read at the PR head SHA. Omitting `automerge` (or setting it `false`) leaves release PRs for a human to merge.
+
 ## Extending
 
 To add a new release type:
 
-1. Add the value to `releaseTypes` in `.github/actions/release-action/src/releaseField.ts`.
+1. Add the value to `releaseTypes` in `packages/actions-core/src/releaseField.ts`.
 2. Extend the release-action publish logic to handle the new value.
 3. Add a row to the table above and mirror it in `.github/actions/release-action/README.md` (keep both tables in the same row order).

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "node": ">=22"
   },
   "packageManager": "bun@1.3.9",
+  "release": {
+    "automerge": true
+  },
   "agents": {
     "rules": "Bun",
     "language": "typescript"

--- a/packages/actions-core/package.json
+++ b/packages/actions-core/package.json
@@ -12,7 +12,8 @@
   "exports": {
     "./fetchRawContent": "./src/fetchRawContent.ts",
     "./checkStatus": "./src/checkStatus.ts",
-    "./parseRepo": "./src/parseRepo.ts"
+    "./parseRepo": "./src/parseRepo.ts",
+    "./releaseField": "./src/releaseField.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/actions-core/src/releaseField.test.ts
+++ b/packages/actions-core/src/releaseField.test.ts
@@ -154,3 +154,37 @@ describe("readRootRelease", () => {
     expect(() => readRootRelease(null)).toThrow(/expected an object/);
   });
 });
+
+describe("readRootRelease — automerge", () => {
+  test("returns automerge alongside members", () => {
+    expect(readRootRelease({ release: { members: ["packages/*"], automerge: true } })).toEqual({
+      members: ["packages/*"],
+      automerge: true,
+    });
+  });
+
+  test("returns automerge alongside type", () => {
+    expect(readRootRelease({ release: { type: "lib-nodejs", automerge: false } })).toEqual({
+      type: "lib-nodejs",
+      automerge: false,
+    });
+  });
+
+  test("returns automerge-only root with no members or type", () => {
+    const result = readRootRelease({ release: { automerge: true } });
+    expect(result).toEqual({ automerge: true });
+    expect("members" in result).toBe(false);
+    expect("type" in result).toBe(false);
+  });
+
+  test("omits automerge key when not present", () => {
+    const result = readRootRelease({ release: { type: "lib-nodejs" } });
+    expect("automerge" in result).toBe(false);
+  });
+
+  test("throws when automerge is not a boolean", () => {
+    expect(() => readRootRelease({ release: { automerge: "yes" } })).toThrow(
+      /'release\.automerge'.*must be a boolean/,
+    );
+  });
+});

--- a/packages/actions-core/src/releaseField.ts
+++ b/packages/actions-core/src/releaseField.ts
@@ -5,11 +5,12 @@
  *
  * - `type` — picks publish targets, version source, and the major-version tag.
  * - `slack` — optional Slack channel for the post-publish notification.
+ * - `automerge` — root-only opt-in for `release-automerge` (default `false`).
  *
  * Detection is fail-closed for `type`: a missing field or an unrecognized
  * value throws an `Error` referencing the spec doc.
  *
- * @see ../../../../docs/release-field.md
+ * @see ../../../docs/release-field.md
  *
  * @example
  * ```typescript
@@ -54,11 +55,16 @@ export interface ReleaseConfig {
  * a standalone repo declares `type` and behaves like a member. Both forms may
  * carry `slack`. `members` and `type` are mutually exclusive at the root —
  * mixing them is a configuration error.
+ *
+ * `automerge` is a repo-wide opt-in consumed only by `release-automerge`
+ * (default `false`); it is independent of `members`/`type` and is never read
+ * per member.
  */
 export interface RootReleaseConfig {
   members?: readonly string[];
   type?: ReleaseType;
   slack?: string;
+  automerge?: boolean;
 }
 
 function fail(message: string): never {
@@ -192,6 +198,22 @@ function readMembers(release: Record<string, unknown>): readonly string[] | unde
   return value as readonly string[];
 }
 
+function readAutomerge(release: Record<string, unknown>): boolean | undefined {
+  if (!("automerge" in release)) {
+    return undefined;
+  }
+
+  const value: unknown = release.automerge;
+
+  if (typeof value !== "boolean") {
+    fail(
+      `'release.automerge' in package.json must be a boolean (true to opt into release auto-merge); got ${typeof value}.`,
+    );
+  }
+
+  return value;
+}
+
 /**
  * Read and validate the top-level `release` object on a parsed repository-root
  * `package.json`.
@@ -202,8 +224,9 @@ function readMembers(release: Record<string, unknown>): readonly string[] | unde
  * `workspaces` discovery).
  *
  * @throws when both `members` and `type` are declared (ambiguous root mode),
- *   when `members` is not a non-empty `string[]`, or when `type`/`slack` are
- *   present but invalid (same rules as {@link readReleaseField}).
+ *   when `members` is not a non-empty `string[]`, when `automerge` is present
+ *   but not a boolean, or when `type`/`slack` are present but invalid (same
+ *   rules as {@link readReleaseField}).
  *
  * @example
  * ```typescript
@@ -212,6 +235,9 @@ function readMembers(release: Record<string, unknown>): readonly string[] | unde
  *
  * readRootRelease({ release: { type: "lib-nodejs", slack: "#releases" } });
  * // → { type: "lib-nodejs", slack: "#releases" }
+ *
+ * readRootRelease({ release: { automerge: true } });
+ * // → { automerge: true }
  *
  * readRootRelease({ name: "monorepo" });
  * // → {}
@@ -247,6 +273,7 @@ export function readRootRelease(packageJson: unknown): RootReleaseConfig {
   }
 
   const slack = readSlack(release);
+  const automerge = readAutomerge(release);
   const config: RootReleaseConfig = {};
 
   if (members) {
@@ -257,6 +284,10 @@ export function readRootRelease(packageJson: unknown): RootReleaseConfig {
 
   if (slack !== undefined) {
     config.slack = slack;
+  }
+
+  if (automerge !== undefined) {
+    config.automerge = automerge;
   }
 
   return config;


### PR DESCRIPTION
Release PRs previously auto-merged for any repo that adopted the release-automerge workflow, with no way to opt out. This adds an explicit, declarative opt-in: release-automerge now merges a release PR only when the repo-root package.json declares `release.automerge: true`.

- Extracted the shared release-field reader into `@code-assistants/actions-core` so release-action and release-automerge use one typed parser
- Added an `automerge` boolean to the root release config (default false), validated as a strict boolean
- release-automerge reads the root package.json at the PR head SHA and no-ops unless `release.automerge` is true
- Enabled the flag for this repository so its own release pipeline keeps auto-merging

---

**Release notes:**

- Release auto-merge is now opt-in: set `release.automerge: true` in the root `package.json` to enable it (default off)
- Repos adopting the synced workflow must add the flag, or their release PRs stay approved-but-unmerged for a human to merge

---

**Issues:**

Closes #112
