### PR TITLE
MAINTENANCE: Harden release-publish against untrusted checkout

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,9 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Check out the default branch (github.sha), never the PR-controlled
+      # merge_commit_sha. This job is gated on `merged == true`, so the release
+      # commit (version + .release_notes) is already on the default branch.
+      # Checking out a PR-derived ref would run untrusted code in this privileged
+      # pull_request_target context (CodeQL actions/untrusted-checkout, CWE-829).
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - uses: awinogradov/code-assistants/.github/actions/release-action@main
         with:


### PR DESCRIPTION
Resolves a CodeQL `actions/untrusted-checkout/high` finding (CWE-829) in the release-publish workflow. The privileged `pull_request_target` job no longer checks out a pull-request-controlled ref, so untrusted fork code can no longer run with the repository's write token and secrets.

- Remove `ref: github.event.pull_request.merge_commit_sha` from the checkout step
- Check out the default branch (`github.sha`), which already contains the merged release commit because the job runs only when `merged == true`

Alert: https://github.com/awinogradov/code-assistants/security/code-scanning/9

---

**Release notes:**

- Hardened the release-publish workflow against untrusted code checkout in the privileged pull_request_target context (CodeQL CWE-829)

<!-- code-assistants-actions-help -->
---
<details>
<summary>Available commands 🤖</summary>
<br />

<!-- action:code-review-action -->
- `@symbiot-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
<!-- /action:code-review-action -->

</details>
<!-- /code-assistants-actions-help -->