### PR TITLE
Evaluate parallel fan-out for code review

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -47,3 +47,6 @@ jobs:
           bot_token: ${{ secrets.BOT_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_CODE_REVIEW }}
           release_pr_authors: ${{ vars.RELEASE_PR_AUTHORS }}
+          # Experiment (#155): run the 11 review sub-agents as parallel SDK calls
+          # from the orchestrator instead of fanning out inside the root model.
+          parallel_fanout: "true"


### PR DESCRIPTION
Enables the orchestrator-side `parallel_fanout` so the 11 `pr:review` sub-agents run as parallel SDK queries instead of inside the root model session. This is a measured experiment (#155) — this PR's own review runs with fan-out ON, and the `Run summary` will be compared against the #142 baseline (107 round-trips / ~12 min / $2.48) to decide keep-vs-revert. Part of the #142 optimization work.

- Set `parallel_fanout: "true"` in `code-review.yml`
- No code change — the fan-out implementation (`reviewFanout.ts`) already exists; this only turns it on
- Latency is expected to drop; token cost may rise (11 cold parallel queries lose the shared-context cache) — that tradeoff is what we're measuring
- Revert the one-line flag if cost balloons or the runner contends badly

---

**Issues:**

Closes #155
Part of #142