### PR TITLE
HOTFIX: Fix Create release PR workflow crash during changelog generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@code-assistants",
+  "name": "@code-assistants/monorepo",
   "version": "0.1.0",
   "description": "Autopilot: plan, implement, commit, PR, and monitor — skills and agents for AI-assisted development workflows",
   "private": true,


### PR DESCRIPTION
The Create release PR workflow was crashing during changelog generation because the repository root `package.json` used an invalid npm scope name (`@code-assistants`, a scope with no `/name`). `conventional-changelog`'s `.readPackage()` normalizes that file via `normalize-package-data`, which throws `Invalid name: "@code-assistants"`. Since changelog generation always runs with the repo root as cwd, this blocked the release PR for every monorepo member.

- Renamed the root `package.json` `name` from `@code-assistants` to the valid scoped form `@code-assistants/monorepo`
- No behavioral change: `auto-label`'s `deriveLabelPrefix` still derives `code-assistants/` (scope-only), member discovery reads `workspaces` (not the root name), and the changelog still resolves the repository URL for commit links

---

**Release notes:**

- Fixed the Release workflow crashing during changelog generation, which blocked release PR creation

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->