### PR TITLE
Make the CONTRIBUTING.md PR checklist copy-pastable as a fenced code block

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -490,6 +490,7 @@ Only one strategy is used per repository. Reasons:
 
 **Before submitting:**
 
+```markdown
 - [ ] Branch name starts with `issue-<number>-` or one of the special prefixes (`hotfix-`, `trivial-`, `maintenance-`, `proposal-`, `security-`)
 - [ ] PR title is a business-valuable description (no `#<n>:` prefix) or uses a recognized special prefix
 - [ ] PR description links the issue via `Closes #<n>` / `Fixes #<n>` / `Resolves #<n>` (when applicable)
@@ -499,6 +500,7 @@ Only one strategy is used per repository. Reasons:
 - [ ] Tests pass locally
 - [ ] If release notes included, uses `**Release notes:**` format (not `## Release Notes`)
 - [ ] Code follows standards
+```
 
 ### Good PR examples
 


### PR DESCRIPTION
The PR checklist in CONTRIBUTING.md rendered as interactive checkboxes, which cannot be copied cleanly into a PR body — copying the rendered list loses the underlying `- [ ]` source. Wrapping the nine items in a fenced `markdown` code block gives a one-click copy button whose raw source pastes back into a PR description as a real checklist, and brings the section in line with the PR-description and Magic-Words examples already fenced the same way in the file.

- Wrapped the nine "Before submitting" items in a fenced `markdown` code block; the `**Before submitting:**` lead-in and the item wording are unchanged (net +2 lines)
- Verified the rendered section is a code block with zero interactive checkboxes, that prettier leaves it byte-identical, and that the copied source pastes back as a nine-item checklist

---

**Issues:**

Closes #329
