### PR TITLE
HOTFIX: Remove false release-branch warning on monorepo releases

### DIFF
--- a/.github/actions/release-action/src/run.test.ts
+++ b/.github/actions/release-action/src/run.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for monorepo branch-template resolution.
+ *
+ * Guards the contract that the standalone `release-{version}` default is treated
+ * as unset (silent monorepo fallback, no `::warning::`), while a member-less
+ * template the operator set themselves is injected with `{member}` and warned.
+ */
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import { resolveBranchTemplate } from "./run.ts";
+
+const originalBranch = process.env.INPUT_BRANCH;
+
+afterEach(() => {
+  if (originalBranch === undefined) {
+    delete process.env.INPUT_BRANCH;
+  } else {
+    process.env.INPUT_BRANCH = originalBranch;
+  }
+});
+
+/** Resolve the template with `INPUT_BRANCH` set to `input`, capturing warnings. */
+function resolveWithWarnings(input: string | undefined): {
+  template: string;
+  warnings: string[];
+} {
+  if (input === undefined) {
+    delete process.env.INPUT_BRANCH;
+  } else {
+    process.env.INPUT_BRANCH = input;
+  }
+  const warnings: string[] = [];
+  const spy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    warnings.push(String(args[0]));
+  });
+  try {
+    return { template: resolveBranchTemplate(), warnings };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("resolveBranchTemplate", () => {
+  test("falls back to the monorepo default without warning when unset", () => {
+    const { template, warnings } = resolveWithWarnings(undefined);
+    expect(template).toBe("release-{member}-{version}");
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("treats an empty input as unset", () => {
+    const { template, warnings } = resolveWithWarnings("");
+    expect(template).toBe("release-{member}-{version}");
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("treats the standalone release-{version} default as unset — no warning", () => {
+    const { template, warnings } = resolveWithWarnings("release-{version}");
+    expect(template).toBe("release-{member}-{version}");
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("returns a member-aware template verbatim", () => {
+    const { template, warnings } = resolveWithWarnings("rel/{member}/{version}");
+    expect(template).toBe("rel/{member}/{version}");
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("injects {member} into a custom member-less template and warns", () => {
+    const { template, warnings } = resolveWithWarnings("rel/{version}");
+    expect(template).toBe("rel/{member}-{version}");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("::warning::");
+    expect(warnings[0]).toContain("missing {member} placeholder");
+  });
+
+  test("appends {member} when a custom template omits {version} too", () => {
+    const { template, warnings } = resolveWithWarnings("release");
+    expect(template).toBe("release-{member}");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("::warning::");
+  });
+});

--- a/.github/actions/release-action/src/run.ts
+++ b/.github/actions/release-action/src/run.ts
@@ -69,15 +69,25 @@ async function openOrUpdatePr(release: MemberRelease, cwd: string): Promise<stri
   return created.stdout.toString().trim();
 }
 
-function resolveBranchTemplate(): string {
+/**
+ * Resolve the per-member branch template for monorepo mode.
+ *
+ * Returns `INPUT_BRANCH` verbatim when it already contains `{member}`. An unset
+ * input — or the standalone `release-{version}` default from `action.yml` that
+ * leaks through when the workflow leaves `branch` unset — falls back silently to
+ * `release-{member}-{version}`. Any other member-less template is the operator's
+ * own choice, so `{member}` is injected and a `::warning::` is emitted.
+ */
+export function resolveBranchTemplate(): string {
   const raw = process.env.INPUT_BRANCH;
   const fallback = "release-{member}-{version}";
-  if (!raw || raw.length === 0) return fallback;
+  // `release-{version}` is the standalone `action.yml` default; treat it as unset.
+  const standaloneDefault = "release-{version}";
+  if (!raw || raw.length === 0 || raw === standaloneDefault) return fallback;
   if (raw.includes("{member}")) return raw;
-  // The standalone default `release-{version}` (the action.yml default) and
-  // any other user-supplied template without `{member}` would collapse all
-  // members onto the same branch. Inject `{member}` so per-member PRs stay
-  // distinct, and warn so the operator can override the input explicitly.
+  // A template the operator set themselves still lacks `{member}`, which would
+  // collapse every member onto the same branch. Inject `{member}` so per-member
+  // PRs stay distinct, and warn so they can fix the input explicitly.
   const injected = raw.replace(/\{version\}/, "{member}-{version}");
   const finalTemplate = injected.includes("{member}") ? injected : `${raw}-{member}`;
   console.log(


### PR DESCRIPTION
Every monorepo `release-create` run logged a GitHub Actions warning claiming the release branch template was missing the `{member}` placeholder, even though the branch it created was already correct. The warning came from the standalone default `release-{version}` leaking into monorepo mode — this removes the noise without changing the branch that gets created.

- `resolveBranchTemplate()` now treats the standalone `release-{version}` default like an unset `INPUT_BRANCH`, falling back to `release-{member}-{version}` silently
- The `::warning::` is kept only for templates an operator explicitly sets that still lack `{member}` (e.g. `rel/{version}`)
- Fixed in the action code rather than `release-create.yml`, which is synced to standalone consumers whose step only substitutes `{version}`
- Added `src/run.test.ts` with 6 cases; full release-action suite passes (325/0) and `tsc --noEmit` is clean

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->