### PR TITLE
Trim over-granted tools from the plan skills and expert-review agent

### DIFF
--- a/claude-plugins/autopilot/agents/expert-review.md
+++ b/claude-plugins/autopilot/agents/expert-review.md
@@ -1,6 +1,7 @@
 ---
 name: expert-review
 description: Review an implementation plan as a domain expert. Use when plan skills need isolated expert scoring to prevent context flooding.
+tools: []
 model: inherit
 ---
 

--- a/claude-plugins/autopilot/skills/plan-bun/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-bun/SKILL.md
@@ -5,7 +5,6 @@ user-invocable: false
 allowed-tools:
   - TaskList
   - TaskUpdate
-  - TaskCreate
   - Read
   - Grep
   - Glob

--- a/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan-nodejs-react/SKILL.md
@@ -5,7 +5,6 @@ user-invocable: false
 allowed-tools:
   - TaskList
   - TaskUpdate
-  - TaskCreate
   - Read
   - Grep
   - Glob


### PR DESCRIPTION
The plan stack skills granted `TaskCreate` but only ever discover (`TaskList`) and update (`TaskUpdate`) tasks — task creation happens once in the plan command's Phase 0, not in the stack pipeline — so the grant was dead. Separately, the `expert-review` agent declared no `tools:` restriction, so it inherited the full tool set even though it only reasons over the plan text passed in its prompt.

- Remove the unused `TaskCreate` grant from `plan-bun` and `plan-nodejs-react` allowed-tools
- Restrict `expert-review` to no tools (`tools: []`, an empty allowlist) since it needs none
- Pure hardening: narrows blast radius and makes each grant match actual usage, no behavior change

---

**Release notes:**

- Plan skills and the expert-review agent now request only the tools they actually use

---

**Issues:**

Closes #188

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->