### PR TITLE
Stop the repomix pack job from failing when main advances on merge

### DIFF
--- a/.github/workflows/repomix-pack.yml
+++ b/.github/workflows/repomix-pack.yml
@@ -55,4 +55,15 @@ jobs:
           git config user.name "${BOT_USERNAME:-github-actions[bot]}"
           git config user.email "${BOT_USERNAME:-github-actions[bot]}@users.noreply.github.com"
           git commit -m "chore(repomix): refresh pack from #${PR_NUMBER}"
-          git push origin HEAD:main
+          # main can advance between checkout and push (concurrent merge, the
+          # preceding pack commit, or a re-run); rebase onto it and retry.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push rejected — main advanced; rebasing onto latest main (attempt ${attempt}/3)."
+            git fetch origin main
+            git rebase origin/main
+          done
+          echo "::error::Failed to push refreshed pack after 3 attempts."
+          exit 1


### PR DESCRIPTION
## Summary

The Repomix pack workflow pushes the regenerated pack straight to `main` after a PR merges. When `main` advanced between the job's `checkout` and its `git push origin HEAD:main`, the push was rejected non-fast-forward and the job failed (e.g. run 26697329314 on #195). This makes the push resilient by rebasing onto the latest `main` and retrying.

## Changes

- Wrap the pack push in a 3-attempt loop in the "Commit pack if changed" step
- Fetch and rebase the pack commit onto `origin/main` between attempts
- Fail the step with an `::error::` annotation after 3 attempts
- Leave triggers, permissions, `BOT_TOKEN`, the concurrency group, and the "No pack changes" fast path unchanged

## Testing

- Parsed the workflow YAML with Ruby's `YAML` loader — valid
- Ran `bash -n` on the extracted "Commit pack if changed" script — no syntax errors
- Confirmed the diff touches only the "Commit pack if changed" step

---

**Issues:** Closes #198

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->