### PR TITLE
Rerun AI code review when a pull request description is edited

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -15,7 +15,7 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -25,17 +25,26 @@ concurrency:
   # comment.id gives each comment its own group so bursty replies aren't cancelled;
   # it's empty for pull_request events, which stay grouped per-PR (event_name + number).
   group: code-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event.comment.id }}
-  cancel-in-progress: true
+  # Don't cancel on `edited`: a review run posts a run-summary footer to the PR body,
+  # which itself fires `pull_request: edited`. Cancelling there would let that bot edit
+  # abort the in-flight review (the new run then skips on the sender guard), leaving the
+  # PR with no review. Non-edited events still cancel so only the latest push is reviewed.
+  cancel-in-progress: ${{ github.event.action != 'edited' }}
 
 jobs:
   ai-review:
     # Skip events sent by the bot itself — its own review/inline comments would
     # otherwise spawn a no-op react-mode run each (the in-action guard skips them
     # only after the runner spins up). Filtering here keeps the run from starting.
+    # The trailing clause re-runs review when a PR title/body is edited, so a
+    # description fix clears a stale CHANGES_REQUESTED verdict without the prior
+    # close/reopen workaround (introduced de-facto by #233's alignment checks).
+    # Base retargets (changes.base) are skipped — a later push re-covers them.
     if: >-
       (github.event_name != 'issue_comment' || github.event.issue.pull_request)
       && vars.BOT_USERNAME != ''
       && github.event.sender.login != vars.BOT_USERNAME
+      && (github.event.action != 'edited' || github.event.changes.title || github.event.changes.body)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The AI code review workflow only re-runs on new commits, not on description edits. Since #233 the reviewer correctly blocks PRs whose description drifts from the actual diff, but fixing the description was invisible to the workflow — the stale `CHANGES_REQUESTED` verdict lingered until someone closed and reopened the PR (or pushed an unrelated commit). This makes a PR title or body edit re-run the review so a description-only fix clears the block on its own.

- Add `edited` to the `pull_request` trigger activity types in `.github/workflows/code-review.yml`
- Guard the `ai-review` job so an `edited` event re-runs only when `github.event.changes.title` or `github.event.changes.body` is present — base-branch retargets and other edits are ignored
- Scope `cancel-in-progress` to non-edited events: a review run posts a run-summary footer to the PR body, which itself fires `pull_request: edited`; without this, that bot edit would cancel the in-flight review (which then skips on the sender guard), leaving the PR with no review
- No action or sync change needed: `code-review-action` selects review mode from the event name (not the activity type), and `code-review-sync` propagates the workflow downstream verbatim

---

**Issues:**

Closes #235

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->