### PR TITLE
Attribute auto-label events to the project bot identity

### DIFF
--- a/.github/actions/auto-label/README.md
+++ b/.github/actions/auto-label/README.md
@@ -113,17 +113,17 @@ jobs:
     steps:
       - uses: awinogradov/code-assistants/.github/actions/auto-label@v1
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.BOT_TOKEN }}
 ```
 
 ## Inputs
 
-| Input                        | Required | Default                            | Description                                                                                                                           |
-| ---------------------------- | -------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `token`                      | yes      | —                                  | Token with `pull-requests: write` + `issues: write`. The default `GITHUB_TOKEN` is sufficient (read-only on fork PRs — see Behavior). |
-| `label-prefix`               | no       | _(derived)_                        | Override the auto-derived prefix. Empty → derived from the root `package.json` `name` scope. A trailing `/` is added when missing.    |
-| `label-color`                | no       | `5319e7`                           | Hex color (no leading `#`) for labels the action creates.                                                                             |
-| `label-description-template` | no       | `Auto-applied: PR touches {label}` | Template for created label descriptions. `{label}` is replaced with the label name.                                                   |
+| Input                        | Required | Default                            | Description                                                                                                                                                                                                                                                                                         |
+| ---------------------------- | -------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `token`                      | yes      | —                                  | Token with `pull-requests: write` + `issues: write`. Pass `${{ secrets.BOT_TOKEN }}` (a PAT or App token) so label events are attributed to the bot identity, not `github-actions[bot]`. Required — an empty value fails the label API calls with HTTP 401. Unavailable on fork PRs (see Behavior). |
+| `label-prefix`               | no       | _(derived)_                        | Override the auto-derived prefix. Empty → derived from the root `package.json` `name` scope. A trailing `/` is added when missing.                                                                                                                                                                  |
+| `label-color`                | no       | `5319e7`                           | Hex color (no leading `#`) for labels the action creates.                                                                                                                                                                                                                                           |
+| `label-description-template` | no       | `Auto-applied: PR touches {label}` | Template for created label descriptions. `{label}` is replaced with the label name.                                                                                                                                                                                                                 |
 
 ## Permissions
 
@@ -148,6 +148,11 @@ against a conservative charset/length before use.
 
 ## Notes
 
+- **`BOT_TOKEN` is required.** The synced `auto-label.yml` passes `${{ secrets.BOT_TOKEN }}` so label
+  events are attributed to the project bot rather than `github-actions[bot]`. Consumers MUST configure
+  a `BOT_TOKEN` secret (a PAT or GitHub App token with `pull-requests: write` + `issues: write`);
+  without it the job fails with HTTP 401. Secrets are not exposed to fork PRs, which is also why the
+  job is gated behind the fork check.
 - **Scope the triggers.** The mode is chosen from `github.event_name`, so a `push` to _any_ branch
   would run prune. Consumers MUST filter `push: branches: [<default>]` (and `pull_request:
 branches`) so prune only runs on the default branch.

--- a/.github/actions/auto-label/action.yml
+++ b/.github/actions/auto-label/action.yml
@@ -4,7 +4,7 @@ description: Label pull requests with `<scope>/<workspace-member>` labels based 
 inputs:
   token:
     description: |
-      GitHub token with `pull-requests: write` and `issues: write` (the latter covers repo-level label management). The workflow's default `GITHUB_TOKEN` is sufficient; on fork PRs it is read-only, so gate the calling job behind a fork check.
+      GitHub token with `pull-requests: write` and `issues: write` (the latter covers repo-level label management). Pass `${{ secrets.BOT_TOKEN }}` (a PAT or GitHub App token) so the label add/remove/create/delete events are attributed to the bot identity that owns the token — attribution is derived from the token's owner, so no separate `BOT_USERNAME` is needed. The default `GITHUB_TOKEN` would attribute every label event to `github-actions[bot]` instead. Required: an empty value fails the label API calls with HTTP 401 and no fallback. Secrets are unavailable on fork PRs, so gate the calling job behind a fork check.
     required: true
   label-prefix:
     description: |

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -29,11 +29,14 @@ permissions:
 jobs:
   auto-label:
     name: Auto label
-    # Fork PRs run with a read-only token and cannot write labels; skip them.
+    # Fork PRs cannot access secrets.BOT_TOKEN (and run with a read-only token); skip them.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: awinogradov/code-assistants/.github/actions/auto-label@main
         with:
-          token: ${{ github.token }}
+          # Pass the bot token so label events are attributed to the project bot
+          # identity, not github-actions[bot]. BOT_TOKEN is required: an empty
+          # value fails the label API calls with HTTP 401 (no fallback).
+          token: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
The auto-label workflow authenticated with the default `GITHUB_TOKEN`, so every label add/remove/create/delete event showed up as `github-actions[bot]` instead of the project bot — splitting the PR audit trail from the bot identity used for commits, license audits, and repomix packs. It now authenticates with `secrets.BOT_TOKEN`, matching `repomix-pack.yml` and `licenses.yml` so every automated mutation shares one intentional author.

- Pass `secrets.BOT_TOKEN` to the auto-label action instead of `github.token` in `auto-label.yml`
- Rewrite the `action.yml` `token` input description to explain bot attribution (no separate `BOT_USERNAME` is needed — attribution is derived from the token owner)
- Document in the README that `BOT_TOKEN` is mandatory and that fork PRs stay gated by the existing fork check because secrets are not exposed to them

**Breaking change & migration:** This is a breaking change for downstream repositories — `auto-label.yml` is distributed verbatim by `contributing-sync`, and Option A makes `BOT_TOKEN` mandatory. Repos that sync the workflow must, when they pick up this change, create a `BOT_TOKEN` repository secret (a PAT — classic with `repo`, or fine-grained with `pull-requests: write` + `issues: write` — or a GitHub App installation token); no protected-branch bypass actor is required because auto-label only calls the GitHub API and never pushes. Without the secret the job fails with HTTP 401 (the `token` input is required and has no fallback). Fork PRs are unaffected: the job is already gated behind the fork check, and secrets are never exposed to fork runs.

**Why Option A (hard switch) instead of the issue's recommended Option B:** Option B (`${{ secrets.BOT_TOKEN || github.token }}`) silently falls back to `github.token` when the secret is unset, reintroducing the `github-actions[bot]` attribution that #267 exists to remove and masking a missing-secret misconfiguration as a passing run. Option A makes the bot identity mandatory and the failure loud, so every consumer's label events carry one intentional author — a deliberate maintainer decision.

---

**Release notes:**

- BREAKING: auto-label now requires a `BOT_TOKEN` secret (with `pull-requests: write` + `issues: write`); downstream repos syncing `auto-label.yml` must configure it or the job fails. Label add/remove/create/delete events are now attributed to the project bot (`BOT_USERNAME`) instead of `github-actions[bot]`.

---

**Issues:**

Closes #267
