### PR TITLE
Standardize project structure, docs index, and chapter conventions in stack rule sets

### DIFF
--- a/docs/01-workspace-structure.md
+++ b/docs/01-workspace-structure.md
@@ -203,8 +203,14 @@ None of these are required. Use them when a member has enough surface area to ne
 
 ### CLAUDE.md §3.1 file organization
 
-- Single module → flat file (`foo.ts`).
-- Multiple related files → directory with NO `index.ts` (`foo/foo.ts`, `foo/foo.test.ts`, `foo/foo.types.ts`).
+```
+foo.ts          # single module: a file, no directory
+
+foo/            # multiple modules: a directory, no index.ts barrel
+├── foo.ts
+├── foo.test.ts
+└── foo.types.ts
+```
 
 These rules are inherited from CLAUDE.md (a symlink to `rules/Bun.md`); not duplicated here.
 

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -15,7 +15,7 @@ To change it, open a pull request against the source file above.
 
 Before making any changes:
 
-1. Read the root `README.md` — its Documentation section lists every doc with a link and description
+1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
 2. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README
 3. Read files that appear relevant to the current task
 4. Treat `docs/` as the source of truth for project-specific conventions and follow those documents over this file when they conflict
@@ -68,8 +68,15 @@ Before making any changes:
 
 ### 3.1 File Organization
 
-- 👤 Single module file only → no directory. Example: `example.ts`
-- 👤 Multiple module files → create directory, NO index.ts. Example: `example/example.ts`, `example/example.test.ts`, `example/example.types.ts`.
+```
+example.ts     # single module: a file, no directory
+
+example/       # multiple modules: a directory, no index.ts barrel
+├── example.ts
+├── example.test.ts
+└── example.types.ts
+```
+
 - 👤 Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
 
 ### 3.2 Import Rules
@@ -304,6 +311,10 @@ Choose ONE backend based on the project's needs. Do not mix.
 - 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
 - 👤 Remove the TODO and its `@see` line when the linked issue closes
 - 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+
+### 11.3 docs/ structure
+
+- 👤 Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
 
 ## 12. Performance
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -15,7 +15,7 @@ To change it, open a pull request against the source file above.
 
 Before making any changes:
 
-1. Read the root `README.md` — its Documentation section lists every doc with a link and description
+1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
 2. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README
 3. Read files that appear relevant to the current task
 4. Treat `docs/` as the source of truth for project-specific conventions and follow those documents over this file when they conflict
@@ -60,8 +60,15 @@ Before making any changes:
 
 ### 3.1 File Organization
 
-- 👤 Single module file only → no directory. Example: `example.ts`
-- 👤 Multiple module files → create directory, NO index.ts. Example: `example/example.ts`, `example/example.test.ts`, `example/example.types.ts`, `example/example.module.css`.
+```
+example.ts     # single module: a file, no directory
+
+example/       # multiple modules: a directory, no index.ts barrel
+├── example.ts
+├── example.test.ts
+├── example.types.ts
+└── example.module.css
+```
 
 ### 3.2 Import Rules
 
@@ -178,6 +185,10 @@ Before making any changes:
 - 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
 - 👤 Remove the TODO and its `@see` line when the linked issue closes
 - 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+
+### 11.3 docs/ structure
+
+- 👤 Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
 
 ## 12. Performance
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -15,7 +15,7 @@ To change it, open a pull request against the source file above.
 
 Before making any changes:
 
-1. Read the root `README.md` — its Documentation section lists every doc with a link and description
+1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
 2. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README
 3. Read files that appear relevant to the current task
 4. Treat `docs/` as the source of truth for project-specific conventions and follow those documents over this file when they conflict
@@ -69,8 +69,15 @@ Before making any changes:
 
 ### 3.1 File Organization
 
-- 👤 Single module file only → no directory. Example: `example.ts`
-- 👤 Multiple module files → create directory, NO index.ts. Example: `example/example.ts`, `example/example.test.ts`, `example/example.types.ts`.
+```
+example.ts     # single module: a file, no directory
+
+example/       # multiple modules: a directory, no index.ts barrel
+├── example.ts
+├── example.test.ts
+└── example.types.ts
+```
+
 - 👤 Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
 
 ### 3.2 Import Rules
@@ -295,6 +302,10 @@ Before making any changes:
 - 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
 - 👤 Remove the TODO and its `@see` line when the linked issue closes
 - 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+
+### 11.3 docs/ structure
+
+- 👤 Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
 
 ## 12. Performance
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -15,7 +15,7 @@ To change it, open a pull request against the source file above.
 
 Before making any changes:
 
-1. Read the root `README.md` — its Documentation section lists every doc with a link and description
+1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
 2. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README
 3. Read files that appear relevant to the current task
 4. Treat `docs/` as the source of truth for project-specific conventions and follow those documents over this file when they conflict
@@ -69,8 +69,16 @@ Before making any changes:
 
 ### 3.1 File Organization
 
-- 👤 Single module file only → no directory. Example: `example.ts`
-- 👤 Multiple module files → create directory, NO index.ts. Example: `example/example.ts`, `example/example.test.ts`, `example/example.types.ts`, `example/example.module.css`.
+```
+example.ts     # single module: a file, no directory
+
+example/       # multiple modules: a directory, no index.ts barrel
+├── example.ts
+├── example.test.ts
+├── example.types.ts
+└── example.module.css
+```
+
 - 👤 Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
 
 ### 3.2 Import Rules
@@ -291,6 +299,10 @@ Before making any changes:
 - 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
 - 👤 Remove the TODO and its `@see` line when the linked issue closes
 - 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+
+### 11.3 docs/ structure
+
+- 👤 Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
 
 ## 12. Performance
 


### PR DESCRIPTION
Make all four stack rule sets prescribe one consistent, scannable layout that every downstream `CLAUDE.md` inherits — and bring this repo's own structure doc into conformance. A repo-wide Markdown audit confirmed everything else already follows the conventions.

- Replace the section 3.1 file-organization bullets with a fenced ASCII tree in all four `rules/*.md` (with `example.module.css` only in the CSS-Modules stacks, omitted in the Tailwind stacks)
- Reword Mandatory Context so the README docs index must be a Markdown table or an equivalent reading-order list
- Add section 11.3 requiring `docs/` to be numbered chapters in reading order
- Tree-ify the file-organization example in `docs/01-workspace-structure.md` to match

Note: issue #317's acceptance criterion said the README docs index "must be a Markdown table". This PR deliberately widens that to "a Markdown table or an equivalent reading-order list" so this repo's own list-style README — which is `rules/Bun.md` via the `CLAUDE.md` symlink — stays conformant to the rule it ships. Both forms satisfy the convention's goal: a scannable, linked, reading-order index. Applied identically across all four rule files.

---

**Issues:**

Closes #317
