### PR TITLE
Assign the issue to you automatically when starting work on it

### DIFF
--- a/claude-plugins/autopilot/README.md
+++ b/claude-plugins/autopilot/README.md
@@ -108,7 +108,7 @@ The skills that need whole-codebase context — `/autopilot:plan`, `/autopilot:r
 
 ### `/autopilot:branch-create`
 
-Create a git branch following repository naming conventions with GitHub issue integration.
+Create a git branch following repository naming conventions with GitHub issue integration. For an issue branch it also self-assigns the issue to you when possible (best-effort; never blocks branch creation).
 
 ```bash
 /autopilot:branch-create 123                                     # Auto-generate slug from GitHub issue title
@@ -284,15 +284,15 @@ Specialized review sub-agents launched in parallel by the `pr:review` skill. Eac
 
 Context-isolating workers invoked by other skills to keep the parent conversation small. Each returns a structured summary only.
 
-| Agent                    | Model   | Used by                        | Purpose                                                                               |
-| ------------------------ | ------- | ------------------------------ | ------------------------------------------------------------------------------------- |
-| `analyze-pr-commits`     | sonnet  | `pr:create`, `pr:update`       | Summarize branch commits, diff, and linked issue for PR context                       |
-| `analyze-staged-changes` | haiku   | `commits:create`               | Categorize staged files and recommend a commit strategy                               |
-| `expert-review`          | inherit | `plan`, `plan-*`               | Score an implementation plan as a domain expert                                       |
-| `fetch-pr-reviews`       | sonnet  | `pr:answer`, `pr:resolve`      | Fetch, filter, and categorize PR review comments by severity                          |
-| `resolve-issue-context`  | sonnet  | `plan`, `run`, `branch:create` | Fetch GitHub issue context; optionally auto-assign current user (idempotent) via `gh` |
-| `scan-and-analyze-todos` | sonnet  | `todo-cleanup`                 | Scan codebase for TODOs and check linked GitHub issue statuses                        |
-| `search-codebase-todos`  | haiku   | `plan`                         | Search the codebase for TODOs and references to a specific issue                      |
+| Agent                    | Model   | Used by                   | Purpose                                                                               |
+| ------------------------ | ------- | ------------------------- | ------------------------------------------------------------------------------------- |
+| `analyze-pr-commits`     | sonnet  | `pr:create`, `pr:update`  | Summarize branch commits, diff, and linked issue for PR context                       |
+| `analyze-staged-changes` | haiku   | `commits:create`          | Categorize staged files and recommend a commit strategy                               |
+| `expert-review`          | inherit | `plan`, `plan-*`          | Score an implementation plan as a domain expert                                       |
+| `fetch-pr-reviews`       | sonnet  | `pr:answer`, `pr:resolve` | Fetch, filter, and categorize PR review comments by severity                          |
+| `resolve-issue-context`  | sonnet  | `plan`, `run`             | Fetch GitHub issue context; optionally auto-assign current user (idempotent) via `gh` |
+| `scan-and-analyze-todos` | sonnet  | `todo-cleanup`            | Scan codebase for TODOs and check linked GitHub issue statuses                        |
+| `search-codebase-todos`  | haiku   | `plan`                    | Search the codebase for TODOs and references to a specific issue                      |
 
 ## Internal Skills (not in slash menu)
 

--- a/claude-plugins/autopilot/agents/resolve-issue-context.md
+++ b/claude-plugins/autopilot/agents/resolve-issue-context.md
@@ -30,6 +30,8 @@ ISSUE_JSON=$(gh issue view "$NUMBER" -R "$REPO" --json title,body,comments,label
 
 ## Phase 2: Auto-Assign Current User (opt-in)
 
+<!-- Canonical self-assign logic. Mirrored in skills/branch:create/SKILL.md Phase 2. Keep in sync. -->
+
 Run this phase ONLY when the caller's prompt contains `Auto-assign current user: true`. Otherwise skip directly to Phase 3 and omit the `**Assignee:**` line from the output.
 
 The agent emits exactly one of the status strings below into the Phase 3 `**Assignee:**` line:
@@ -56,7 +58,7 @@ Resolve the status with these steps:
 3. Check whether `LOGIN` is already in the assignees array from Phase 1, with an explicit `jq` variable binding:
 
    ```bash
-   ALREADY=$(printf '%s' "$ISSUE_JSON" | jq -r --arg login "$LOGIN" 'any(.assignees[]; .login == $login)')
+   ALREADY=$(printf '%s' "$ISSUE_JSON" | jq -r --arg login "$LOGIN" 'any(.assignees[]?; .login == $login)')
    ```
 
    If `ALREADY == "true"`, set status to `@<LOGIN> (already assigned)` and skip to Phase 3.
@@ -71,7 +73,7 @@ Resolve the status with these steps:
 5. Post-verify via a fresh read, because `gh issue edit --add-assignee` returns exit 0 even when GitHub silently drops the addition (caller lacks `triage`/`write` permission, or the issue is already at the 10-assignee limit). `gh --jq` only accepts a single expression and cannot pass `--arg` through to `jq`, so pipe the JSON to `jq` directly:
 
    ```bash
-   VERIFIED=$(gh issue view "$NUMBER" -R "$REPO" --json assignees 2>/dev/null | jq -r --arg login "$LOGIN" 'any(.assignees[]; .login == $login)' 2>/dev/null)
+   VERIFIED=$(gh issue view "$NUMBER" -R "$REPO" --json assignees 2>/dev/null | jq -r --arg login "$LOGIN" 'any(.assignees[]?; .login == $login)' 2>/dev/null)
    ```
 
    - `EDIT_EXIT == 0` AND `VERIFIED == "true"` → `@<LOGIN> (just assigned)`

--- a/claude-plugins/autopilot/skills/branch:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/branch:create/SKILL.md
@@ -69,12 +69,16 @@ Invoke `Skill(autopilot:preflight-check)` with `mode: branch` from this conversa
 
 **Skip this phase entirely for special prefix flag branches (--hotfix, --trivial, --maintenance, --proposal).**
 
-1. **Determine the repository** from `git remote get-url origin` (or use the current `gh repo set-default`).
-
-2. **Fetch the issue:**
+1. **Determine the repository** and bind it to `REPO` so every `gh` call in this phase targets the same repo (important in worktrees and multi-remote checkouts):
 
    ```bash
-   gh issue view <ISSUE-NUMBER> --json title,body,state
+   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   ```
+
+2. **Fetch the issue** (include `assignees` so the self-assign step needs no extra call):
+
+   ```bash
+   gh issue view <ISSUE-NUMBER> -R "$REPO" --json title,body,state,assignees
    ```
 
 3. **Extract:**
@@ -84,6 +88,58 @@ Invoke `Skill(autopilot:preflight-check)` with `mode: branch` from this conversa
 
 4. **If issue not found:**
    - Error: `Issue #<ISSUE-NUMBER> not found in <repo>`
+
+5. **Self-assign the current user** — idempotent and best-effort; it must never block branch creation.
+
+   <!-- Mirrors resolve-issue-context.md Phase 2 (canonical). Keep in sync. -->
+
+   Assigning the issue the moment work starts keeps "who is working on what" accurate. This runs on every issue branch (special-prefix branches skip Phase 2, so they never assign). On ANY failure, emit the status line and continue to Phase 3 — the branch is the deliverable; assignment is a side effect.
+
+   Emit exactly one status (same vocabulary as the canonical agent):
+   - `@<login> (just assigned)`
+   - `@<login> (already assigned)`
+   - `unassigned — gh not authenticated`
+   - `unassigned — issue closed`
+   - `unassigned — permission denied or assignee limit reached`
+   - `unassigned — gh edit error: <first line of stderr>`
+
+   Resolve it with these steps:
+   1. Resolve the authenticated login (cached 5 minutes):
+
+      ```bash
+      LOGIN=$(gh api user --cache 5m --jq .login 2>/dev/null)
+      ```
+
+      If `LOGIN` is empty → `unassigned — gh not authenticated`; continue to Phase 3.
+
+   2. If the issue `state` from step 2 is `CLOSED` → `unassigned — issue closed`; continue to Phase 3.
+
+   3. Check whether `LOGIN` is already assigned. GitHub logins are `[A-Za-z0-9-]`, so the login is safe to interpolate into a single `gh --jq` expression (gh's `--jq` cannot take `--arg`); `.assignees[]?` tolerates a null or absent array:
+
+      ```bash
+      ALREADY=$(gh issue view <ISSUE-NUMBER> -R "$REPO" --json assignees --jq "any(.assignees[]?; .login==\"$LOGIN\")" 2>/dev/null)
+      ```
+
+      If `ALREADY == "true"` → `@<LOGIN> (already assigned)`; continue to Phase 3.
+
+   4. Otherwise attempt the assignment, capturing stderr and exit code (keep this order; read `$?` on the very next line):
+
+      ```bash
+      STDERR=$(gh issue edit <ISSUE-NUMBER> -R "$REPO" --add-assignee "$LOGIN" 2>&1 >/dev/null)
+      EDIT_EXIT=$?
+      ```
+
+   5. Post-verify with a fresh read, because `gh issue edit --add-assignee` returns exit 0 even when GitHub silently drops the addition (caller lacks `triage`/`write` permission, or the issue is at the 10-assignee limit):
+
+      ```bash
+      VERIFIED=$(gh issue view <ISSUE-NUMBER> -R "$REPO" --json assignees --jq "any(.assignees[]?; .login==\"$LOGIN\")" 2>/dev/null)
+      ```
+
+      - `EDIT_EXIT == 0` AND `VERIFIED == "true"` → `@<LOGIN> (just assigned)`
+      - `EDIT_EXIT == 0` AND `VERIFIED != "true"` → `unassigned — permission denied or assignee limit reached`
+      - `EDIT_EXIT != 0` → `unassigned — gh edit error: <first line of $STDERR>`
+
+   In all cases, continue to Phase 3.
 
 ## Phase 3: Generate Branch Slug
 


### PR DESCRIPTION
Starting work on a GitHub issue now assigns it to you automatically, so teammates can always tell who has picked it up. Previously assignment lived only in an optional planning step, so an issue started via `/autopilot:run` — or any path that skipped that step — was left unassigned.

- `branch-create` now self-assigns the issue when an issue branch is created — the one step that always runs when work starts
- Assignment is idempotent and best-effort: re-running is a no-op, and it never blocks branch creation
- The opt-in assignment during planning is unchanged; both paths now share one canonical routine

---

**Release notes:**

- Starting work on an issue now assigns it to you automatically when the branch is created
- Assignment is best-effort and never blocks branch creation

---

**Issues:**

Closes #151
