### PR TITLE
Add a skill to delegate tasks to the OpenAI Codex CLI

### DIFF
--- a/claude-plugins/autopilot/README.md
+++ b/claude-plugins/autopilot/README.md
@@ -260,6 +260,16 @@ Generate ASCII schemas, diagrams, and UI wireframes using Unicode box-drawing ch
 /autopilot:ascii-schemas
 ```
 
+### `/autopilot:ask-codex`
+
+Delegate a code-analysis, refactoring, or automated-editing task to the OpenAI Codex CLI, then critically evaluate its output as a peer AI. Prompts for model and reasoning effort, picks a sandbox mode, runs `codex exec` safely (stderr suppression, stdin-hang fix), and supports session resume. Requires the `codex` CLI installed and on `PATH`.
+
+```bash
+/autopilot:ask-codex                                   # Prompt for model + effort, run a Codex task
+/autopilot:ask-codex "audit auth flow for races"       # Seed the task description
+/autopilot:ask-codex "refactor parser" --model gpt-5.5 --effort high
+```
+
 ## Agents
 
 ### `pr:review:*` (11 agents)

--- a/claude-plugins/autopilot/skills/ask:codex/SKILL.md
+++ b/claude-plugins/autopilot/skills/ask:codex/SKILL.md
@@ -57,7 +57,7 @@ Parse `$ARGUMENTS` for an optional task description and optional `--model` / `--
 ## Following Up
 
 - After every `codex` command, use `AskUserQuestion` to confirm next steps, collect clarifications, or decide whether to resume.
-- When resuming, pipe the new prompt via stdin: `echo "new prompt" | codex exec resume --last 2>/dev/null`. The resumed session reuses the original model, effort, and sandbox.
+- When resuming, pipe the new prompt via stdin: `echo "new prompt" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. The resumed session reuses the original model, effort, and sandbox.
 - Restate the chosen model, reasoning effort, and sandbox mode when proposing follow-up actions.
 
 ## Critical Evaluation of Codex Output

--- a/claude-plugins/autopilot/skills/ask:codex/SKILL.md
+++ b/claude-plugins/autopilot/skills/ask:codex/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ask:codex
+description: Delegate a code analysis, refactoring, or automated-editing task to the OpenAI Codex CLI (codex exec / codex resume), then critically evaluate its output as a peer AI. Use when the user asks to run Codex, references OpenAI Codex, or wants a second model's take on the code.
+argument-hint: "[task description] [--model <model>] [--effort <xhigh|high|medium|low>]"
+allowed-tools:
+  - Bash(codex *)
+  - Bash(echo *)
+  - AskUserQuestion
+  - WebSearch
+  - Read
+---
+
+# Ask Codex
+
+Delegate a task to the OpenAI Codex CLI and report the result. Codex runs as a peer model — its output is evaluated critically, never accepted blindly.
+
+## When to Use
+
+- The user asks to run Codex (`codex exec`, `codex resume`) or references OpenAI Codex.
+- The user wants a second model's analysis, refactor, or automated edit of the code.
+
+Do NOT use for: git/PR workflows (use the other autopilot skills) or tasks that do not involve the Codex CLI.
+
+## Input
+
+Parse `$ARGUMENTS` for an optional task description and optional `--model` / `--effort` flags. Anything missing is collected in the next step.
+
+## Running a Task
+
+1. If model or effort was not supplied in `$ARGUMENTS`, ask the user (via `AskUserQuestion`, **one prompt with two questions**) which model (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, `gpt-5.3-codex`) and which reasoning effort (`xhigh`, `high`, `medium`, `low`).
+2. Select the sandbox mode; default to `--sandbox read-only` unless edits or network access are required.
+3. Assemble the command with the appropriate options:
+   - `-m, --model <MODEL>`
+   - `--config model_reasoning_effort="<xhigh|high|medium|low>"`
+   - `--sandbox <read-only|workspace-write|danger-full-access>`
+   - `--full-auto`
+   - `-C, --cd <DIR>`
+   - `--skip-git-repo-check`
+   - `"your prompt here"` (final positional argument)
+4. Always pass `--skip-git-repo-check`.
+5. Resume: continue a prior session with `echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. Insert any flags **between** `exec` and `resume`, and pass no config flags on resume unless the user explicitly requests them (the session inherits the original model, effort, and sandbox).
+6. **IMPORTANT**: append `2>/dev/null` to every `codex exec` command to suppress thinking tokens (stderr). Only show stderr when the user explicitly asks to see thinking tokens or for debugging.
+7. **IMPORTANT (stdin)**: `codex exec` always reads stdin and concatenates it with the positional prompt. If stdin is not closed, codex blocks forever. When stdin is not a TTY but also not closed (background tasks, hooks, scripts), append `</dev/null`, e.g. `codex exec ... "prompt" </dev/null 2>/dev/null`. Symptom of getting this wrong: zero bytes of stdout, zero CPU, process hangs.
+8. Run the command, capture stdout (filtered as appropriate), and summarize the outcome for the user.
+9. After Codex completes, tell the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
+
+### Quick Reference
+
+| Use case                       | Sandbox mode            | Key flags                                                                                |
+| ------------------------------ | ----------------------- | ---------------------------------------------------------------------------------------- |
+| Read-only review or analysis   | `read-only`             | `--sandbox read-only 2>/dev/null`                                                        |
+| Apply local edits              | `workspace-write`       | `--sandbox workspace-write --full-auto 2>/dev/null`                                      |
+| Permit network or broad access | `danger-full-access`    | `--sandbox danger-full-access --full-auto 2>/dev/null`                                   |
+| Resume recent session          | inherited from original | `echo "prompt" \| codex exec --skip-git-repo-check resume --last 2>/dev/null` (no flags) |
+| Run from another directory     | match task needs        | `-C <DIR>` plus other flags `2>/dev/null`                                                |
+
+## Following Up
+
+- After every `codex` command, use `AskUserQuestion` to confirm next steps, collect clarifications, or decide whether to resume.
+- When resuming, pipe the new prompt via stdin: `echo "new prompt" | codex exec resume --last 2>/dev/null`. The resumed session reuses the original model, effort, and sandbox.
+- Restate the chosen model, reasoning effort, and sandbox mode when proposing follow-up actions.
+
+## Critical Evaluation of Codex Output
+
+Codex is powered by OpenAI models with their own knowledge cutoffs and limitations. Treat Codex as a **colleague, not an authority**.
+
+- **Trust your own knowledge** when confident. If Codex claims something you know is wrong, push back directly.
+- **Research disagreements** with `WebSearch` or documentation before accepting Codex's claims.
+- **Remember knowledge cutoffs** — Codex may not know about recent releases, APIs, or changes.
+- **Don't defer blindly**, especially on model names/capabilities, recent library versions or API changes, and evolving best practices.
+
+When Codex is wrong: state the disagreement to the user, provide evidence, and optionally resume the session to discuss — identify yourself as Claude using your actual current model name, frame it as a peer discussion (either AI could be wrong), and let the user decide on genuine ambiguity:
+
+```bash
+echo "This is Claude (<your current model name>) following up. I disagree with [X] because [evidence]. What's your take?" | codex exec --skip-git-repo-check resume --last 2>/dev/null
+```
+
+## Error Handling
+
+- Stop and report failures whenever `codex --version` or a `codex exec` command exits non-zero; ask for direction before retrying.
+- Before using high-impact flags (`--full-auto`, `--sandbox danger-full-access`, `--skip-git-repo-check`) ask permission via `AskUserQuestion` unless already granted.
+- When output includes warnings or partial results, summarize them and ask how to adjust via `AskUserQuestion`.


### PR DESCRIPTION
Adds a new autopilot skill, /autopilot:ask-codex, that delegates a code-analysis, refactoring, or automated-editing task to the OpenAI Codex CLI and critically evaluates its output as a peer AI. Adapted from the community skills-directory/skill-codex plugin to follow autopilot's conventions.

- Add skills/ask:codex/SKILL.md with model/effort prompting, sandbox selection, safe stdin/stderr handling, and session resume
- Document the skill in the autopilot README skill catalog

---

**Issues:**

Closes #219

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->