### PR TITLE
Apply RFC-0001 reference formatting to generated PR descriptions and release notes

### DIFF
--- a/.github/actions/code-review-action/src/prBodyReferenceFormatting.test.ts
+++ b/.github/actions/code-review-action/src/prBodyReferenceFormatting.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Guards that the body-generation phases of the pr:create and pr:update autopilot
+ * skills explicitly instruct the model to apply the inlined reference-formatting
+ * rules (RFC-0001). Both skills already inline the canonical block — the
+ * referenceFormattingSync test guards that copy stays byte-identical — but inlining
+ * alone never made the generators apply it, so generated PR bodies escaped the
+ * standard (issue #279).
+ *
+ * This is a presence-guard: it asserts the apply-instruction survives in the
+ * instructions ABOVE the inlined block, so the wiring cannot be silently dropped. It
+ * reads only the text before the `<!-- ref-format:start -->` sentinel — the inlined
+ * block itself contains reference-formatting prose, so including it would let the
+ * block satisfy the assertion by accident. A missing sentinel fails loudly rather
+ * than degrading the slice into a near-whole-file match.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+// Depth mirrors referenceFormattingSync.test.ts in this directory — a move of the
+// action updates both in lockstep.
+const actionDir = join(import.meta.dirname, "..");
+const repoRoot = join(actionDir, "..", "..", "..");
+const skillsDir = join(repoRoot, "claude-plugins/autopilot/skills");
+
+const startSentinel = "<!-- ref-format:start -->";
+// Load-bearing phrase: the apply-instruction each skill carries in its body-
+// generation phase. Reword it only alongside this test.
+const applyInstruction = "reference-formatting rules inlined at the end";
+
+const skills = ["pr:create", "pr:update"];
+
+describe("PR body reference-formatting wiring", () => {
+  test.each(skills)("%s instructs the body generator to apply RFC-0001", async (skill) => {
+    const content = await readFile(join(skillsDir, skill, "SKILL.md"), "utf8");
+    const blockStart = content.indexOf(startSentinel);
+    expect(blockStart).toBeGreaterThan(-1);
+    expect(content.slice(0, blockStart)).toContain(applyInstruction);
+  });
+});

--- a/claude-plugins/autopilot/skills/pr:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:create/SKILL.md
@@ -159,6 +159,8 @@ If the agent reports breaking changes, treat `--release-notes` as mandatory — 
 
 ## Phase 4: Generate PR Description
 
+**Reference formatting (MANDATORY):** The generated body — both the description and the release-notes section — MUST follow the reference-formatting rules inlined at the end of this skill. The rule that keeps regressing: render every mention of a standard consistently as a link to its versioned RFC by stable ID (e.g., `[RFC-0001](<repo-blob-url>/rfc/0001-reference-formatting.md)`), never a mix of bare text and links in the same body.
+
 The PR body uses `---` separators to divide three sections: description, release notes (optional), and issue links.
 
 **CRITICAL — Section ordering is MANDATORY and MUST NOT be rearranged:**

--- a/claude-plugins/autopilot/skills/pr:update/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:update/SKILL.md
@@ -175,6 +175,8 @@ Tool parameters:
 
 ### PR Body
 
+**Reference formatting (MANDATORY):** The generated body — both the description and the release-notes section — MUST follow the reference-formatting rules inlined at the end of this skill. The rule that keeps regressing: render every mention of a standard consistently as a link to its versioned RFC by stable ID (e.g., `[RFC-0001](<repo-blob-url>/rfc/0001-reference-formatting.md)`), never a mix of bare text and links in the same body.
+
 The PR body uses `---` separators to divide three sections: description, release notes (optional), and issue links.
 
 **CRITICAL — Section ordering is MANDATORY and MUST NOT be rearranged:**


### PR DESCRIPTION
`pr:create` and `pr:update` inline the [RFC-0001](https://github.com/awinogradov/code-assistants/blob/main/rfc/0001-reference-formatting.md) reference-formatting block verbatim, but their body-generation steps never instructed the model to apply it — so generated PR descriptions and release notes escaped the standard (it surfaced on 268, whose body rendered the standard three times linked and three times bare). This wires an explicit apply-instruction into each skill's body-generation step and guards it with a test, the same gap class that 259 closed for the reply surfaces.

- Add a reference-formatting instruction to `pr:create` Phase 4 and `pr:update` PR Body generation, calling out the always-link-the-versioned-[RFC-0001](https://github.com/awinogradov/code-assistants/blob/main/rfc/0001-reference-formatting.md) rule that keeps regressing
- Add `prBodyReferenceFormatting.test.ts`, which asserts both skills carry the instruction above the inlined block (reading only the text before the `<!-- ref-format:start -->` sentinel) so the wiring cannot silently regress

---

**Release notes:**

- Generated PR descriptions and release notes now follow the [RFC-0001](https://github.com/awinogradov/code-assistants/blob/main/rfc/0001-reference-formatting.md) reference-formatting standard

---

**Issues:**

Closes #279
