### PR TITLE
MAINTENANCE: Stop the AI review check showing skipped when a review ran

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -221,6 +221,18 @@ runs:
           exit 0
         fi
 
+        # Skip the bot's own pull_request events. updatePrFooter edits the PR body
+        # to add a help footer, which fires `pull_request: edited` as the reviewer
+        # bot. The workflow lets that event through its job `if:` so the ai-review
+        # check reports success here instead of a skipped run that would overshadow
+        # the real review's verdict — but without this guard the run would re-review
+        # and rewrite the footer. No-op to success rather than reviewing.
+        if [[ "$EVENT_NAME" == "pull_request" && -n "$INPUT_REVIEWER" && "$EVENT_SENDER" == "$INPUT_REVIEWER" ]]; then
+          echo "Skipping: pull_request event triggered by bot ($EVENT_SENDER)"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         # When react_to_comments is disabled, pass through explicit inputs
         if [[ "$INPUT_REACT_TO_COMMENTS" != "true" ]]; then
           echo "mode=${INPUT_MODE}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -33,17 +33,25 @@ concurrency:
 
 jobs:
   ai-review:
-    # Skip events sent by the bot itself — its own review/inline comments would
-    # otherwise spawn a no-op react-mode run each (the in-action guard skips them
-    # only after the runner spins up). Filtering here keeps the run from starting.
-    # The trailing clause re-runs review when a PR title/body is edited, so a
+    # The bot's own NON-edited events (its review and inline comments) are skipped
+    # here so they don't spawn a no-op react run — the in-action guard would skip
+    # them only after a runner spins up, so filtering at the job `if:` is cheaper.
+    #
+    # The bot's own `edited` events are deliberately NOT skipped: the action writes
+    # a help footer to the PR body (updatePrFooter), which fires `pull_request:
+    # edited` as the bot. Skipping that here produced a *skipped* ai-review check
+    # that overshadowed the real review's verdict. Letting it through lets the
+    # action's ctx step detect the bot sender and no-op every step, so the run
+    # reports success instead of "skipping".
+    #
+    # The last clause re-runs review when a user edits a PR title/body, so a
     # description fix clears a stale CHANGES_REQUESTED verdict without the prior
     # close/reopen workaround (introduced de-facto by #233's alignment checks).
     # Base retargets (changes.base) are skipped — a later push re-covers them.
     if: >-
       (github.event_name != 'issue_comment' || github.event.issue.pull_request)
       && vars.BOT_USERNAME != ''
-      && github.event.sender.login != vars.BOT_USERNAME
+      && (github.event.sender.login != vars.BOT_USERNAME || github.event.action == 'edited')
       && (github.event.action != 'edited' || github.event.changes.title || github.event.changes.body)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The AI code review check could read as skipped on a PR even though a review was posted and the verdict recorded. The reviewer bot adds an Available commands help footer to the PR body, which fires a `pull_request: edited` event as the bot; that spawned a second ai-review run which the job filter skipped, and because it was the latest run it overshadowed the real review status. The same path would surface a CHANGES_REQUESTED run as skipped too.

- Let the bot's own `pull_request: edited` events through the workflow job filter (sender is not the bot, OR the action is `edited`)
- Add a guard in the action's context-detection step so a bot-sender `pull_request` event resolves to a no-op that reports success, instead of re-running the review
- A real user title/body edit still triggers a fresh review (the behavior added to clear a stale CHANGES_REQUESTED verdict is preserved)
- Trade-off: the bot's one-time footer edit now spins a brief no-op run per PR so the ai-review check reads success instead of skipped

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->