### PR TITLE
Restore Auto label action so it loads and runs again

### DIFF
--- a/.github/actions/auto-label/action.yml
+++ b/.github/actions/auto-label/action.yml
@@ -4,7 +4,7 @@ description: Label pull requests with `<scope>/<workspace-member>` labels based 
 inputs:
   token:
     description: |
-      GitHub token with `pull-requests: write` and `issues: write` (the latter covers repo-level label management). Pass `${{ secrets.BOT_TOKEN }}` (a PAT or GitHub App token) so the label add/remove/create/delete events are attributed to the bot identity that owns the token — attribution is derived from the token's owner, so no separate `BOT_USERNAME` is needed. The default `GITHUB_TOKEN` would attribute every label event to `github-actions[bot]` instead. Required: an empty value fails the label API calls with HTTP 401 and no fallback. Secrets are unavailable on fork PRs, so gate the calling job behind a fork check.
+      GitHub token with `pull-requests: write` and `issues: write` (the latter covers repo-level label management). Pass the `secrets.BOT_TOKEN` secret (a PAT or GitHub App token) so the label add/remove/create/delete events are attributed to the bot identity that owns the token — attribution is derived from the token's owner, so no separate `BOT_USERNAME` is needed. The default `GITHUB_TOKEN` would attribute every label event to `github-actions[bot]` instead. Required: an empty value fails the label API calls with HTTP 401 and no fallback. Secrets are unavailable on fork PRs, so gate the calling job behind a fork check.
     required: true
   label-prefix:
     description: |


### PR DESCRIPTION
The Auto label action has failed to load on every push to main since PR #270, so pull requests stopped receiving their `<scope>/<workspace-member>` labels and each push left a red check. GitHub evaluates `${{ }}` expressions throughout a composite action manifest — including input `description` scalars — but the `secrets` context exists only in workflow files, so `${{ secrets.BOT_TOKEN }}` made the manifest fail to load with `Unrecognized named-value: 'secrets'` before any step ran.

- Dropped the `${{ }}` wrapper around `secrets.BOT_TOKEN` in the `token` input description, keeping the secret name as inert backtick text
- Mirrors the earlier `licenses-audit` fix for the same failure class; no action behavior changes

---

**Release notes:**

- Fixed the Auto label action failing to load on every push, so pull requests receive their workspace-member labels again

---

**Issues:**

Closes #276
