### PR TITLE
HOTFIX: Stop unrelated PRs from cancelling each other's auto-label run

### DIFF
--- a/.github/actions/auto-label/README.md
+++ b/.github/actions/auto-label/README.md
@@ -94,7 +94,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: auto-label-${{ github.repository }}
+  group: auto-label-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -12,10 +12,13 @@ on:
   push:
     branches: [main]
 
-# Shared group across both events so a push-triggered prune never runs concurrently
-# with a pull_request-triggered label sync (which would race on the same labels).
+# Per-PR concurrency: concurrent PRs never cancel each other's label sync, and a
+# newer sync for the same PR supersedes the older run. The push-prune runs in its
+# own (github.ref) group so PR activity never cancels it. A prune may briefly
+# overlap a PR sync, but that is self-healing — the next push re-prunes and each
+# PR's labels reflect its own diff.
 concurrency:
-  group: auto-label-${{ github.repository }}
+  group: auto-label-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:


### PR DESCRIPTION
The auto-label workflow used a repo-wide concurrency group with `cancel-in-progress` on `pull_request` events, so an event on one PR cancelled an in-flight label sync on any other open PR — leaving PRs with stale or missing labels. This scopes concurrency per pull request so PRs no longer cancel each other.

- Replace the repo-wide `github.repository` group with a per-PR group keyed on `github.event.pull_request.number`
- Push-prune now runs in its own `github.ref` group, so PR activity never cancels a prune
- Trade-off: a prune may briefly overlap a PR's label sync, but it is self-healing — the next push re-prunes and each PR's labels reflect its own diff
- Mirror the same concurrency block in the action README usage example

The workflow is distributed verbatim to consumer repos, so this fix propagates downstream on the next contributing-sync.

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->