### PR TITLE
Make plan skills read and update the repository's own docs

### DIFF
--- a/claude-plugins/autopilot/skills/plan-bun/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-bun/SKILL.md
@@ -51,8 +51,9 @@ Use these IDs for all TaskUpdate calls in the phases below.
    - **Ref** — For official documentation: `mcp__Ref__ref_search_documentation` with the technology name and topic, then `mcp__Ref__ref_read_url` to read specific pages from results.
    - **Exa** — For real-world patterns and examples: `mcp__exa__web_search_exa` for API patterns, migration guides, changelogs. `mcp__exa__get_code_context_exa` for code examples.
    - **Perplexity** — For general and architectural questions: `mcp__perplexity__search` for factual lookups. `mcp__perplexity__reason` for trade-off analysis.
-4. **CLAUDE.md Compliance** - Map each planned change to project rules
-5. **Repomix** - Search codebase via `mcp__repomix__grep_repomix_output` (outputId from Phase 0). Use `mcp__repomix__read_repomix_output` with `startLine`/`endLine` for specific sections only.
+4. **Repository Documentation** (MANDATORY) - Read the repo's own docs as the project's source of truth: read the root `README.md` and inspect/read all files under `docs/` and its subfolders. Feed project-specific conventions into the plan.
+5. **CLAUDE.md Compliance** - Map each planned change to project rules
+6. **Repomix** - Search codebase via `mcp__repomix__grep_repomix_output` (outputId from Phase 0). Use `mcp__repomix__read_repomix_output` with `startLine`/`endLine` for specific sections only.
 
 After completing all context gathering, call TaskUpdate to set task 2 ("Gather context") to `status: "completed"`.
 
@@ -162,7 +163,10 @@ Every step MUST include a `verify:` line — an observable check (test name, com
 
 ## Post-Implementation
 
-After all implementation steps and verification are complete, present next actions using AskUserQuestion.
+After all implementation steps and verification are complete:
+
+1. **Update documentation (MANDATORY)** — update any `README.md` and `docs/*` affected by these changes so the documented source of truth stays current. When an update needs a diagram, generate it via `Skill(autopilot:ascii-schemas)` and embed the output verbatim — do not hand-draw.
+2. Present next actions using AskUserQuestion.
 
 **If the implementation included user-facing changes** (feat: or fix: commits created during this session), use `--release-notes` in the "Create PR" option. Otherwise, use the plain option.
 

--- a/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
@@ -51,8 +51,9 @@ Use these IDs for all TaskUpdate calls in the phases below.
    - **Ref** — For official documentation: `mcp__Ref__ref_search_documentation` with the technology name and topic, then `mcp__Ref__ref_read_url` to read specific pages from results.
    - **Exa** — For real-world patterns and examples: `mcp__exa__web_search_exa` for API patterns, migration guides, changelogs. `mcp__exa__get_code_context_exa` for code examples.
    - **Perplexity** — For general and architectural questions: `mcp__perplexity__search` for factual lookups. `mcp__perplexity__reason` for trade-off analysis.
-4. **CLAUDE.md Compliance** - Map each planned change to project rules
-5. **Repomix** - Search codebase via `mcp__repomix__grep_repomix_output` (outputId from Phase 0). Use `mcp__repomix__read_repomix_output` with `startLine`/`endLine` for specific sections only.
+4. **Repository Documentation** (MANDATORY) - Read the repo's own docs as the project's source of truth: read the root `README.md` and inspect/read all files under `docs/` and its subfolders. Feed project-specific conventions into the plan.
+5. **CLAUDE.md Compliance** - Map each planned change to project rules
+6. **Repomix** - Search codebase via `mcp__repomix__grep_repomix_output` (outputId from Phase 0). Use `mcp__repomix__read_repomix_output` with `startLine`/`endLine` for specific sections only.
 
 After completing all context gathering, call TaskUpdate to set task 2 ("Gather context") to `status: "completed"`.
 
@@ -167,7 +168,10 @@ Every step MUST include a `verify:` line — an observable check (test name, com
 
 ## Post-Implementation
 
-After all implementation steps and verification are complete, present next actions using AskUserQuestion.
+After all implementation steps and verification are complete:
+
+1. **Update documentation (MANDATORY)** — update any `README.md` and `docs/*` affected by these changes so the documented source of truth stays current. When an update needs a diagram, generate it via `Skill(autopilot:ascii-schemas)` and embed the output verbatim — do not hand-draw.
+2. Present next actions using AskUserQuestion.
 
 **If the implementation included user-facing changes** (feat: or fix: commits created during this session), use `--release-notes` in the "Create PR" option. Otherwise, use the plain option.
 

--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -234,6 +234,17 @@ Run multiple `resolve-library-id` calls in parallel, then multiple `query-docs` 
 
 Use all available documentation sources. If a source is unavailable or returns no results, continue with remaining sources. Each tool provides different information (structured docs, official references, real-world patterns, reasoning).
 
+### Repository Documentation (MANDATORY)
+
+Before planning, read the repository's own documentation as the project's source of truth (it overrides defaults per CLAUDE.md):
+
+- Read the root `README.md`.
+- Inspect every file under `docs/` and its subfolders, and read those relevant to the task.
+
+Feed the project-specific conventions found there into analysis and the plan.
+
+The generated plan MUST update this documentation after implementation: its `## Post-Implementation` block must require updating any `README.md` and `docs/*` affected by the change so the documented source of truth stays current. When such an update needs a diagram, the plan must generate it via `Skill(autopilot:ascii-schemas)` and embed the output verbatim — never hand-draw.
+
 ### Plan File Header (MANDATORY)
 
 Every plan file written by any stack skill MUST begin with a single `# <Title>` line on line 1, followed by a blank line. This rule is stack-agnostic and supersedes any stack-specific Phase 5 template that omits the header.


### PR DESCRIPTION
The autopilot plan skills looked up external library docs but never read the repository's own README or docs/, and never required plans to update them — so generated plans could miss project conventions and leave docs stale. This change makes both ends mandatory and keeps the wording consistent across the orchestrator and both stack skills.

- Added a Repository Documentation (MANDATORY) step so plans read the root README.md and all docs/* before planning
- Required the generated plan's Post-Implementation block to update any affected README.md and docs/*, with diagrams generated via Skill(autopilot:ascii-schemas)
- Mirrored the rules across plan, plan-bun, and plan-nodejs-react

---

**Release notes:**

- Plan skills now read the repository's own README and docs/ as source of truth before planning
- Generated plans now require updating affected README/docs after implementation, using ascii-schemas for any diagrams

---

**Issues:**

Closes #170