### PR TITLE
HOTFIX: Auto-merge polls for pending checks instead of stalling

### DIFF
--- a/.github/actions/code-review-action/src/preflightChecks.ts
+++ b/.github/actions/code-review-action/src/preflightChecks.ts
@@ -6,7 +6,7 @@
  * @example
  * GH_TOKEN=xxx REPO=owner/repo PR_NUMBER=123 PR_HEAD_SHA=abc JOB_NAME=review POLL_INTERVAL=10 CHECKS_TIMEOUT=600 PR_AUTHOR=user bun run scripts/preflightChecks.ts
  */
-import { fetchCheckStatuses } from "@code-assistants/actions-core/checkStatus";
+import { fetchCheckStatuses, pollCheckStatuses } from "@code-assistants/actions-core/checkStatus";
 import type { Octokit } from "@octokit/rest";
 
 import { setOutput } from "./actionsOutput.ts";
@@ -69,38 +69,28 @@ function parsePreflightEnv(): PreflightConfig {
  */
 async function pollUntilComplete(config: PreflightConfig): Promise<PreflightOutcome> {
   const { octokit, owner, repoName, headSha, jobName, pollIntervalMs, timeoutMs } = config;
-  let elapsed = 0;
+  const timeoutSec = Math.round(timeoutMs / 1000);
 
-  while (elapsed < timeoutMs) {
-    const result = await fetchCheckStatuses(octokit, owner, repoName, headSha, jobName);
+  const result = await pollCheckStatuses(
+    () => fetchCheckStatuses(octokit, owner, repoName, headSha, jobName),
+    {
+      pollIntervalMs,
+      timeoutMs,
+      onPending: (pendingNames, elapsedMs) =>
+        console.log(
+          `Waiting for checks: ${pendingNames.join(", ")}... (${Math.round(elapsedMs / 1000)}s / ${timeoutSec}s)`,
+        ),
+    },
+  );
 
-    if (result.hasFailed) {
-      return { status: "failed", failedNames: result.failedNames };
-    }
-    if (result.allCompleted) {
-      return { status: "passed" };
-    }
-
-    const elapsedSec = Math.round(elapsed / 1000);
-    const timeoutSec = Math.round(timeoutMs / 1000);
-    console.log(
-      `Waiting for checks: ${result.pendingNames.join(", ")}... (${elapsedSec}s / ${timeoutSec}s)`
-    );
-
-    await Bun.sleep(pollIntervalMs);
-    elapsed += pollIntervalMs;
+  if (result.hasFailed) {
+    return { status: "failed", failedNames: result.failedNames };
   }
-
-  const finalResult = await fetchCheckStatuses(octokit, owner, repoName, headSha, jobName);
-
-  if (finalResult.hasFailed) {
-    return { status: "failed", failedNames: finalResult.failedNames };
-  }
-  if (finalResult.allCompleted) {
+  if (result.allCompleted) {
     return { status: "passed" };
   }
 
-  return { status: "timeout", pendingNames: finalResult.pendingNames };
+  return { status: "timeout", pendingNames: result.pendingNames };
 }
 
 /** Build sarcastic comment for failed checks. */
@@ -146,7 +136,7 @@ async function postSkipComment(
   repo: string,
   prNumber: number,
   reviewer: string,
-  body: string
+  body: string,
 ): Promise<void> {
   const { data: comments } = await octokit.rest.issues.listComments({
     owner,
@@ -175,7 +165,7 @@ async function postSkipComment(
 try {
   const config = parsePreflightEnv();
   console.log(
-    `Preflight: polling checks for ${config.headSha.slice(0, 7)} every ${config.pollIntervalMs / 1000}s (timeout: ${config.timeoutMs / 1000}s)`
+    `Preflight: polling checks for ${config.headSha.slice(0, 7)} every ${config.pollIntervalMs / 1000}s (timeout: ${config.timeoutMs / 1000}s)`,
   );
 
   const outcome = await pollUntilComplete(config);
@@ -192,7 +182,7 @@ try {
       config.repoName,
       config.pullNumber,
       config.reviewer,
-      comment
+      comment,
     );
     await setOutput("skip_review", "true");
   } else {
@@ -205,7 +195,7 @@ try {
       config.repoName,
       config.pullNumber,
       config.reviewer,
-      comment
+      comment,
     );
     await setOutput("skip_review", "true");
   }

--- a/.github/actions/release-automerge/README.md
+++ b/.github/actions/release-automerge/README.md
@@ -11,9 +11,13 @@ A PR is merged only when **all** of the following hold:
 - the releasing member opted in: `release.automerge` resolves to `true`, taking
   the member's own value and falling back to the root default — `member ?? root ??
 false`, read at the PR head SHA,
-- every sibling check is green (a failed check skips; a still-pending check skips),
-  and
-- the PR's `reviewDecision` is `APPROVED`.
+- the PR's `reviewDecision` is `APPROVED` (checked first, so non-approval review
+  events skip without waiting), and
+- every sibling check is green. Because an approval commonly fires this action
+  before CI finishes — and GitHub does not redeliver `check_suite` events for
+  `GITHUB_TOKEN` check suites — pending checks are **polled** until they settle
+  (15s interval, 8-minute cap inside the 10-minute job) rather than skipped; a
+  failed check skips, as does one still pending after the cap.
 
 > **The `APPROVED` decision comes from auto-approval.** [`code-review-action`](../code-review-action/README.md) posts it for trusted release-PR authors. That requires the release PR to be authored by an identity **distinct** from the reviewer (GitHub forbids approving your own PR); see [Author and approver must be distinct identities](../../../docs/release-automerge.md#author-and-approver-must-be-distinct-identities). Without a recorded approval this action never merges.
 

--- a/.github/actions/release-automerge/src/automerge.ts
+++ b/.github/actions/release-automerge/src/automerge.ts
@@ -14,7 +14,7 @@
  * @example
  * GH_TOKEN=xxx REPO=owner/repo HEAD_SHA=abc JOB_NAME=automerge bun run src/automerge.ts
  */
-import { fetchCheckStatuses, type CheckResult } from "@code-assistants/actions-core/checkStatus";
+import { fetchCheckStatuses, pollCheckStatuses } from "@code-assistants/actions-core/checkStatus";
 import { fetchRawContent } from "@code-assistants/actions-core/fetchRawContent";
 import { parseRepo } from "@code-assistants/actions-core/parseRepo";
 import { readRootRelease } from "@code-assistants/actions-core/releaseField";
@@ -272,32 +272,9 @@ async function mergeRelease(config: AutomergeConfig, pullNumber: number): Promis
   }
 }
 
-/**
- * Poll the aggregated check status until every sibling check completes, fails, or
- * the timeout elapses. Mirrors code-review-action's preflight poll loop: an
- * approval commonly fires this action before CI finishes, so wait for the checks
- * to settle rather than skip (no later event reliably re-runs the merge).
- */
-async function waitForChecks(config: AutomergeConfig): Promise<CheckResult> {
-  const { octokit, owner, repo, headSha, jobName } = config;
-  let elapsed = 0;
-  let result = await fetchCheckStatuses(octokit, owner, repo, headSha, jobName);
-
-  while (!result.hasFailed && !result.allCompleted && elapsed < checksTimeoutMs) {
-    console.log(
-      `Waiting for checks: ${result.pendingNames.join(", ")} (${Math.round(elapsed / 1000)}s / ${checksTimeoutMs / 1000}s)`,
-    );
-    await Bun.sleep(checksPollIntervalMs);
-    elapsed += checksPollIntervalMs;
-    result = await fetchCheckStatuses(octokit, owner, repo, headSha, jobName);
-  }
-
-  return result;
-}
-
 /** Evaluate the merge gate for the triggering commit and merge when satisfied. */
 async function run(config: AutomergeConfig): Promise<void> {
-  const { octokit, owner, repo, headSha } = config;
+  const { octokit, owner, repo, headSha, jobName } = config;
 
   const { data: associated } = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
     owner,
@@ -327,7 +304,20 @@ async function run(config: AutomergeConfig): Promise<void> {
     return;
   }
 
-  const checks = await waitForChecks(config);
+  // An approval routinely fires this action before CI finishes, and GitHub does
+  // not redeliver check_suite events for GITHUB_TOKEN suites — so poll until the
+  // checks settle rather than skip on the first pending read.
+  const checks = await pollCheckStatuses(
+    () => fetchCheckStatuses(octokit, owner, repo, headSha, jobName),
+    {
+      pollIntervalMs: checksPollIntervalMs,
+      timeoutMs: checksTimeoutMs,
+      onPending: (pendingNames, elapsedMs) =>
+        console.log(
+          `Waiting for checks: ${pendingNames.join(", ")} (${Math.round(elapsedMs / 1000)}s / ${checksTimeoutMs / 1000}s)`,
+        ),
+    },
+  );
   if (checks.hasFailed) {
     console.log(`Skip: failed checks — ${checks.failedNames.join(", ")}`);
     return;

--- a/.github/actions/release-automerge/src/automerge.ts
+++ b/.github/actions/release-automerge/src/automerge.ts
@@ -14,7 +14,7 @@
  * @example
  * GH_TOKEN=xxx REPO=owner/repo HEAD_SHA=abc JOB_NAME=automerge bun run src/automerge.ts
  */
-import { fetchCheckStatuses } from "@code-assistants/actions-core/checkStatus";
+import { fetchCheckStatuses, type CheckResult } from "@code-assistants/actions-core/checkStatus";
 import { fetchRawContent } from "@code-assistants/actions-core/fetchRawContent";
 import { parseRepo } from "@code-assistants/actions-core/parseRepo";
 import { readRootRelease } from "@code-assistants/actions-core/releaseField";
@@ -45,6 +45,13 @@ const releaseNotesFile = /(?:^|\/)\.release_notes\/[^/]+\.md$/;
 // GitHub merge-API responses that mean "nothing to do" rather than a real error:
 // 405 not mergeable / already merged, 409 head SHA moved (sha mismatch), 422 unprocessable.
 const idempotentMergeStatuses = new Set([405, 409, 422]);
+// An approval usually triggers this action while CI is still running, and GitHub
+// does not redeliver `check_suite` events for `GITHUB_TOKEN` check suites — so no
+// later event would re-run the merge once CI turns green. Poll until checks settle
+// instead of skipping on the first pending read. Bounded well inside the workflow's
+// 10-minute job timeout. Repo-agnostic: no consumer-specific workflow names.
+const checksPollIntervalMs = 15_000;
+const checksTimeoutMs = 480_000;
 
 /** Configuration parsed from environment. */
 interface AutomergeConfig {
@@ -265,9 +272,32 @@ async function mergeRelease(config: AutomergeConfig, pullNumber: number): Promis
   }
 }
 
+/**
+ * Poll the aggregated check status until every sibling check completes, fails, or
+ * the timeout elapses. Mirrors code-review-action's preflight poll loop: an
+ * approval commonly fires this action before CI finishes, so wait for the checks
+ * to settle rather than skip (no later event reliably re-runs the merge).
+ */
+async function waitForChecks(config: AutomergeConfig): Promise<CheckResult> {
+  const { octokit, owner, repo, headSha, jobName } = config;
+  let elapsed = 0;
+  let result = await fetchCheckStatuses(octokit, owner, repo, headSha, jobName);
+
+  while (!result.hasFailed && !result.allCompleted && elapsed < checksTimeoutMs) {
+    console.log(
+      `Waiting for checks: ${result.pendingNames.join(", ")} (${Math.round(elapsed / 1000)}s / ${checksTimeoutMs / 1000}s)`,
+    );
+    await Bun.sleep(checksPollIntervalMs);
+    elapsed += checksPollIntervalMs;
+    result = await fetchCheckStatuses(octokit, owner, repo, headSha, jobName);
+  }
+
+  return result;
+}
+
 /** Evaluate the merge gate for the triggering commit and merge when satisfied. */
 async function run(config: AutomergeConfig): Promise<void> {
-  const { octokit, owner, repo, headSha, jobName } = config;
+  const { octokit, owner, repo, headSha } = config;
 
   const { data: associated } = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
     owner,
@@ -288,19 +318,24 @@ async function run(config: AutomergeConfig): Promise<void> {
     return;
   }
 
-  const checks = await fetchCheckStatuses(octokit, owner, repo, headSha, jobName);
+  // Gate on approval before waiting on checks: pull_request_review fires for every
+  // review (comment, changes-requested, approval), so non-approval events skip
+  // immediately instead of holding a runner polling their checks.
+  const decision = await fetchReviewDecision(octokit, owner, repo, pr.number);
+  if (!isApprovedDecision(decision)) {
+    console.log(`Skip: review decision is ${decision ?? "none"}, not APPROVED`);
+    return;
+  }
+
+  const checks = await waitForChecks(config);
   if (checks.hasFailed) {
     console.log(`Skip: failed checks — ${checks.failedNames.join(", ")}`);
     return;
   }
   if (!checks.allCompleted) {
-    console.log(`Skip: pending checks — ${checks.pendingNames.join(", ")}`);
-    return;
-  }
-
-  const decision = await fetchReviewDecision(octokit, owner, repo, pr.number);
-  if (!isApprovedDecision(decision)) {
-    console.log(`Skip: review decision is ${decision ?? "none"}, not APPROVED`);
+    console.log(
+      `Skip: checks still pending after ${checksTimeoutMs / 1000}s — ${checks.pendingNames.join(", ")}`,
+    );
     return;
   }
 

--- a/docs/release-automerge.md
+++ b/docs/release-automerge.md
@@ -35,8 +35,8 @@ the merge with no manual step.
    │ 1. resolve open PR for the head SHA               │
    │ 2. head ref ~ ^release-  AND  state == open ?     │
    │ 3. release.automerge === true (member|root) ?     │
-   │ 4. all checks green? (shared aggregation)         │
-   │ 5. reviewDecision == APPROVED ?                   │
+   │ 4. reviewDecision == APPROVED ?                   │
+   │ 5. all checks green? (poll until settled)         │
    │ 6. merge (sha-pinned) with an allowed method      │
    └───────────────────────────┬───────────────────────┘
                   ▼ all true                ▼ any false / any error
@@ -46,22 +46,30 @@ the merge with no manual step.
             release-publish.yml runs on merge
 ```
 
-- **Triggers:** `check_suite: [completed]` and `pull_request_review: [submitted]`.
-  The first covers checks finishing after approval; the second covers a late
-  approval landing after checks are already green. Both events expose the head
-  branch reliably (`check_suite.head_branch` / `pull_request.head.ref`), so the job
-  carries an `if:` guard that runs it **only** when that branch matches `^release-`
-  — on every other PR the job is skipped and posts no check. The action re-checks
-  `^release-` internally as defense in depth. (The `status` event is intentionally
-  not a trigger: its payload has no reliable release-branch signal to filter on, and
-  approval already re-evaluates commit statuses, so dropping it avoids running on
-  non-release PRs without losing meaningful coverage.)
-- **Merge conditions (all must hold):** the head ref matches `^release-`, the PR
-  is open, the repo opted in via `release.automerge === true`, every sibling check
-  is green (failed → skip; still pending → skip), and `reviewDecision == APPROVED`.
-  The check aggregation reuses the same logic as the AI-review preflight (see
-  [the shared `checkStatus` helper][checkstatus]), deduplicated by name and
-  excluding the action's own job.
+- **Triggers:** `pull_request_review: [submitted]` and `check_suite: [completed]`.
+  `pull_request_review` is the primary trigger — the approval that unblocks a
+  release PR is posted by `code-review-action` as a real PAT, so it fires reliably.
+  `check_suite` is only a best-effort backstop: GitHub does **not** redeliver
+  `check_suite` events for check suites produced by the `GITHUB_TOKEN` CI workflows,
+  so on a release branch it cannot be relied on to fire when the last check turns
+  green. Because an approval routinely lands while CI is still running, the action
+  **polls** for the pending checks to settle rather than skipping (see Merge
+  conditions) — that, not `check_suite`, is what covers "checks finishing after
+  approval," and it needs no consumer-specific workflow names. Both events expose
+  the head branch reliably (`pull_request.head.ref` / `check_suite.head_branch`), so
+  the job carries an `if:` guard that runs it **only** when that branch matches
+  `^release-`; the action re-checks `^release-` internally as defense in depth. (The
+  `status` event is intentionally not a trigger: its payload has no reliable
+  release-branch signal to filter on.)
+- **Merge conditions (all must hold):** the head ref matches `^release-`, the PR is
+  open, the repo opted in via `release.automerge === true`,
+  `reviewDecision == APPROVED`, and every sibling check is green. Approval is checked
+  **first** so non-approval review events skip immediately; only then does the action
+  wait on checks. Pending checks are **polled** (15s interval) until they complete or
+  an 8-minute timeout elapses — within the job's 10-minute limit — then failed → skip,
+  still-pending → skip. The check aggregation reuses the same logic as the AI-review
+  preflight (see [the shared `checkStatus` helper][checkstatus]), deduplicated by name
+  and excluding the action's own job.
 - **Opt-in gate (default off):** the action merges only when `release.automerge`
   resolves to `true` (see the [`release` field spec](./release-field.md)). Because
   a monorepo opens one release PR **per member** (`release-<member>-<version>`),

--- a/packages/actions-core/src/checkStatus.test.ts
+++ b/packages/actions-core/src/checkStatus.test.ts
@@ -10,7 +10,13 @@ import type { Octokit } from "@octokit/rest";
 
 import { describe, expect, test } from "bun:test";
 
-import { deduplicateCheckRuns, fetchCheckStatuses, normalizeCheckName } from "./checkStatus.ts";
+import {
+  type CheckResult,
+  deduplicateCheckRuns,
+  fetchCheckStatuses,
+  normalizeCheckName,
+  pollCheckStatuses,
+} from "./checkStatus.ts";
 
 interface FakeRun {
   id: number;
@@ -35,7 +41,7 @@ interface CapturedCalls {
  */
 function fakeOctokit(
   runs: FakeRun[],
-  statuses: FakeStatus[]
+  statuses: FakeStatus[],
 ): { octokit: Octokit; calls: CapturedCalls } {
   const calls: CapturedCalls = { paginate: [], combined: [] };
   const octokit = {
@@ -82,7 +88,7 @@ describe("fetchCheckStatuses", () => {
   test("all green completed runs pass", async () => {
     const { octokit } = fakeOctokit(
       [{ id: 1, name: "build", status: "completed", conclusion: "success" }],
-      []
+      [],
     );
     const result = await fetchCheckStatuses(octokit, "o", "r", "sha", "automerge");
     expect(result).toEqual({
@@ -103,7 +109,7 @@ describe("fetchCheckStatuses", () => {
   test("excludes its own check by normalized name", async () => {
     const { octokit } = fakeOctokit(
       [{ id: 1, name: "Release Automerge", status: "in_progress", conclusion: null }],
-      []
+      [],
     );
     const result = await fetchCheckStatuses(octokit, "o", "r", "sha", "release-automerge");
     expect(result.allCompleted).toBe(true);
@@ -113,7 +119,7 @@ describe("fetchCheckStatuses", () => {
   test("incomplete sibling run counts as pending", async () => {
     const { octokit } = fakeOctokit(
       [{ id: 1, name: "build", status: "in_progress", conclusion: null }],
-      []
+      [],
     );
     const result = await fetchCheckStatuses(octokit, "o", "r", "sha", "automerge");
     expect(result.allCompleted).toBe(false);
@@ -126,7 +132,7 @@ describe("fetchCheckStatuses", () => {
         { id: 1, name: "build", status: "completed", conclusion: "failure" },
         { id: 2, name: "build", status: "completed", conclusion: "success" },
       ],
-      []
+      [],
     );
     const result = await fetchCheckStatuses(octokit, "o", "r", "sha", "automerge");
     expect(result.hasFailed).toBe(false);
@@ -136,7 +142,7 @@ describe("fetchCheckStatuses", () => {
   test("cancelled-only run carries no signal and does not block the gate", async () => {
     const { octokit } = fakeOctokit(
       [{ id: 1, name: "flaky", status: "completed", conclusion: "cancelled" }],
-      []
+      [],
     );
     const result = await fetchCheckStatuses(octokit, "o", "r", "sha", "automerge");
     expect(result.allCompleted).toBe(true);
@@ -147,7 +153,7 @@ describe("fetchCheckStatuses", () => {
   test("failed conclusion is reported", async () => {
     const { octokit } = fakeOctokit(
       [{ id: 1, name: "lint", status: "completed", conclusion: "timed_out" }],
-      []
+      [],
     );
     const result = await fetchCheckStatuses(octokit, "o", "r", "sha", "automerge");
     expect(result.hasFailed).toBe(true);
@@ -160,12 +166,107 @@ describe("fetchCheckStatuses", () => {
       [
         { context: "ci/pending", state: "pending" },
         { context: "ci/broken", state: "error" },
-      ]
+      ],
     );
     const result = await fetchCheckStatuses(octokit, "o", "r", "sha", "automerge");
     expect(result.allCompleted).toBe(false);
     expect(result.pendingNames).toEqual(["ci/pending"]);
     expect(result.hasFailed).toBe(true);
     expect(result.failedNames).toEqual(["ci/broken"]);
+  });
+});
+
+describe("pollCheckStatuses", () => {
+  const pending: CheckResult = {
+    allCompleted: false,
+    hasFailed: false,
+    failedNames: [],
+    pendingNames: ["ci"],
+  };
+  const completed: CheckResult = {
+    allCompleted: true,
+    hasFailed: false,
+    failedNames: [],
+    pendingNames: [],
+  };
+  const failed: CheckResult = {
+    allCompleted: false,
+    hasFailed: true,
+    failedNames: ["ci"],
+    pendingNames: [],
+  };
+  const noSleep = (): Promise<void> => Promise.resolve();
+
+  test("returns immediately when all checks are already complete (no sleep)", async () => {
+    let fetched = 0;
+    let slept = 0;
+    const result = await pollCheckStatuses(
+      () => {
+        fetched += 1;
+        return Promise.resolve(completed);
+      },
+      {
+        pollIntervalMs: 1000,
+        timeoutMs: 10_000,
+        sleep: () => {
+          slept += 1;
+          return Promise.resolve();
+        },
+      },
+    );
+    expect(result.allCompleted).toBe(true);
+    expect(fetched).toBe(1);
+    expect(slept).toBe(0);
+  });
+
+  test("returns immediately when a check has already failed", async () => {
+    let fetched = 0;
+    const result = await pollCheckStatuses(
+      () => {
+        fetched += 1;
+        return Promise.resolve(failed);
+      },
+      { pollIntervalMs: 1000, timeoutMs: 10_000, sleep: noSleep },
+    );
+    expect(result.hasFailed).toBe(true);
+    expect(fetched).toBe(1);
+  });
+
+  test("polls until checks settle, sleeping between fetches", async () => {
+    const sequence = [pending, pending, completed];
+    let i = 0;
+    let slept = 0;
+    const result = await pollCheckStatuses(() => Promise.resolve(sequence[i++] ?? completed), {
+      pollIntervalMs: 1000,
+      timeoutMs: 10_000,
+      sleep: () => {
+        slept += 1;
+        return Promise.resolve();
+      },
+    });
+    expect(result.allCompleted).toBe(true);
+    expect(i).toBe(3); // fetched three times
+    expect(slept).toBe(2); // slept between the three fetches
+  });
+
+  test("returns the pending result once the wall-clock timeout elapses", async () => {
+    let fetched = 0;
+    let tick = 0;
+    const result = await pollCheckStatuses(
+      () => {
+        fetched += 1;
+        return Promise.resolve(pending);
+      },
+      {
+        pollIntervalMs: 1000,
+        timeoutMs: 3000,
+        sleep: noSleep,
+        now: () => tick++ * 1000, // 0, 1000, 2000, ... advances each call
+      },
+    );
+    expect(result.allCompleted).toBe(false);
+    expect(result.pendingNames).toEqual(["ci"]);
+    // Bounded: start + initial-elapsed + two ticks under 3000ms, then exits.
+    expect(fetched).toBeLessThanOrEqual(4);
   });
 });

--- a/packages/actions-core/src/checkStatus.ts
+++ b/packages/actions-core/src/checkStatus.ts
@@ -59,7 +59,7 @@ export async function fetchCheckStatuses(
   owner: string,
   repo: string,
   ref: string,
-  jobName: string
+  jobName: string,
 ): Promise<CheckResult> {
   const normalizedJobName = normalizeCheckName(jobName);
 
@@ -69,7 +69,7 @@ export async function fetchCheckStatuses(
   ]);
 
   const allSiblingRuns = checkRuns.filter(
-    (run) => normalizeCheckName(run.name) !== normalizedJobName
+    (run) => normalizeCheckName(run.name) !== normalizedJobName,
   );
   // A cancelled run carries no pass/fail/pending signal (e.g. a path-filter-skipped
   // job, or a run superseded by a newer push). Excluding cancelled runs entirely —
@@ -78,7 +78,7 @@ export async function fetchCheckStatuses(
   // poll loop to recover, and GitHub's merge API still enforces genuinely required
   // checks regardless.
   const siblingRuns = deduplicateCheckRuns(
-    allSiblingRuns.filter((run) => run.conclusion !== "cancelled")
+    allSiblingRuns.filter((run) => run.conclusion !== "cancelled"),
   );
 
   const pendingRuns = siblingRuns
@@ -104,4 +104,59 @@ export async function fetchCheckStatuses(
     failedNames: allFailed,
     pendingNames: allPending,
   };
+}
+
+/** Options for {@link pollCheckStatuses}. */
+export interface PollCheckOptions {
+  /** Delay between polls, in milliseconds. */
+  pollIntervalMs: number;
+  /** Wall-clock budget before giving up, in milliseconds. */
+  timeoutMs: number;
+  /** Sleep implementation; injected in tests. Defaults to a `setTimeout` promise. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Monotonic clock in milliseconds; injected in tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Invoked once per still-pending tick before sleeping (e.g. to log progress). */
+  onPending?: (pendingNames: string[], elapsedMs: number) => void;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Poll a {@link CheckResult} source until checks fail, all complete, or the
+ * timeout elapses. Elapsed time is measured on a wall clock (`now()`), so the
+ * latency of each status fetch counts toward the cap — the loop cannot overrun
+ * the budget by the aggregate fetch time. Returns the final result; the caller
+ * decides how to treat a still-pending (timed-out) result.
+ *
+ * `fetchStatus`, `sleep`, and `now` are injectable so the loop is testable
+ * without real timers or a GitHub client.
+ *
+ * @example
+ *   const result = await pollCheckStatuses(
+ *     () => fetchCheckStatuses(octokit, owner, repo, sha, jobName),
+ *     { pollIntervalMs: 15_000, timeoutMs: 480_000 },
+ *   );
+ */
+export async function pollCheckStatuses(
+  fetchStatus: () => Promise<CheckResult>,
+  options: PollCheckOptions,
+): Promise<CheckResult> {
+  const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? Date.now;
+  const start = now();
+
+  let result = await fetchStatus();
+  let elapsed = now() - start;
+  while (!result.hasFailed && !result.allCompleted && elapsed < options.timeoutMs) {
+    options.onPending?.(result.pendingNames, elapsed);
+    await sleep(options.pollIntervalMs);
+    result = await fetchStatus();
+    elapsed = now() - start;
+  }
+
+  return result;
 }


### PR DESCRIPTION
Release PRs reached approved + all-green but never merged. The auto-merge action ran once (on the approval event) while CI was still pending, logged `Skip: pending checks`, and nothing re-ran it once the checks went green — GitHub does not redeliver `check_suite` events for check suites produced by the `GITHUB_TOKEN` CI workflows, so there is no later trigger on a release branch.

Rather than depend on specific trigger sources (a `workflow_run` list would have to enumerate each consumer repo's check-producing workflows — this action is distributed downstream), the action now **waits** for checks the way `code-review-action`'s preflight does: it polls.

- Added `pollCheckStatuses` to `@code-assistants/actions-core/checkStatus` — a poll-until-settled loop that measures elapsed on a **wall clock** (per-fetch latency counts toward the cap, so it can't overrun the 10-minute job) with an injectable fetch thunk, `sleep`, and `now` for deterministic tests.
- `release-automerge` polls via that helper (15s interval, 8-min cap) instead of skipping on the first pending read, and evaluates `reviewDecision` **before** waiting so non-approval review events skip immediately.
- `code-review-action`'s preflight now shares the same helper, dropping its duplicate poll loop.
- Added unit tests for `pollCheckStatuses` (immediate-complete, failed short-circuit, poll-until-settled, wall-clock timeout).
- No workflow-trigger changes — repo-agnostic, works in every downstream repo regardless of their check names. Docs + READMEs updated.