### PR TITLE
Make the contributing guide's prerequisites fit any downstream stack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,6 @@ All contributors must adhere to our [Code of Conduct](./CODE_OF_CONDUCT.md). Ple
 
 ### Prerequisites
 
-| Stack          | Requirements                                                     |
-| -------------- | ---------------------------------------------------------------- |
-| **TypeScript** | [Bun](https://bun.sh/) 1.x, [NodeJS](https://nodejs.org/) 22 LTS |
-
 Use [README.md](./README.md) for development setup instructions.
 
 ## How to Contribute


### PR DESCRIPTION
The contributing guide is distributed byte-for-byte into every downstream repository, but its Prerequisites section hardcoded a single Bun/NodeJS stack — so any consumer on a different stack received the wrong prerequisites and could not correct them locally (the next sync overwrites local edits). This removes that stack-specific table and relies on the section's existing pointer to each repository's own `README.md`, which is intentionally excluded from the sync.

- Removed the hardcoded Stack/Requirements table (Bun, NodeJS) from the Prerequisites section of `CONTRIBUTING.md`
- Kept the existing `README.md` pointer so each repository documents its own stack and development setup
- Content-only change — no `contributing-sync`/`files-sync` action or workflow edit; it propagates automatically on the next sync

---

**Issues:**

Closes #328
