### PR TITLE
Fix licenses audit action failing to load on dependency PRs

### DIFF
--- a/.github/actions/licenses-audit/action.yml
+++ b/.github/actions/licenses-audit/action.yml
@@ -4,7 +4,7 @@ description: Regenerate the license report on dependency-changing pull requests,
 inputs:
   bot_token:
     description: |
-      PAT (classic with `repo`, or fine-grained with `contents: write`) or GitHub App installation token used to check out the PR branch with persisted credentials and push the regenerated license report. The default `GITHUB_TOKEN` is not used: the auto-commit must be authored by and pushed as the bot identity so it carries correct attribution and re-triggers the PR's checks (commits pushed with `GITHUB_TOKEN` do not). Pass `${{ secrets.BOT_TOKEN }}`. Required: an empty value fails the push with no fallback.
+      PAT (classic with `repo`, or fine-grained with `contents: write`) or GitHub App installation token used to check out the PR branch with persisted credentials and push the regenerated license report. The default `GITHUB_TOKEN` is not used: the auto-commit must be authored by and pushed as the bot identity so it carries correct attribution and re-triggers the PR's checks (commits pushed with `GITHUB_TOKEN` do not). Pass the `secrets.BOT_TOKEN` secret. Required: an empty value fails the push with no fallback.
     required: true
   bot_username:
     description: |


### PR DESCRIPTION
The `licenses-audit` composite action failed to load because its `bot_token` input description embedded a live `${{ secrets.BOT_TOKEN }}` expression. GitHub evaluates `${{ }}` expressions when it loads a composite-action manifest, where the `secrets` context is unavailable, so the runner aborted at "Set up job" — failing the `Licenses` workflow's `Audit` job on every dependency-changing PR and, in turn, blocking `symbiot-bot` code review on those PRs.

- Replace the `${{ secrets.BOT_TOKEN }}` example in the `bot_token` description with plain-text `secrets.BOT_TOKEN`, matching how `release-automerge` and `upstream-sync` describe the same token
- Description text only — no change to the action's inputs, steps, outputs, or runtime behavior

---

**Release notes:**

- Fixed the licenses-audit action failing to load on pull requests that change dependency files

---

**Issues:**

Closes #254
