### PR TITLE
Make autopilot planning analyze the codebase once and show tasks in order

### DIFF
--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -135,11 +135,7 @@ Acquire codebase snapshot (prefer the committed pack to avoid re-packing):
     - `compress`: true
 ```
 
-After all calls complete:
-
-1. Store the `outputId` from the snapshot acquisition (attach or pack) response for use throughout all phases
-2. Use `grep_repomix_output` with the `outputId` for a shallow, task-relevant lookup — only enough to render the issue context and orient (keywords from issue title/description, related module names). This is NOT codebase analysis: the single broad codebase pass runs later in the pipeline's **Context Gathering** phase, and **Deep Analysis** synthesizes over it. Do not crawl the tree here.
-3. Use `read_repomix_output` with `startLine`/`endLine` only to read the specific sections that lookup surfaces
+After all calls complete, store the `outputId` from the snapshot acquisition (attach or pack) response — Phase 1 (Context Gathering) is the single phase that reads the codebase from it. Phase 0 does NOT grep or read code: build the issue context, Steelmanned Intent, and Assumptions below from the resolved issue JSON (title, body, comments) and the TODO results alone. Defer every codebase read to Phase 1.
 
 ### Issue Context Output
 
@@ -402,6 +398,8 @@ Use these IDs for all TaskUpdate calls in the phases below.
 
 **FIRST**, call TaskUpdate to set task 2 ("Gather context") to `status: "in_progress"`.
 
+This is the pipeline's single codebase-reading pass: Phase 0 read no code and Phase 2 only synthesizes, so gather here everything the rest of planning needs about the code and record it in the **Context Map** (step 7).
+
 1. **Branch Changes** - Analyze all changes since diverging from main:
    - `git log origin/main..HEAD --oneline` - commits on this branch
    - `git diff origin/main...HEAD` - all code changes
@@ -413,6 +411,12 @@ Use these IDs for all TaskUpdate calls in the phases below.
 4. **Repository Documentation** (MANDATORY) - Follow the **Repository Documentation** rule in `## Common Instructions`.
 5. **CLAUDE.md Compliance** - Follow the **CLAUDE.md Compliance** rule in `## Common Instructions`.
 6. **Repomix** - Search codebase via `mcp__repomix__grep_repomix_output` (outputId from Phase 0). Use `mcp__repomix__read_repomix_output` with `startLine`/`endLine` for specific sections only.
+7. **Context Map (the output of this pass)** - Because this is the only phase that reads the codebase, record a compact written inventory of what it found, enough that every later phase reasons over the map instead of re-reading:
+   - Relevant files/modules and their role in the change
+   - Existing patterns and similar implementations to mirror
+   - Key types, interfaces, and Zod schemas in play
+   - Test conventions and fixtures that apply
+   - In-flight changes from the branch diff (step 1) the snapshot does not reflect
 
 After completing all context gathering, call TaskUpdate to set task 2 ("Gather context") to `status: "completed"`.
 
@@ -420,11 +424,11 @@ After completing all context gathering, call TaskUpdate to set task 2 ("Gather c
 
 **FIRST**, call TaskUpdate to set task 3 ("Analyze codebase") to `status: "in_progress"`.
 
-This is a synthesis step, not a second crawl — Phase 1 (Context Gathering) already traversed the codebase. Reason over the context Phase 1 gathered across the dimensions below; do not re-grep or re-read the whole tree Phase 1 already covered.
+This is a synthesis step, not a second crawl. Reason over the **Context Map** Phase 1 produced — that map is the codebase read, and it already holds the files, patterns, types, tests, and in-flight changes this analysis needs. Work the dimensions below against it; do not re-grep or re-read the tree to reconstruct what the map already contains.
 
-Reach for an additional read only under the same snapshot-vs-live rule Phase 1 applies, and only for what that rule allows:
+Reach for an additional read only if the Context Map is genuinely missing something the analysis turns on, and only under the same snapshot-vs-live rule Phase 1 applies — then fold the result back into the map:
 
-- a targeted `mcp__repomix__grep_repomix_output`/`mcp__repomix__read_repomix_output` (outputId from Phase 0) for one specific section the synthesis still needs, or
+- a targeted `mcp__repomix__grep_repomix_output`/`mcp__repomix__read_repomix_output` (outputId from Phase 0) for the one missing section, or
 - a live Grep/Read/Glob for in-flight working-tree code the snapshot is too stale to show (the branch's uncommitted changes).
 
 | Dimension        | Key Questions                                             |

--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -55,8 +55,8 @@ Create all 6 tasks using TaskCreate, in order, before starting any work:
 | 1   | Resolve input        | Resolving input        | plan   |
 | 2   | Gather context       | Gathering context      | skill  |
 | 3   | Analyze codebase     | Analyzing codebase     | skill  |
-| 4   | Validate plan scores | Validating plan scores | skill  |
-| 5   | Review with experts  | Reviewing with experts | skill  |
+| 4   | Review with experts  | Reviewing with experts | skill  |
+| 5   | Validate plan scores | Validating plan scores | skill  |
 | 6   | Output final plan    | Outputting final plan  | skill  |
 
 Create each task with:
@@ -138,8 +138,8 @@ Acquire codebase snapshot (prefer the committed pack to avoid re-packing):
 After all calls complete:
 
 1. Store the `outputId` from the snapshot acquisition (attach or pack) response for use throughout all phases
-2. Use `grep_repomix_output` with the `outputId` to search for task-relevant code (keywords from issue title/description, related module names)
-3. Use `read_repomix_output` with `startLine`/`endLine` only to read specific sections found via grep
+2. Use `grep_repomix_output` with the `outputId` for a shallow, task-relevant lookup — only enough to render the issue context and orient (keywords from issue title/description, related module names). This is NOT codebase analysis: the single broad codebase pass runs later in the pipeline's **Context Gathering** phase, and **Deep Analysis** synthesizes over it. Do not crawl the tree here.
+3. Use `read_repomix_output` with `startLine`/`endLine` only to read the specific sections that lookup surfaces
 
 ### Issue Context Output
 
@@ -392,8 +392,8 @@ Call TaskList to find the planning tasks created by the plan command. Match task
 
 - Task 2: "Gather context"
 - Task 3: "Analyze codebase"
-- Task 4: "Validate plan scores"
-- Task 5: "Review with experts"
+- Task 4: "Review with experts"
+- Task 5: "Validate plan scores"
 - Task 6: "Output final plan"
 
 Use these IDs for all TaskUpdate calls in the phases below.
@@ -420,7 +420,12 @@ After completing all context gathering, call TaskUpdate to set task 2 ("Gather c
 
 **FIRST**, call TaskUpdate to set task 3 ("Analyze codebase") to `status: "in_progress"`.
 
-Analyze each dimension before planning. Use `mcp__repomix__grep_repomix_output` (outputId from Phase 0) to search for relevant code, and `mcp__repomix__read_repomix_output` with `startLine`/`endLine` to read specific sections. Fall back to Grep, Read, or Glob when Repomix results are insufficient.
+This is a synthesis step, not a second crawl — Phase 1 (Context Gathering) already traversed the codebase. Reason over the context Phase 1 gathered across the dimensions below; do not re-grep or re-read the whole tree Phase 1 already covered.
+
+Reach for an additional read only under the same snapshot-vs-live rule Phase 1 applies, and only for what that rule allows:
+
+- a targeted `mcp__repomix__grep_repomix_output`/`mcp__repomix__read_repomix_output` (outputId from Phase 0) for one specific section the synthesis still needs, or
+- a live Grep/Read/Glob for in-flight working-tree code the snapshot is too stale to show (the branch's uncommitted changes).
 
 | Dimension        | Key Questions                                             |
 | ---------------- | --------------------------------------------------------- |
@@ -434,9 +439,7 @@ After completing deep analysis, call TaskUpdate to set task 3 ("Analyze codebase
 
 ### Phase 3: Draft Plan
 
-**FIRST**, call TaskUpdate to set task 6 ("Output final plan") to `status: "in_progress"`.
-
-Assemble a complete plan draft now — before scoring and expert review — so both operate on a concrete artifact instead of an imagined one. Build the draft from the output template below and keep it available for Phase 4 (expert review) and Phase 5 (scoring). Leave the `Score:` line as a placeholder; Phase 5 fills it. Do NOT mark task 6 completed yet — it stays in progress until Phase 6 finalizes the plan.
+Assemble a complete plan draft now — before scoring and expert review — so both operate on a concrete artifact instead of an imagined one. Build the draft from the output template below and keep it available for Phase 4 (expert review) and Phase 5 (scoring). Leave the `Score:` line as a placeholder; Phase 5 fills it. This draft is interim — do NOT flip any task status here; it flows directly into the Phase 4 review. Task 6 ("Output final plan") activates in Phase 6 when the final plan is written, so the progress list advances in numeric order (Review and Validate finish before Output begins).
 
 The template below starts with `# <Title>` — see the canonical "Plan File Header (MANDATORY)" rule in `## Common Instructions` above for title derivation and section ordering.
 
@@ -487,11 +490,9 @@ After the user selects their option:
 - "Done": no further action needed
 ```
 
-Keep task 6 in progress — Phase 6 marks it completed after the plan is finalized.
-
 ### Phase 4: Dynamic Expert Review
 
-**FIRST**, call TaskUpdate to set task 5 ("Review with experts") to `status: "in_progress"`.
+**FIRST**, call TaskUpdate to set task 4 ("Review with experts") to `status: "in_progress"`.
 
 Select experts from your stack's **expert table** delta — always include the Pre-mortem Analyst, then 2-3 additional experts based on task scope.
 
@@ -511,11 +512,11 @@ Use the Agent tool with:
 
 Wait for all agents to complete. Each returns a JSON object (`expertRole`, `score`, `verdict`, `findings`, `revision`). Aggregate the `findings` across experts to refine the Phase 3 draft internally, and treat any `needs-revision` verdict as a signal to address that expert's findings before finalizing. Do not include the raw expert JSON in the plan output.
 
-After all expert reviews complete, call TaskUpdate to set task 5 ("Review with experts") to `status: "completed"`.
+After all expert reviews complete, call TaskUpdate to set task 4 ("Review with experts") to `status: "completed"`.
 
 ### Phase 5: Validation Scoring
 
-**FIRST**, call TaskUpdate to set task 4 ("Validate plan scores") to `status: "in_progress"`.
+**FIRST**, call TaskUpdate to set task 5 ("Validate plan scores") to `status: "in_progress"`.
 
 Rate the reviewed plan (20 points each dimension = 100 total):
 
@@ -536,9 +537,11 @@ If score < 95, automatically:
 3. Re-analyze and re-score internally (do not output retry details)
 4. Repeat until 95+ achieved
 
-After scoring completes, call TaskUpdate to set task 4 ("Validate plan scores") to `status: "completed"`.
+After scoring completes, call TaskUpdate to set task 5 ("Validate plan scores") to `status: "completed"`.
 
 ### Phase 6: Finalize Output
+
+**FIRST**, call TaskUpdate to set task 6 ("Output final plan") to `status: "in_progress"`.
 
 Apply the expert findings (Phase 4) and the validated score (Phase 5) to the Phase 3 draft, then write the final plan file. Replace the `Score:` placeholder in the `## Summary` block with the Phase 5 result (`Score: [X]/100`).
 

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -139,11 +139,7 @@ Acquire codebase snapshot (prefer the committed pack to avoid re-packing):
     - `compress`: true
 ```
 
-After all calls complete:
-
-1. Store the `outputId` from the snapshot acquisition (attach or pack) response for use throughout all phases
-2. Use `grep_repomix_output` with the `outputId` for a shallow, task-relevant lookup — only enough to render the issue context and orient (keywords from issue title/description, related module names). This is NOT codebase analysis: the single broad codebase pass runs later in the pipeline's **Context Gathering** phase, and **Deep Analysis** synthesizes over it. Do not crawl the tree here.
-3. Use `read_repomix_output` with `startLine`/`endLine` only to read the specific sections that lookup surfaces
+After all calls complete, store the `outputId` from the snapshot acquisition (attach or pack) response — the stack pipeline's Context Gathering phase is the single place that reads the codebase from it. Phase 0 does NOT grep or read code: render the issue context below from the resolved issue JSON and the TODO results alone. Defer every codebase read to Context Gathering.
 
 ### Issue Context Output
 

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -59,8 +59,8 @@ Create all 6 tasks using TaskCreate, in order, before starting any work:
 | 1   | Resolve input        | Resolving input        | autopilot |
 | 2   | Gather context       | Gathering context      | skill     |
 | 3   | Analyze codebase     | Analyzing codebase     | skill     |
-| 4   | Validate plan scores | Validating plan scores | skill     |
-| 5   | Review with experts  | Reviewing with experts | skill     |
+| 4   | Review with experts  | Reviewing with experts | skill     |
+| 5   | Validate plan scores | Validating plan scores | skill     |
 | 6   | Output final plan    | Outputting final plan  | skill     |
 
 Create each task with:
@@ -142,8 +142,8 @@ Acquire codebase snapshot (prefer the committed pack to avoid re-packing):
 After all calls complete:
 
 1. Store the `outputId` from the snapshot acquisition (attach or pack) response for use throughout all phases
-2. Use `grep_repomix_output` with the `outputId` to search for task-relevant code (keywords from issue title/description, related module names)
-3. Use `read_repomix_output` with `startLine`/`endLine` only to read specific sections found via grep
+2. Use `grep_repomix_output` with the `outputId` for a shallow, task-relevant lookup — only enough to render the issue context and orient (keywords from issue title/description, related module names). This is NOT codebase analysis: the single broad codebase pass runs later in the pipeline's **Context Gathering** phase, and **Deep Analysis** synthesizes over it. Do not crawl the tree here.
+3. Use `read_repomix_output` with `startLine`/`endLine` only to read the specific sections that lookup surfaces
 
 ### Issue Context Output
 

--- a/docs/plan-run-skills.md
+++ b/docs/plan-run-skills.md
@@ -149,7 +149,7 @@ Gather the branch diff (`git log/diff origin/main...HEAD`), then decide **where 
 
 ### Phase 2 · Deep Analysis
 
-Analyze the change across five dimensions before planning: **Architecture** (where it fits), **Patterns** (what existing code to follow), **Data Flow** (source of truth), **Types** (interfaces/schemas, what needs Zod), and **Edge Cases** (failure/null/race conditions).
+A synthesis step, not a second crawl: reason over the context Phase 1 already gathered, across five dimensions — **Architecture** (where it fits), **Patterns** (what existing code to follow), **Data Flow** (source of truth), **Types** (interfaces/schemas, what needs Zod), and **Edge Cases** (failure/null/race conditions). Any extra read obeys the same snapshot-vs-live rule as Phase 1 — a targeted lookup only, never a re-crawl of the tree Phase 1 covered.
 
 ### Phase 3 · Draft Plan
 

--- a/docs/plan-run-skills.md
+++ b/docs/plan-run-skills.md
@@ -47,7 +47,7 @@ The two skills share the same front half. `plan` produces the plan and stops, as
 
 **Flow Legend:**
 
-- ① Resolve the input (issue vs. description) and gather context in parallel — repomix snapshot plus, for issues, two context sub-agents.
+- ① Resolve the input (issue vs. description) in parallel — attach the repomix snapshot (no code read yet) plus, for issues, two context sub-agents.
 - ② `preflight-check` validates branch/worktree state and that `main` is current before any work.
 - ③ Cross-cutting rules (doc-lookup, repo-docs, CLAUDE.md, ASCII schemas) declared once and reused by the pipeline.
 - ④ Read `package.json` `agents.rules` and delegate to one stack skill.
@@ -101,10 +101,10 @@ The skill detects the input type from its arguments and gathers context **in par
 | contains `github.com` | GitHub issue URL  |
 | anything else         | Plain description |
 
-- **Codebase snapshot (always).** Prefer the committed `.repomix/pack.xml` via `attach_packed_output`; fall back to a live `pack_codebase` when it is absent. The returned `outputId` is reused by every later phase. See [Committed Repomix pack](./repomix-pack.md).
+- **Codebase snapshot (always).** Prefer the committed `.repomix/pack.xml` via `attach_packed_output`; fall back to a live `pack_codebase` when it is absent. Phase 0 only _attaches_ the pack — it does not read code from it; the returned `outputId` is handed to Phase 1, the single phase that reads the codebase. See [Committed Repomix pack](./repomix-pack.md).
 - **For GitHub issues (parallel sub-agents).** `resolve-issue-context` fetches the issue (and, when the caller opts in, idempotently self-assigns the current user); `search-codebase-todos` finds TODOs referencing the issue. Both return JSON (see [Sub-agents](#sub-agents-and-their-json-contracts)).
 
-The skill then emits, for the user's review: the rendered **issue context**, a one-line **steelmanned intent** (the request restated in its strongest form — the stable target for expert reviewers, copied verbatim into the plan's `## Summary`), and **Assumptions & Open Questions**. Any load-bearing open question is raised via `AskUserQuestion` before delegating.
+The skill then emits, for the user's review (all derived from the resolved issue JSON and TODOs, not a codebase scan): the rendered **issue context**, a one-line **steelmanned intent** (the request restated in its strongest form — the stable target for expert reviewers, copied verbatim into the plan's `## Summary`), and **Assumptions & Open Questions**. Any load-bearing open question is raised via `AskUserQuestion` before delegating.
 
 ## Preflight check
 
@@ -145,11 +145,11 @@ The delegated stack skill discovers the planning tasks (via `TaskList`) and runs
 
 ### Phase 1 · Context Gathering
 
-Gather the branch diff (`git log/diff origin/main...HEAD`), then decide **where context comes from** before crawling: the Phase 0 snapshot serves broad/whole-repo reads, while live tools (Explore agents / Grep / Glob) serve only what the snapshot cannot — in-flight working-tree code or targeted fresh reads. This one rule stops the snapshot and live tools from re-traversing the same tree. Documentation lookup, repository documentation, and CLAUDE.md compliance follow the Common Instructions.
+This is the pipeline's **single codebase-reading pass** — Phase 0 reads no code and Phase 2 only synthesizes. Gather the branch diff (`git log/diff origin/main...HEAD`), then decide **where context comes from** before crawling: the Phase 0 snapshot serves broad/whole-repo reads, while live tools (Explore agents / Grep / Glob) serve only what the snapshot cannot — in-flight working-tree code or targeted fresh reads. The pass ends by recording a **Context Map** — files and their roles, patterns to mirror, key types/schemas, test conventions, and in-flight changes — which becomes the single artifact every later phase reasons over instead of re-reading. Documentation lookup, repository documentation, and CLAUDE.md compliance follow the Common Instructions.
 
 ### Phase 2 · Deep Analysis
 
-A synthesis step, not a second crawl: reason over the context Phase 1 already gathered, across five dimensions — **Architecture** (where it fits), **Patterns** (what existing code to follow), **Data Flow** (source of truth), **Types** (interfaces/schemas, what needs Zod), and **Edge Cases** (failure/null/race conditions). Any extra read obeys the same snapshot-vs-live rule as Phase 1 — a targeted lookup only, never a re-crawl of the tree Phase 1 covered.
+A synthesis step, not a second crawl: reason over the **Context Map** from Phase 1 across five dimensions — **Architecture** (where it fits), **Patterns** (what existing code to follow), **Data Flow** (source of truth), **Types** (interfaces/schemas, what needs Zod), and **Edge Cases** (failure/null/race conditions). The map is the codebase read; an extra lookup is allowed only when it is genuinely missing something, under the same snapshot-vs-live rule as Phase 1, with the result folded back into the map — never a re-crawl of the tree.
 
 ### Phase 3 · Draft Plan
 


### PR DESCRIPTION
The plan and run skills read the codebase across three separate phases during planning. A prior fix (#183) removed two of those reads; this collapses the rest to a single pass and renumbers the six progress tasks so the list advances in order.

- Phase 0 no longer reads code — it renders issue context from the resolved issue JSON and hands the snapshot's `outputId` to Phase 1
- Phase 1 is the single codebase-reading pass and ends by recording a Context Map (files, patterns, types, tests, in-flight changes)
- Phase 2 Deep Analysis synthesizes over the Context Map instead of re-grepping the tree
- Renumbered tasks so Review precedes Validate and Output activates last, so the progress list advances 1 to 6
- Mirrored the Phase 0 changes in run/SKILL.md and synced docs/plan-run-skills.md

---

**Release notes:**

- Plan and run now read the codebase once during planning (a single Context Gathering pass) instead of across three phases
- Planning progress now advances in order, with Review before Validate and Output last

---

**Issues:**

Closes #211