### PR TITLE
Grant the sub-agent launcher tool in plan skills

### DIFF
--- a/claude-plugins/autopilot/skills/plan-bun/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-bun/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
+  - Agent
   - Bash(git *)
   - MCP(context7:*)
   - MCP(Ref:*)

--- a/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
+  - Agent
   - Bash(git *)
   - MCP(context7:*)
   - MCP(Ref:*)

--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -6,6 +6,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
+  - Agent
   - Bash(git *)
   - Bash(gh *)
   - MCP(context7:*)


### PR DESCRIPTION
The plan, plan-bun, and plan-nodejs-react skills instruct sub-agent launches ("Use the Agent tool", "Launch Explore agents", "launch expert-review") but never listed the Agent launcher in allowed-tools — unlike pr:review, pr:monitor, and todo-cleanup, which already grant it and launch sub-agents successfully.

- Add Agent to allowed-tools in all three plan skills
- Aligns declared tools with the instructed launches; matches the existing pr:review precedent
- Resolves audit finding P2 (dimension 4): the launcher must be declared so gated/headless invocations can reach the sub-agent steps

---

**Release notes:**

- Plan skills now declare the Agent tool they use to launch context and expert-review sub-agents

---

**Issues:**

Closes #182