### PR TITLE
Add ban-patterns composite action for declarative CI pattern bans

### DIFF
--- a/.github/actions/ban-patterns/README.md
+++ b/.github/actions/ban-patterns/README.md
@@ -1,0 +1,103 @@
+# Ban patterns
+
+Composite GitHub Action that greps the working tree for consumer-supplied forbidden regex
+patterns and fails the job with an `::error::` annotation when any pattern matches. It replaces
+copy-pasted "ban X pattern" inline workflow steps (like the time-based-waits check from
+[symbiot PR 140](https://github.com/awinogradov/symbiot/pull/140)) with a single declarative
+`uses:` line, so the rule set lives in workflow inputs instead of opaque shell.
+
+## Usage
+
+The action greps files already on disk — run `actions/checkout` first.
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ban-patterns:
+    name: Ban patterns
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ban time-based waits in features
+        uses: awinogradov/code-assistants/.github/actions/ban-patterns@main
+        with:
+          paths: features/
+          include-globs: |
+            *.feature
+            *.ts
+          patterns: |
+            ^\s*(And |Given |When |Then )?I (wait|pause|sleep)( |$)
+            waitForTimeout\(
+            (^|[^.])setTimeout\(
+            globalThis\.setTimeout\(
+          error-message: Time-based waits are banned in features/. See features/README.md.
+          issue-link: https://github.com/awinogradov/symbiot/issues/131
+```
+
+## Inputs
+
+| Input           | Required | Default                 | Description                                                                                                                                                                                        |
+| --------------- | -------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `patterns`      | Yes      | —                       | Newline-separated list of extended (ERE) regex patterns to ban. Blank lines are ignored. The action fails explicitly when the list is empty — GitHub does not enforce `required: true` at runtime. |
+| `paths`         | No       | `.`                     | Newline-separated list of files or directories to search. Blank lines are ignored.                                                                                                                 |
+| `include-globs` | No       | _(empty — all files)_   | Newline-separated list of file globs passed to grep as `--include` filters (e.g. `*.ts`). Globs match the file **basename** only — scope directories via `paths`.                                  |
+| `error-message` | No       | `Banned pattern found.` | Single-line message emitted in the error annotation when any pattern matches.                                                                                                                      |
+| `issue-link`    | No       | _(empty)_               | URL appended to the error annotation pointing at the rule's rationale.                                                                                                                             |
+
+Patterns are GNU grep EREs as run on `ubuntu-latest` runners, so GNU extensions like `\s` and
+`\b` work. Inside a YAML block scalar (`patterns: |`) no extra escaping is needed — write the
+regex exactly as you would on a grep command line.
+
+## Outputs
+
+| Output | Description                                                                                                             |
+| ------ | ----------------------------------------------------------------------------------------------------------------------- |
+| _none_ | The action signals violations through job status. Matches surface in the step log and as an error annotation on the PR. |
+
+## Permissions
+
+The workflow's default `GITHUB_TOKEN` is sufficient — the action itself makes no API calls and
+never writes to the repository:
+
+- `contents: read` — `actions/checkout` needs it to put the files on disk for grep.
+
+## Behavior
+
+The action runs a single `shell: bash` step:
+
+1. Fails with `::error::` if `patterns` is empty or whitespace-only (runtime guard, since
+   `required: true` is documentation-only for actions).
+2. Runs `grep -rIEn --exclude-dir=.git --exclude-dir=node_modules` once per pattern across all
+   `paths`, applying any `include-globs`. Binary files are skipped.
+3. Scans **all** patterns before failing, so one run reports every violation.
+4. On any match: prints the matching `file:line:content` hits (wrapped in a
+   [`::stop-commands::` guard](https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#stopping-and-starting-workflow-commands)
+   so matched file content cannot inject workflow commands), then emits
+   `::error::<error-message> See <issue-link>` (the ` See <issue-link>` suffix is omitted when
+   `issue-link` is empty) and exits 1.
+5. A grep failure other than "no match" — invalid regex, unreadable or missing path — fails the
+   job with its own distinct `::error::` annotation instead of silently passing.
+
+All inputs reach the script through environment variables, never shell interpolation, so a
+hostile pattern or path cannot inject commands.
+
+## Versioning
+
+Reference the action by tag of the autopilot repo, e.g.:
+
+```yaml
+uses: awinogradov/code-assistants/.github/actions/ban-patterns@v1
+```
+
+Consumers may also reference `@main` to always pick up the latest behavior. The input set and
+the default scan scope are treated as a frozen API: changes are additive only, and any
+behavior-changing default ships behind a new opt-in input.

--- a/.github/actions/ban-patterns/action.yml
+++ b/.github/actions/ban-patterns/action.yml
@@ -1,0 +1,88 @@
+name: Ban patterns
+description: Fail the job with an error annotation when forbidden regex patterns match files in the working tree. Patterns, paths, and globs are consumer-supplied and passed through env vars so they are never shell-interpolated.
+
+inputs:
+  patterns:
+    description: |
+      Newline-separated list of extended (ERE) regex patterns to ban. Blank lines are ignored.
+      GitHub does not enforce `required: true` at runtime, so the action fails explicitly when
+      the list is empty or whitespace-only.
+    required: true
+  paths:
+    description: |
+      Newline-separated list of files or directories to search. Blank lines are ignored.
+      Defaults to the whole working tree.
+    required: false
+    default: "."
+  include-globs:
+    description: |
+      Newline-separated list of file globs passed to grep as `--include` filters (e.g. `*.ts`).
+      Globs match the file basename only — scope directories via `paths`. Blank lines are
+      ignored. Empty means all files.
+    required: false
+    default: ""
+  error-message:
+    description: Single-line message emitted in the error annotation when any pattern matches.
+    required: false
+    default: "Banned pattern found."
+  issue-link:
+    description: URL appended to the error annotation pointing at the rule's rationale.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Scan for banned patterns
+      shell: bash
+      env:
+        PATTERNS: ${{ inputs.patterns }}
+        SEARCH_PATHS: ${{ inputs.paths }}
+        INCLUDE_GLOBS: ${{ inputs.include-globs }}
+        ERROR_MESSAGE: ${{ inputs.error-message }}
+        ISSUE_LINK: ${{ inputs.issue-link }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$(printf '%s' "$PATTERNS" | tr -d '[:space:]')" ]; then
+          echo "::error::ban-patterns: the patterns input is required and cannot be empty."
+          exit 1
+        fi
+
+        include_args=()
+        while IFS= read -r glob; do
+          [ -n "$glob" ] && include_args+=("--include=$glob")
+        done <<< "$INCLUDE_GLOBS"
+
+        search_paths=()
+        while IFS= read -r path; do
+          [ -n "$path" ] && search_paths+=("$path")
+        done <<< "$SEARCH_PATHS"
+        [ "${#search_paths[@]}" -gt 0 ] || search_paths=(".")
+
+        violations=""
+        while IFS= read -r pattern; do
+          [ -n "$pattern" ] || continue
+          status=0
+          matches="$(grep -rIEn --exclude-dir=.git --exclude-dir=node_modules \
+            ${include_args[@]+"${include_args[@]}"} -e "$pattern" -- "${search_paths[@]}")" || status=$?
+          if [ "$status" -eq 0 ]; then
+            violations+="Pattern '$pattern' matched:"$'\n'"$matches"$'\n'
+          elif [ "$status" -gt 1 ]; then
+            echo "::error::ban-patterns: grep exited with $status for pattern '$pattern' (invalid regex or unreadable path)."
+            exit "$status"
+          fi
+        done <<< "$PATTERNS"
+
+        if [ -n "$violations" ]; then
+          guard="ban-patterns-${GITHUB_RUN_ID:-local}-$RANDOM"
+          echo "::stop-commands::$guard"
+          printf '%s' "$violations"
+          echo "::$guard::"
+          message="$ERROR_MESSAGE"
+          [ -n "$ISSUE_LINK" ] && message="$message See $ISSUE_LINK"
+          echo "::error::$message"
+          exit 1
+        fi
+
+        echo "No banned patterns found."

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The `docs/` guides are numbered chapters in reading order — newcomers start at
 - [`agents-rules-sync`](./.github/actions/agents-rules-sync/README.md) — sync the stack-appropriate `rules/<stack>.md` into `CLAUDE.md` based on `package.json` `agents.rules`
 - [`contributing-check`](./.github/actions/contributing-check/README.md) — validate branch name, commit messages, and PR title against `CONTRIBUTING.md`
 - [`contributing-sync`](./.github/actions/contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, and the contributing workflow from upstream
+- [`ban-patterns`](./.github/actions/ban-patterns/README.md) — fail the job when forbidden regex patterns match files in the working tree
 - [`licenses-audit`](./.github/actions/licenses-audit/README.md) — regenerate the license report on dependency-changing PRs, auto-commit drift on same-repo PRs, and fail fork PRs that ship stale license data
 - [`release-action`](./.github/actions/release-action/README.md) — conventional-commit-driven release pipeline for npm packages, GitHub Actions, and Claude plugins
 - [`release-automerge`](./.github/actions/release-automerge/README.md) — merge an approved, all-green release PR (`^release-`), driven by an event-based workflow so `release-publish.yml` runs without a manual click


### PR DESCRIPTION
Extracts the inline "Ban time-based waits" CI step from [symbiot PR 140](https://github.com/awinogradov/symbiot/pull/140) into a reusable `ban-patterns` composite action, so symbiot (and any other consumer) can declare forbidden-pattern rules with a single `uses:` line instead of copy-pasted inline bash.

- New `.github/actions/ban-patterns/` YAML composite action (no workspace membership): one `shell: bash` step that runs `grep -rIEn` per pattern across consumer-supplied `paths` with optional `--include` globs, scans all patterns before failing, and exits 1 with an `::error::` annotation composed from `error-message` and `issue-link`
- All five inputs reach the script through env vars (never shell-interpolated), an empty `patterns` list fails explicitly since GitHub does not enforce `required: true` at runtime, matched lines are printed inside a `::stop-commands::` guard so file content cannot inject workflow commands, and grep failures (invalid regex, unreadable path) fail the job distinctly from no-match
- The action README mirrors the `contributing-check` shape (Usage with the symbiot adoption example, Inputs, Outputs, Permissions, Behavior, Versioning) and the action is registered in the root README list

---

**Release notes:**

- Added `ban-patterns` composite action that fails a job with an error annotation when forbidden regex patterns match files in the working tree

---

**Issues:**

Closes #63