### PR TITLE
Grant the task and agent tools the plan and run skills require

### DIFF
--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -3,6 +3,8 @@ name: plan
 description: Perform deep analysis of the codebase, recent changes, and the requested task. Create a validated, expert-reviewed implementation plan
 argument-hint: "<task description, GitHub issue number, or GitHub issue URL>"
 allowed-tools:
+  - TaskCreate
+  - TaskUpdate
   - Read
   - Grep
   - Glob

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -3,9 +3,12 @@ name: run
 description: Plan, implement, commit, create PR, and monitor until approved
 argument-hint: "<task description, GitHub issue number, or GitHub issue URL>"
 allowed-tools:
+  - TaskCreate
+  - TaskUpdate
   - Read
   - Grep
   - Glob
+  - Agent
   - Edit
   - Write
   - Bash(git *)


### PR DESCRIPTION
The plan and run orchestrator skills call TaskCreate/TaskUpdate (and, in run, the Agent tool) as their first Phase 0 actions, but never declared those tools in allowed-tools. Because allowed-tools pre-approves listed tools, the omission made each skill prompt for permission on its very first step instead of running pre-approved — and left the orchestrators inconsistent with the stack skills, which deliberately declare the task tools they use.

- plan/SKILL.md: add TaskCreate and TaskUpdate
- run/SKILL.md: add Agent, TaskCreate, and TaskUpdate
- Issue #214 also reported out-of-order task tracking (Defect 2); that was already resolved by commit ab37008, so no change is needed there
- The run/SKILL.md grants are a consistency fix beyond #214's plan-only scope, included at the maintainer's request

---

**Release notes:**

- The plan and run skills no longer trigger a permission prompt for the task-tracking and sub-agent tools they use internally

---

**Issues:**

Closes #214

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->