### PR TITLE
Render the review run summary in smaller text

### DIFF
--- a/.github/actions/code-review-action/src/runSummaryFooter.test.ts
+++ b/.github/actions/code-review-action/src/runSummaryFooter.test.ts
@@ -79,15 +79,23 @@ describe("renderRunSummaryFooter", () => {
   });
 
   test("keeps the blank line after <br /> so the table renders inside <details>", () => {
-    expect(renderRunSummaryFooter(coreSummary, reviewer)).toContain("<br />\n\n| Metric | Value |");
+    expect(renderRunSummaryFooter(coreSummary, reviewer)).toContain(
+      "<br />\n\n| <sub>Metric</sub> | <sub>Value</sub> |",
+    );
   });
 
-  test("formats durations as seconds and cost as USD", () => {
+  test("keeps the delimiter row free of <sub> so the table parses", () => {
     const footer = renderRunSummaryFooter(coreSummary, reviewer);
-    expect(footer).toContain("| Model time | 34.0s |");
-    expect(footer).toContain("| Cost (USD) | $0.35 |");
-    expect(footer).toContain("| Tokens in / out | 500 / 100 |");
-    expect(footer).toContain("| Cache read / write | 400 / 20 |");
+    expect(footer).toContain("\n| --- | --- |\n");
+    expect(footer).not.toContain("<sub>---");
+  });
+
+  test("formats durations as seconds and cost as USD in <sub> cells", () => {
+    const footer = renderRunSummaryFooter(coreSummary, reviewer);
+    expect(footer).toContain("| <sub>Model time</sub> | <sub>34.0s</sub> |");
+    expect(footer).toContain("| <sub>Cost (USD)</sub> | <sub>$0.35</sub> |");
+    expect(footer).toContain("| <sub>Tokens in / out</sub> | <sub>500 / 100</sub> |");
+    expect(footer).toContain("| <sub>Cache read / write</sub> | <sub>400 / 20</sub> |");
   });
 
   test("renders no fan-out rows (single-pass review)", () => {

--- a/.github/actions/code-review-action/src/runSummaryFooter.ts
+++ b/.github/actions/code-review-action/src/runSummaryFooter.ts
@@ -68,7 +68,18 @@ function formatSeconds(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
-/** Build the markdown metric rows for the single-pass review run. */
+/**
+ * Render one table row with each cell wrapped in `<sub>` so GitHub draws the
+ * run diagnostics in its smaller font, de-emphasizing them relative to the
+ * review findings. The wrapping is per cell because GFM stops parsing a pipe
+ * table that is wrapped in `<sub>` as a whole; cell values are trusted
+ * internal metrics, so no HTML escaping is needed.
+ */
+function formatSubRow(label: string, value: string): string {
+  return `| <sub>${label}</sub> | <sub>${value}</sub> |`;
+}
+
+/** Build the `<sub>`-wrapped markdown metric rows for the single-pass review run. */
 function buildRows(summary: RunSummary): string[] {
   const rows = [
     ["Mode", summary.mode],
@@ -80,13 +91,15 @@ function buildRows(summary: RunSummary): string[] {
     ["Cost (USD)", `$${summary.cost_usd.toFixed(2)}`],
   ];
 
-  return rows.map(([label, value]) => `| ${label} | ${value} |`);
+  return rows.map(([label, value]) => formatSubRow(label, value));
 }
 
 /**
  * Render the run-summary footer: a visible `@<reviewer>` usage hint followed by
  * the marker-wrapped, collapsible metrics block (built from the shared
- * {@link buildMarkedDetailsBlock} helper).
+ * {@link buildMarkedDetailsBlock} helper). The table cells render in `<sub>`
+ * small text (see {@link formatSubRow}) so the diagnostics stay visually
+ * secondary to the review content.
  *
  * The hint is stable text and sits *outside* the strip markers so it survives
  * {@link stripRunSummaryFooter} and stays in the comment after dedup; only the
@@ -105,7 +118,8 @@ export function renderRunSummaryFooter(summary: RunSummary, reviewer: string): s
       startMarker: footerStartMarker,
       endMarker: footerEndMarker,
       summary: "Review run summary 🤖",
-      bodyLines: ["| Metric | Value |", "| --- | --- |", ...buildRows(summary)],
+      // The delimiter row stays bare: wrapping it in <sub> breaks GFM table parsing.
+      bodyLines: [formatSubRow("Metric", "Value"), "| --- | --- |", ...buildRows(summary)],
     }),
   ].join("\n");
 }

--- a/docs/03-code-review-run-summary.md
+++ b/docs/03-code-review-run-summary.md
@@ -61,7 +61,7 @@ The metrics are computed in one process (`runClaude.ts`) and rendered in another
 
 ## Rendered footer
 
-`renderRunSummaryFooter` emits a visible `@<reviewer>` usage hint followed by the collapsible metrics block. The hint is stable text and sits **outside** the strip markers so it survives dedup stripping and stays in the comment; only the run-varying metrics are marker-bounded. Inside the block, the start marker sits directly above the `---` rule, and a blank line after `<br />` lets the GitHub-flavored markdown table render inside `<details>`.
+`renderRunSummaryFooter` emits a visible `@<reviewer>` usage hint followed by the collapsible metrics block. The hint is stable text and sits **outside** the strip markers so it survives dedup stripping and stays in the comment; only the run-varying metrics are marker-bounded. Inside the block, the start marker sits directly above the `---` rule, and a blank line after `<br />` lets the GitHub-flavored markdown table render inside `<details>`. Every table cell is wrapped in `<sub>` so the diagnostics render in GitHub's smaller font and stay visually secondary to the review findings — per cell, not around the table, because GFM stops parsing a pipe table wrapped in inline HTML, and the `| --- | --- |` delimiter row stays bare for the same reason (GitHub also strips `style`/`class`, so `<sub>` is the only sanctioned small-text treatment).
 
 ```text
 > 💡 `@review-bot <comment>` — Ask the AI reviewer a question or request changes. Replies inside a review thread the bot already opened don't need the mention.
@@ -72,15 +72,15 @@ The metrics are computed in one process (`runClaude.ts`) and rendered in another
 <summary>Review run summary 🤖</summary>
 <br />
 
-| Metric | Value |
+| <sub>Metric</sub> | <sub>Value</sub> |
 | --- | --- |
-| Mode | review |
-| Model time | 34.0s |
-| Tool round-trips | 10 |
-| Assistant turns | 3 |
-| Tokens in / out | 157825 / 36705 |
-| Cache read / write | 157000 / 800 |
-| Cost (USD) | $0.35 |
+| <sub>Mode</sub> | <sub>review</sub> |
+| <sub>Model time</sub> | <sub>34.0s</sub> |
+| <sub>Tool round-trips</sub> | <sub>10</sub> |
+| <sub>Assistant turns</sub> | <sub>3</sub> |
+| <sub>Tokens in / out</sub> | <sub>157825 / 36705</sub> |
+| <sub>Cache read / write</sub> | <sub>157000 / 800</sub> |
+| <sub>Cost (USD)</sub> | <sub>$0.35</sub> |
 
 </details>
 <!-- run-summary-end -->


### PR DESCRIPTION
The review run summary footer rendered its metrics table at the same visual size as the review findings, pulling attention from what matters. Every table cell is now wrapped in `<sub>` so GitHub draws the per-run diagnostics in its smaller font while the pipe table still parses.

- Added a `formatSubRow` helper in `runSummaryFooter.ts` that wraps each header and metric cell in `<sub>`; the `| --- | --- |` delimiter row stays bare because GFM stops parsing a pipe table wrapped in inline HTML (GitHub strips `style`/`class`, so `<sub>` is the only sanctioned small-text treatment)
- Both the review comment and the preflight skip comment pick up the treatment automatically — they share `renderRunSummaryFooter`
- Dedup stripping is unaffected: `stripRunSummaryFooter` keys off the run-summary markers, not cell content
- Verified through GitHub's markdown render API that the new footer parses to a real table with `<sub>` cells
- Updated test expectations and added a guard test asserting the delimiter row stays free of `<sub>`

---

**Release notes:**

- Review run summary metrics now render in smaller text, keeping the visual focus on review findings

---

**Issues:**

Closes #281