### PR TITLE
Remove the dead Quiz Mode clarification format from planning

### DIFF
--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -382,18 +382,6 @@ Then invoke `/autopilot:branch-create --<chosen-prefix> "<description>"` using t
 
 Do NOT add `## Pre-Implementation` — already on a feature branch with active work.
 
-## Quiz Mode Format
-
-When clarification needed:
-
-```
-**Q[N]**: [Clear question]
-A) [Option with brief explanation]
-B) [Option with brief explanation]
-C) [Option with brief explanation]
-D) Other: ___
-```
-
 ## Stack Pipeline (Phases 1–6)
 
 The stack skills (`plan-bun`, `plan-nodejs-react`) execute this shared pipeline after the Phase 1 delegation above, supplying their three deltas (example libraries, expert table, verify examples) from their own `## Stack Deltas` section. The pipeline is defined ONCE here so the two stacks cannot drift; wherever a phase says "your stack's <delta>", read the value from the delegating stack skill. These "Phase 1–6" are the stack-execution phases — distinct from this orchestrator's Phase 0–2 above — and the stack skill runs them in order after being delegated to.
@@ -544,7 +532,7 @@ Rate the reviewed plan (20 points each dimension = 100 total):
 If score < 95, automatically:
 
 1. Identify weak dimensions (score < 19)
-2. Ask clarifying questions in quiz format
+2. Ask clarifying questions via `AskUserQuestion` if a weak dimension hinges on a material ambiguity
 3. Re-analyze and re-score internally (do not output retry details)
 4. Repeat until 95+ achieved
 


### PR DESCRIPTION
The plan skills carried a "Quiz Mode Format" section (an A/B/C/D text block) alongside the mandated `AskUserQuestion` tool, but no phase ever invoked Quiz Mode — it was dead instruction, and the Phase 5 Auto-Iteration step mixed "ask in quiz format" with a silent re-score loop. This removes the dead path so clarification has one mechanism.

- Delete the unused Quiz Mode Format section from plan/SKILL.md
- Reword Phase 5 Auto-Iteration step 2 to ask via `AskUserQuestion` (gated to material ambiguities) instead of quiz format, resolving the silent/interactive mix

Scope notes:
- The audit also named the `plan-bun`/`plan-nodejs-react` copies, but #184 already collapsed those skills to frontmatter + deltas, so no Quiz Mode block remains there.
- `run/SKILL.md` still carries an identical dead Quiz Mode Format block; it is outside this issue's stated three-file scope, so it is left for a separate follow-up rather than expanded into here.

---

**Release notes:**

- Plan skills now have a single clarification mechanism (AskUserQuestion); the unused Quiz Mode format is gone

---

**Issues:**

Closes #187

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->