### PR TITLE
MAINTENANCE: Resolve open code-scanning security alerts

### DIFF
--- a/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.test.ts
+++ b/.github/actions/agents-rules-sync/src/resolvePackageAgentsRules.test.ts
@@ -15,7 +15,7 @@ describe('resolvePackageAgentsRules', () => {
     expect(() => resolvePackageAgentsRules('not json')).toThrow(/not valid JSON/);
     expect(() => resolvePackageAgentsRules('not json')).toThrow(agentsFieldDocsUrl);
     for (const value of agentsRulesValues) {
-      expect(() => resolvePackageAgentsRules('not json')).toThrow(new RegExp(`"${value.replace(/\+/g, '\\+')}"`));
+      expect(() => resolvePackageAgentsRules('not json')).toThrow(`"${value}"`);
     }
   });
 
@@ -35,7 +35,7 @@ describe('resolvePackageAgentsRules', () => {
     const raw = JSON.stringify({ agents: { rules: 'Deno' } });
     expect(() => resolvePackageAgentsRules(raw)).toThrow(/Invalid `agents.rules`/);
     for (const value of agentsRulesValues) {
-      expect(() => resolvePackageAgentsRules(raw)).toThrow(new RegExp(`"${value.replace(/\+/g, '\\+')}"`));
+      expect(() => resolvePackageAgentsRules(raw)).toThrow(`"${value}"`);
     }
   });
 

--- a/.github/actions/release-action/README.md
+++ b/.github/actions/release-action/README.md
@@ -245,11 +245,9 @@ jobs:
           bot_username: ${{ vars.BOT_USERNAME }}
           npm_token: ${{ secrets.NPM_TOKEN }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
-        env:
-          PR_CHANGED_FILES: ${{ steps.changed.outputs.files }}
 ```
 
-`PR_CHANGED_FILES` is a newline-separated list of paths supplied by an upstream step (e.g., `gh pr view <N> --json files --jq '.files[].path'`). When the env variable is unset, the action falls back to `GITHUB_EVENT_PATH` and accepts a single-member PR shape.
+The action reads the merged PR's changed files itself — via `GITHUB_EVENT_PATH` (the GitHub event payload) and the GitHub API using `bot_token` — so no upstream step or extra environment configuration is required.
 
 ## Versioning
 

--- a/.github/actions/release-action/src/run.ts
+++ b/.github/actions/release-action/src/run.ts
@@ -179,16 +179,7 @@ async function runMonorepoPublish(cwd: string): Promise<void> {
     throw new Error("Publish invoked without monorepo discovery — check action.yml gating");
   }
 
-  // The PR file list is supplied via gh pr view in the workflow shell; the
-  // resolver supports either a `changedFiles` override (passed via env) or
-  // GITHUB_EVENT_PATH discovery. Read the env override here.
-  const overrideFiles = process.env.PR_CHANGED_FILES;
-  const changedFiles = overrideFiles
-    ? overrideFiles
-        .split("\n")
-        .map((line) => line.trim())
-        .filter(Boolean)
-    : await readChangedFiles({ cwd });
+  const changedFiles = await readChangedFiles({ cwd });
 
   const plan = await resolvePublishPlan({ cwd, changedFiles });
 

--- a/.github/actions/release-action/src/tickets/tickets.test.ts
+++ b/.github/actions/release-action/src/tickets/tickets.test.ts
@@ -481,6 +481,14 @@ describe("tickets", () => {
       expect(result).toContain('  title: "Fix \\"broken\\" thing"');
     });
 
+    test("escapes backslashes before quotes in titles", () => {
+      const result = serializePrDescriptionsToYaml([
+        { prNumber: 1, title: 'C:\\path "x"', content: "Fixed it", author: "dev" },
+      ]);
+
+      expect(result).toContain('  title: "C:\\\\path \\"x\\""');
+    });
+
     test("serializes multiple descriptions", () => {
       const result = serializePrDescriptionsToYaml([
         { prNumber: 1, title: "First", content: "Content 1", author: "dev1" },

--- a/.github/actions/release-action/src/tickets/tickets.test.ts
+++ b/.github/actions/release-action/src/tickets/tickets.test.ts
@@ -489,6 +489,14 @@ describe("tickets", () => {
       expect(result).toContain('  title: "C:\\\\path \\"x\\""');
     });
 
+    test("escapes backslashes in titles without quotes", () => {
+      const result = serializePrDescriptionsToYaml([
+        { prNumber: 1, title: 'C:\\path', content: "Fixed it", author: "dev" },
+      ]);
+
+      expect(result).toContain('  title: "C:\\\\path"');
+    });
+
     test("serializes multiple descriptions", () => {
       const result = serializePrDescriptionsToYaml([
         { prNumber: 1, title: "First", content: "Content 1", author: "dev1" },

--- a/.github/actions/release-action/src/tickets/tickets.ts
+++ b/.github/actions/release-action/src/tickets/tickets.ts
@@ -401,7 +401,7 @@ export function extractPrDescriptions(
 export function serializePrDescriptionsToYaml(descriptions: PrDescription[]): string {
   return descriptions
     .map((d) => {
-      const escapedTitle = d.title.replace(/"/g, '\\"');
+      const escapedTitle = d.title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       const indentedContent = d.content
         .split("\n")
         .map((line) => `    ${line}`)

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -35,18 +35,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
-      - name: Resolve changed files
-        env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          delimiter="$(openssl rand -hex 16)"
-          {
-            echo "PR_CHANGED_FILES<<${delimiter}"
-            gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename'
-            echo "${delimiter}"
-          } >> "$GITHUB_ENV"
-
       - uses: awinogradov/code-assistants/.github/actions/release-action@main
         with:
           mode: publish


### PR DESCRIPTION
Resolves four open GitHub code-scanning (CodeQL) alerts on the default branch — three incomplete-string-escaping findings and the critical environment-variable injection in the release-publish workflow.

- Alert 5 (release-action): escape backslashes before quotes when serializing PR titles to YAML, so a backslash in a title can no longer corrupt the double-quoted scalar (covered by combined and isolated backslash test cases)
- Alerts 3 and 4 (agents-rules-sync): assert error messages with a plain substring instead of a constructed RegExp, removing the incomplete +-only escaping
- Alert 8 (release-publish, critical): remove the step that wrote attacker-influenced PR filenames into $GITHUB_ENV; the action already resolves changed files via readChangedFiles, so the env override and its docs are dropped
- Alert 7 (untrusted-checkout) left as-is — it runs only post-merge against an already-merged commit, an accepted false positive
