### PR TITLE
Add a pull request check to lint workflows and composite actions

### DIFF
--- a/.github/workflows/validate-actions.yml
+++ b/.github/workflows/validate-actions.yml
@@ -1,0 +1,23 @@
+name: Validate Actions
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+concurrency:
+  group: validate-actions-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: awinogradov/code-assistants/.github/actions/validate-actions@main

--- a/.github/workflows/validate-actions.yml
+++ b/.github/workflows/validate-actions.yml
@@ -8,7 +8,7 @@ on:
       - ".github/actions/**"
 
 concurrency:
-  group: validate-actions-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: validate-actions-${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Adds the thin `pull_request` workflow that runs the `validate-actions` action (merged in #253) over the GitHub Actions layer, so workflow-syntax and inline-shell mistakes are caught at PR time before they reach `main` and propagate downstream. This completes the two-PR delivery for #247.

- New `.github/workflows/validate-actions.yml`, triggered on PRs touching `.github/workflows/**` or `.github/actions/**`
- Delegates to `awinogradov/code-assistants/.github/actions/validate-actions@main` (the action is now on `main`, so the reference resolves and the workflow lints its own file on this PR)
- Fail-only, least-privilege (`contents: read`), scoped concurrency with `cancel-in-progress`

---

**Issues:**

Closes #247
