### PR TITLE
Pass reviewer env to the PR help footer step

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -407,6 +407,7 @@ runs:
         GH_TOKEN: ${{ inputs.bot_token }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+        REVIEWER: ${{ inputs.reviewer }}
         HELP_ID: code-review-action
         HELP_TEXT: |
           - `@${{ inputs.reviewer }} <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.


### PR DESCRIPTION
The Update PR help footer step ran updatePrFooter.ts without passing REVIEWER, but the shared parseRepoEnv() requires GH_TOKEN, REPO, PR_NUMBER, and REVIEWER. So the step threw on every review run and was swallowed fail-open — the help footer never posted and each CI log carried a stack trace. The review itself was unaffected.

- Add the reviewer login to the footer step env, matching the Submit Review step
- One-line fix; YAML validated, no behavior change beyond the footer now posting

---

**Release notes:**

- The AI code review PR help footer now posts correctly instead of failing silently