### PR TITLE
Stop the review bot's own comments from spawning no-op runs

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -29,7 +29,13 @@ concurrency:
 
 jobs:
   ai-review:
-    if: (github.event_name != 'issue_comment' || github.event.issue.pull_request) && vars.BOT_USERNAME != ''
+    # Skip events sent by the bot itself — its own review/inline comments would
+    # otherwise spawn a no-op react-mode run each (the in-action guard skips them
+    # only after the runner spins up). Filtering here keeps the run from starting.
+    if: >-
+      (github.event_name != 'issue_comment' || github.event.issue.pull_request)
+      && vars.BOT_USERNAME != ''
+      && github.event.sender.login != vars.BOT_USERNAME
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The bot's review and inline comments each fire a `pull_request_review_comment` event, spawning a react-mode workflow run that spins up a runner only to skip in the in-action `Detect context` guard (~6 no-op 7-18s runs per review, observed across #135/#142 work). This filters those events at the job level so the run never starts. Part of the #142 optimization work (Phase 1b).

- Add `github.event.sender.login != vars.BOT_USERNAME` to the `ai-review` job `if:` condition
- `pull_request` review runs are unaffected (sender is the pusher, not the bot)
- The existing in-action sender/author guards stay as defense-in-depth

---

**Issues:**

Closes #145
Part of #142