### PR TITLE
Stop the AI code review from approving PRs it never actually reviewed

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -494,6 +494,7 @@ runs:
         PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
         REVIEWER: ${{ inputs.reviewer }}
         STRUCTURED_OUTPUT: ${{ steps.review.outputs.structured_output }}
+        FANOUT_WHOLLY_FAILED: ${{ steps.review.outputs.fanout_wholly_failed }}
         EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
         RUN_SUMMARY: ${{ steps.review.outputs.run_summary }}
         PR_HEAD_SHA: ${{ steps.ctx.outputs.pr_head_sha }}

--- a/.github/actions/code-review-action/src/reviewFanout.test.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.test.ts
@@ -13,12 +13,13 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type pino from "pino";
 
-import type { FanoutContext, SubagentResult } from "./reviewFanout.ts";
+import type { FanoutContext, FanoutStats, SubagentResult } from "./reviewFanout.ts";
 import {
   buildFanoutStats,
   buildSubagentPrompt,
   collectStructuredFindings,
   detectStack,
+  isFanoutWhollyFailed,
   loadReviewAgents,
   parseAgentFrontmatter,
   resolveModel,
@@ -213,6 +214,91 @@ describe("collectStructuredFindings", () => {
     expect(result.findings).toEqual([]);
     expect(result.error).toContain("findings");
     expect(result.raw).toBe(JSON.stringify({ findings: "nope" }));
+  });
+
+  test("recovers findings from the result text when structured_output is absent", async () => {
+    const result = await collectStructuredFindings(
+      noopLog,
+      streamOf(
+        resultMessage({ subtype: "success", result: JSON.stringify({ findings: [validFinding] }) }),
+      ),
+    );
+    expect(result).toEqual({ findings: [validFinding] });
+  });
+
+  test("recovers a valid empty findings object from the result text", async () => {
+    const result = await collectStructuredFindings(
+      noopLog,
+      streamOf(resultMessage({ subtype: "success", result: '{ "findings": [] }' })),
+    );
+    expect(result).toEqual({ findings: [] });
+    expect(result.error).toBeUndefined();
+  });
+
+  test("strips a fenced code block around the result text", async () => {
+    const fenced = ["```json", JSON.stringify({ findings: [validFinding] }), "```"].join("\n");
+    const result = await collectStructuredFindings(
+      noopLog,
+      streamOf(resultMessage({ subtype: "success", result: fenced })),
+    );
+    expect(result).toEqual({ findings: [validFinding] });
+  });
+
+  test("prefers structured_output over the result text when both are present", async () => {
+    const result = await collectStructuredFindings(
+      noopLog,
+      streamOf(
+        resultMessage({
+          subtype: "success",
+          structured_output: { findings: [validFinding] },
+          result: "not json",
+        }),
+      ),
+    );
+    expect(result).toEqual({ findings: [validFinding] });
+  });
+
+  test("skips the dimension when neither structured_output nor result text is valid JSON", async () => {
+    const result = await collectStructuredFindings(
+      noopLog,
+      streamOf(resultMessage({ subtype: "success", result: "I could not complete the review." })),
+    );
+    expect(result.findings).toEqual([]);
+    expect(result.error).toContain("did not match the findings schema");
+    expect(result.raw).toBe("I could not complete the review.");
+  });
+});
+
+describe("isFanoutWhollyFailed", () => {
+  const stats = (agentCount: number, failedCount: number): FanoutStats => ({
+    agentCount,
+    failedCount,
+    parallelSpeedup: 0,
+    agentDurations: [],
+  });
+
+  test("true when every agent errored", () => {
+    expect(isFanoutWhollyFailed(stats(12, 12))).toBe(true);
+  });
+
+  test("true for a single failed agent", () => {
+    expect(isFanoutWhollyFailed(stats(1, 1))).toBe(true);
+  });
+
+  test("false when at least one agent succeeded", () => {
+    expect(isFanoutWhollyFailed(stats(3, 1))).toBe(false);
+  });
+
+  test("false when no agents failed", () => {
+    expect(isFanoutWhollyFailed(stats(3, 0))).toBe(false);
+  });
+
+  test("false for a single successful agent", () => {
+    expect(isFanoutWhollyFailed(stats(1, 0))).toBe(false);
+  });
+
+  test("false when no agents ran", () => {
+    expect(isFanoutWhollyFailed(stats(0, 0))).toBe(false);
   });
 });
 

--- a/.github/actions/code-review-action/src/reviewFanout.test.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.test.ts
@@ -244,6 +244,28 @@ describe("collectStructuredFindings", () => {
     expect(result).toEqual({ findings: [validFinding] });
   });
 
+  test("falls back to the result text when structured_output is null", async () => {
+    const result = await collectStructuredFindings(
+      noopLog,
+      streamOf(
+        resultMessage({
+          subtype: "success",
+          structured_output: null,
+          result: JSON.stringify({ findings: [validFinding] }),
+        }),
+      ),
+    );
+    expect(result).toEqual({ findings: [validFinding] });
+  });
+
+  test("recovers findings from prose-wrapped result text via the brace slice", async () => {
+    const result = await collectStructuredFindings(
+      noopLog,
+      streamOf(resultMessage({ subtype: "success", result: 'Result: { "findings": [] } done' })),
+    );
+    expect(result).toEqual({ findings: [] });
+  });
+
   test("prefers structured_output over the result text when both are present", async () => {
     const result = await collectStructuredFindings(
       noopLog,

--- a/.github/actions/code-review-action/src/reviewFanout.ts
+++ b/.github/actions/code-review-action/src/reviewFanout.ts
@@ -276,12 +276,37 @@ async function runSubagent(
 }
 
 /**
- * Drain the SDK stream and parse the terminal result's structured output.
+ * Recover the findings object an agent emits as its final text when the SDK
+ * `structured_output` channel is empty. Tries the raw text, then a fenced code
+ * block, then the first-brace-to-last-brace slice; returns `undefined` when none
+ * parse (truncated or prose-wrapped output degrades to a skipped dimension).
+ */
+function parseResultJson(result: string | undefined): unknown {
+  if (!result) return undefined;
+  const trimmed = result.trim();
+  const unfenced = trimmed.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```$/i, "").trim();
+  const sliced = trimmed.slice(trimmed.indexOf("{"), trimmed.lastIndexOf("}") + 1);
+  for (const candidate of [trimmed, unfenced, sliced]) {
+    if (!candidate) continue;
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // Fall through to the next recovery strategy.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Drain the SDK stream and parse the terminal result's findings.
  *
- * `structured_output` exists only on a `subtype: "success"` result; any error
- * subtype (including `error_max_structured_output_retries`), a missing result,
- * or a schema-invalid payload degrades to a skipped dimension — same policy as a
- * failed in-model sub-agent — with the raw payload kept for diagnostics.
+ * Findings come from the `subtype: "success"` result: preferentially via the SDK
+ * `structured_output` channel, otherwise recovered from the result text with
+ * {@link parseResultJson} (the agents emit the findings object as their final
+ * message). A missing result, any error subtype (including
+ * `error_max_structured_output_retries`), or a payload matching neither degrades
+ * to a skipped dimension — same policy as a failed in-model sub-agent — with the
+ * attempted payload kept in `raw` for diagnostics.
  */
 export async function collectStructuredFindings(
   log: pino.Logger,
@@ -298,7 +323,10 @@ export async function collectStructuredFindings(
     return { findings: [], error: `Sub-agent ended with ${resultMessage.subtype}.` };
   }
 
-  const parsed = agentOutputSchema.safeParse(resultMessage.structured_output);
+  const structured = resultMessage.structured_output;
+  const usedResultText = structured === undefined || structured === null;
+  const candidate = usedResultText ? parseResultJson(resultMessage.result) : structured;
+  const parsed = agentOutputSchema.safeParse(candidate);
   if (!parsed.success) {
     const issues = parsed.error.issues
       .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
@@ -306,9 +334,10 @@ export async function collectStructuredFindings(
     return {
       findings: [],
       error: `Sub-agent structured output did not match the findings schema: ${issues}`,
-      raw: JSON.stringify(resultMessage.structured_output),
+      raw: usedResultText ? resultMessage.result : JSON.stringify(structured),
     };
   }
+  if (usedResultText) log.debug("Recovered findings from result text (no structured_output).");
   return { findings: parsed.data.findings };
 }
 
@@ -363,6 +392,16 @@ export function buildFanoutStats(results: SubagentResult[], totalMs: number): Fa
     parallelSpeedup: totalMs > 0 ? +(totalAgentMs / totalMs).toFixed(2) : 0,
     agentDurations,
   };
+}
+
+/**
+ * True when every spawned sub-agent errored — the fan-out yielded zero usable
+ * review signal. The caller fails the run loudly instead of writing an empty
+ * findings file the root model would read as "no findings → approve". A partial
+ * failure (at least one agent succeeded) is NOT wholly failed.
+ */
+export function isFanoutWhollyFailed(stats: FanoutStats): boolean {
+  return stats.agentCount > 0 && stats.failedCount === stats.agentCount;
 }
 
 /**

--- a/.github/actions/code-review-action/src/runClaude.ts
+++ b/.github/actions/code-review-action/src/runClaude.ts
@@ -23,6 +23,7 @@ import { setOutput } from "./actionsOutput.ts";
 import { aggregateReviews } from "./aggregateReviews.ts";
 import { logMessage } from "./logClaudeMessage.ts";
 import {
+  isFanoutWhollyFailed,
   runReviewFanout,
   toAgentReviews,
   type FanoutContext,
@@ -343,6 +344,17 @@ async function runFanoutIfEnabled(
   };
 
   const { results, stats } = await runReviewFanout(fanoutCtx);
+  // A 100%-failed fan-out has zero review signal. Writing the usual empty
+  // findings file would let the root model post a clean approval, so fail the
+  // run loudly instead — Submit Review keys off this output to fail the check.
+  if (isFanoutWhollyFailed(stats)) {
+    log.error(
+      { agent_count: stats.agentCount, failed_count: stats.failedCount },
+      "Review fan-out wholly failed; all sub-agents errored."
+    );
+    await setOutput("fanout_wholly_failed", "true");
+    throw new Error(`Review fan-out wholly failed: all ${stats.agentCount} sub-agents errored.`);
+  }
   // Merge the per-agent findings deterministically in code so the root model
   // receives a single ready-to-format list instead of re-deduping 12 blocks.
   const findings = aggregateReviews(toAgentReviews(results));

--- a/.github/actions/code-review-action/src/submitReview.ts
+++ b/.github/actions/code-review-action/src/submitReview.ts
@@ -76,6 +76,15 @@ async function cleanupBotThreads(
 }
 
 // Main execution
+
+// A wholly-failed review fan-out has no usable signal. Fail the check loudly
+// instead of posting a review — guarded before any parse/dedup so a prior
+// same-SHA review cannot flip this green.
+if (process.env.FANOUT_WHOLLY_FAILED === "true") {
+  console.error("Review fan-out wholly failed: all sub-agents errored. Failing the review check.");
+  process.exit(1);
+}
+
 const { octokit, owner, repoName, pullNumber, reviewer } = parseRepoEnv();
 const structuredOutput = process.env.STRUCTURED_OUTPUT ?? "";
 


### PR DESCRIPTION
The AI code-review Action fans out 12 sub-agents whose structured findings never reached the orchestrator, so it posted an empty APPROVED without reviewing the diff — and this repo auto-merges approved PRs. This recovers the findings and makes a fully-failed review block instead of approve.

- Recover each sub-agent's findings from its final text output when the SDK structured-output channel is empty, still preferring the structured channel when present
- Fail the review check when every sub-agent errors, instead of writing an empty findings file the root model reads as an approval
- Add regression tests for text recovery, empty findings, structured-output precedence, and the all-failed safety net

---

**Release notes:**

- Fix the AI code review posting an empty approval when its review sub-agents return no findings
- A fully-failed review now fails the check instead of silently approving

---

**Issues:**

Closes #174
