### PR TITLE
MAINTENANCE: Harden release-publish workflow against environment variable injection

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -40,10 +40,11 @@ jobs:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          delimiter="$(openssl rand -hex 16)"
           {
-            echo 'PR_CHANGED_FILES<<EOF'
+            echo "PR_CHANGED_FILES<<${delimiter}"
             gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename'
-            echo EOF
+            echo "${delimiter}"
           } >> "$GITHUB_ENV"
 
       - uses: awinogradov/code-assistants/.github/actions/release-action@main


### PR DESCRIPTION
The `release-publish` workflow built the multiline `PR_CHANGED_FILES` environment variable from attacker-influenceable PR filenames using a constant `EOF` heredoc delimiter. Under the `pull_request_target` trigger, a merged PR can carry a file path containing newline characters followed by a line reading `EOF` and then `LD_PRELOAD=...`, closing the heredoc early and appending arbitrary `$GITHUB_ENV` variables such as `LD_PRELOAD` or `BASH_ENV` — a critical environment-variable-injection vector flagged by CodeQL `actions/envvar-injection` ([code-scanning alert 6](https://github.com/awinogradov/code-assistants/security/code-scanning/6)).

- Generate a per-run random delimiter with `openssl rand -hex 16` and use it as the heredoc opener and closer, mirroring the existing `code-review-action` convention
- A 128-bit delimiter cannot be reproduced by a PR filename, so untrusted paths can no longer break out of `$GITHUB_ENV`
- Preserve the newline-separated `PR_CHANGED_FILES` contract consumed by `release-action` (`run.ts`) — no consumer change needed
- Verified with a parser-level repro (injection blocked; the old constant-`EOF` form injected) and the `release-action` test suite (325 pass)

Scope: resolves the critical env-var-injection finding only. The sibling `actions/untrusted-checkout` finding on the same workflow shares the `pull_request_target` root cause and remains as separately tracked residual risk.

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->