### PR TITLE
Document the canonical TODO and FIXME comment format for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -574,6 +574,41 @@ Closes #400
 
 See [`CLAUDE.md`](./CLAUDE.md) for the full coding-standards matrix, and the Documentation section of [`README.md`](./README.md) for project-specific docs.
 
+### TODO Comments
+
+Deferred work is tracked with issue-linked `TODO`/`FIXME` comments so it never gets lost and stale comments can be retired.
+
+| Marker  | Meaning             |
+| ------- | ------------------- |
+| `TODO`  | Planned improvement |
+| `FIXME` | Known defect        |
+
+**Rules:**
+
+- Uppercase keyword, colon + single space: `// TODO: <description>`
+- Link the tracking issue with `// @see <issue-url>` on the line immediately below — use the full issue URL, never a bare `#123` in the description (scanners misread it as already linked)
+- Do not place a TODO directly above a JSDoc block containing an unrelated `@see` — scanners read the following lines for the issue link
+- Remove the comment and its `@see` line when the issue closes
+- Do not use `XXX`, `HACK`, or `NOTE` markers
+
+**Examples:**
+
+✅ Linked TODO:
+
+```typescript
+// TODO: validate env vars at startup
+// @see https://github.com/<owner>/<repo>/issues/<number>
+```
+
+❌ Untracked or unparseable:
+
+```typescript
+// HACK: works around #45
+// todo fix later
+```
+
+> TIP: Use the `/autopilot:todo-cleanup` slash command to scan TODOs, create issues, and link them automatically.
+
 ## Getting Help
 
 - **Questions** — open a [GitHub Discussion](https://github.com/awinogradov/code-assistants/discussions)

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -299,6 +299,11 @@ Choose ONE backend based on the project's needs. Do not mix.
 - 👤 Avoid link to exact lines of code
 - 👤 Focus on "why" and "how to use", not "what"
 - 👤 Avoid duplicates comments — it means code must be refactored
+- 👤 Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
+- 👤 Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
+- 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
+- 👤 Remove the TODO and its `@see` line when the linked issue closes
+- 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ## 12. Performance
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -173,6 +173,11 @@ Before making any changes:
 - 👤 Avoid link to exact lines of code
 - 👤 Focus on "why" and "how to use", not "what"
 - 👤 Avoid duplicates comments — it means code must be refactored
+- 👤 Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
+- 👤 Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
+- 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
+- 👤 Remove the TODO and its `@see` line when the linked issue closes
+- 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ## 12. Performance
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -290,6 +290,11 @@ Before making any changes:
 - 👤 Avoid link to exact lines of code
 - 👤 Focus on "why" and "how to use", not "what"
 - 👤 Avoid duplicates comments — it means code must be refactored
+- 👤 Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
+- 👤 Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
+- 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
+- 👤 Remove the TODO and its `@see` line when the linked issue closes
+- 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ## 12. Performance
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -286,6 +286,11 @@ Before making any changes:
 - 👤 Avoid link to exact lines of code
 - 👤 Focus on "why" and "how to use", not "what"
 - 👤 Avoid duplicates comments — it means code must be refactored
+- 👤 Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
+- 👤 Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
+- 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
+- 👤 Remove the TODO and its `@see` line when the linked issue closes
+- 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ## 12. Performance
 


### PR DESCRIPTION
Contributors had no documented TODO comment format, while the autopilot TODO machinery (the todo-cleanup skill and its scanning agents) only manages comments of a specific shape. This PR documents that shape in the places contributors actually read.

- Added five TODO/FIXME format bullets to the "Code comments" section of all four `rules/*.md` stack rule sets (byte-identical across the four — all are TypeScript stacks): only `TODO`/`FIXME` markers, `// TODO: <description>` with uppercase keyword and colon + single space, a full-URL `// @see <issue-url>` link on the line immediately below, and removal when the linked issue closes
- Added a "TODO Comments" subsection to CONTRIBUTING.md with a marker/meaning table, lifecycle rules, good/bad examples, and a tip pointing to the todo-cleanup slash command
- `CLAUDE.md` is intentionally untouched — it is auto-synced from `rules/Bun.md`

---

**Issues:**

Closes #296