### PR TITLE
Generate beautiful, brand-themed PDFs with the new pdf:create skill

### DIFF
--- a/.github/actions/code-review-action/src/linkResolution.test.ts
+++ b/.github/actions/code-review-action/src/linkResolution.test.ts
@@ -33,6 +33,9 @@ async function walkMarkdown(dir: string): Promise<string[]> {
   }
   const out: string[] = [];
   for (const entry of entries) {
+    // Skip bundled dependencies (e.g. the pdf:create skill's renderer/node_modules):
+    // their READMEs carry package-relative links that do not resolve in this tree.
+    if (entry.isDirectory() && entry.name === "node_modules") continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) out.push(...(await walkMarkdown(full)));
     else if (entry.isFile() && entry.name.endsWith(".md")) out.push(full);

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,7 @@ bun.lock
 dist/
 coverage/
 .github/workflows/
+
+# Bundled, self-contained Node sub-project for the pdf:create skill — decoupled
+# from the Bun workspace and the root Prettier (.{md,json}) glob on purpose.
+claude-plugins/autopilot/skills/pdf:create/renderer/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The `docs/` guides are numbered chapters in reading order — newcomers start at
 8. [Upstream sync](./docs/08-upstream-sync.md) — the one-action `upstream-sync` aggregator and the thin `upstream.yml` consumers run, with per-kind opt-out
 9. [Committed Repomix pack](./docs/09-repomix-pack.md) — the `.repomix/pack.xml` snapshot, the merge-triggered workflow that refreshes it, and the snapshot-first contract skills follow
 
+**Part VI — Document generation.** Turning content into beautiful, branded files.
+
+10. [The `pdf:create` skill](./docs/10-pdf-create-skill.md) — how the bundled, portable `@react-pdf/renderer` pipeline turns content plus an optional `design.md` into a themed PDF, and how its Node sub-project stays decoupled from the Bun workspace
+
 **Appendix.** Historical records — kept for context, not current guidance.
 
 - [Plan skills audit](./docs/appendix-a-plan-skills-audit.md) — a dimension-by-dimension audit of the `plan`, `plan-bun`, and `plan-nodejs-react` skills; most of its recommendations have since shipped

--- a/claude-plugins/autopilot/README.md
+++ b/claude-plugins/autopilot/README.md
@@ -84,6 +84,7 @@ code-assistants/
             ├── dependabot:resolve/
             ├── issue:create/
             ├── issue:run/
+            ├── pdf:create/             # bundles a self-contained Node renderer/ sub-project
             ├── plan/
             ├── plan-bun/
             ├── plan-nodejs-react/
@@ -268,6 +269,16 @@ Generate ASCII schemas, diagrams, and UI wireframes using Unicode box-drawing ch
 
 ```bash
 /autopilot:ascii-schemas
+```
+
+### `/autopilot:pdf-create`
+
+Generate a beautiful, brand-themed, multi-page PDF — report, research doc, six-pager, or playbook — from structured content, using a bundled `@react-pdf/renderer` pipeline (direct rendering, no headless browser). Optionally themed by a Google `design.md`. The skill is self-contained and portable: copy its folder into `~/.claude/skills/` to use it without the plugin (requires a local Node runtime). See the [pdf:create skill doc](../../docs/10-pdf-create-skill.md).
+
+```bash
+/autopilot:pdf-create "quarterly report from these notes"                 # Default theme
+/autopilot:pdf-create "strategy six-pager" ./brand/design.md             # Brand-themed
+/autopilot:pdf-create "ops playbook" ./brand/design.md ./playbook.pdf    # Theme + output path
 ```
 
 ### `/autopilot:ask-codex`

--- a/claude-plugins/autopilot/skills/pdf:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/pdf:create/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: pdf:create
+description: >-
+  Generate a beautiful, brand-themed, multi-page PDF — report, research doc,
+  six-pager, or playbook — from structured content using a bundled
+  @react-pdf/renderer pipeline (direct rendering, no headless browser). Use when
+  the user asks to create, generate, build, export, or design a PDF, report,
+  whitepaper, six-pager, playbook, proposal, or branded document, especially
+  from notes, data, or a Google design.md brand spec.
+  Trigger on: "PDF", "create a report", "generate a document", "six-pager",
+  "playbook", "proposal", "whitepaper", "branded PDF", "design.md", "export to PDF".
+  Do NOT use for: editing or extracting text from an existing PDF, or filling PDF forms.
+argument-hint: "<what to put in the PDF> [path/to/design.md] [path/to/output.pdf]"
+allowed-tools:
+  - Read
+  - Write
+  - Bash(node *)
+  - Bash(npm *)
+  - Bash(npx *)
+  - AskUserQuestion
+---
+
+# Create a beautiful PDF (`pdf:create`)
+
+Turn structured content into a polished, multi-page PDF using a bundled, self-contained `@react-pdf/renderer` pipeline. Rendering is **deterministic and runs outside this conversation**: you assemble a small JSON document, a Node script turns it into a themed PDF. You never hand-write rendering code.
+
+## When to use
+
+- The user wants a PDF report, research document, six-pager, playbook, proposal, or any branded multi-page document.
+- The user has content (notes, data, sections, tables, charts) and wants it laid out beautifully.
+- The user provides — or wants to apply — a brand identity via a Google `design.md` file.
+
+Do not use this to read, edit, merge, or extract from an existing PDF.
+
+## How it works
+
+```text
+You assemble  ──►  content.json  ──►  render.tsx  ──►  validate (Zod)  ──►  theme
+(from the user's        (Write tool)        │            content + design.md     │
+ content + choices)                          │                                    ▼
+                                             └──►  registerFonts ──► template ──► output.pdf
+```
+
+Three inputs, all passed as file paths (no inline JSON on the command line):
+
+1. **content JSON** — the document model you write (metadata, cover, sections, blocks). This is the only artifact you produce per run; its schema is the stable contract.
+2. **design.md** (optional) — a brand spec whose tokens (colors, typography, spacing) become the theme. Omit it to use the bundled default theme.
+3. **output path** — where the `.pdf` is written.
+
+## Portability (works without the plugin)
+
+The skill is a self-contained folder: `SKILL.md` plus a `renderer/` Node project with its own pinned dependencies. It has **no** cross-skill calls and **no** MCP dependencies. To use it outside this plugin, copy the whole `pdf:create/` folder into `~/.claude/skills/` — it behaves identically. The only requirement is a local **Node** runtime (Node 18–22 recommended); the first render installs the renderer's dependencies once. It does not run in the hosted claude.ai web sandbox, which has no Node toolchain.
+
+## Workflow
+
+Let `SKILL_DIR` be the directory that contains this `SKILL.md`. Every command below runs from `SKILL_DIR/renderer`.
+
+### Phase 1 — Pick a template and gather content
+
+Choose the template that fits the request (see [Templates](#templates)). If the user has not implied one, ask with `AskUserQuestion` (Report / Research doc / Six-pager / Playbook). Collect the content: title and metadata, an optional cover, and the ordered sections with their blocks (headings, paragraphs, lists, tables, figures, charts, callouts, pull quotes).
+
+### Phase 2 — Write the content JSON
+
+Read `renderer/references/content-schema.md` for the full schema, and `renderer/references/examples/report.content.json` for a worked example. Then write a content JSON file (e.g. to a temp path or the user's working directory) that conforms to it. Keep prose in the content; do not put styling in it — styling comes from the theme.
+
+### Phase 3 — Resolve a brand theme (optional)
+
+If the user supplied (or points to) a `design.md`, pass its path with `--design`. Otherwise omit it and the bundled default theme is used. See [design.md theming](#designmd-theming).
+
+### Phase 4 — Install renderer dependencies (one-time)
+
+```bash
+node install-check.mjs
+```
+
+This installs the renderer's pinned runtime dependencies on first use and is a no-op afterward (guarded by a marker file). If `node` is not found, tell the user this skill needs a local Node runtime on PATH.
+
+### Phase 5 — Render
+
+```bash
+node --import tsx render.tsx \
+  --content "<content.json>" \
+  --out "<output.pdf>" \
+  [--design "<design.md>"] \
+  [--template <report|researchDoc|sixPager|playbook>]
+```
+
+`--template` overrides the `template` field in the content JSON; usually you can omit it. The script validates both inputs and exits non-zero with a clear, field-named message on any problem (see [Failure modes](#failure-modes)).
+
+### Phase 6 — Report and verify
+
+On success the script prints the output path and byte size. Tell the user where the PDF is. If anything failed, read the error message — it names the offending file, field, font, or token — fix the content JSON or design.md, and re-run.
+
+## The content JSON contract
+
+The renderer accepts one document object. Top level: `schemaVersion` (1), `template`, `metadata`, optional `cover`, `toc` (boolean), `sections[]`, and optional `appendix[]`. Each section has an `id`, `title`, and ordered `blocks[]`. Blocks are a discriminated union on `type`: `heading`, `paragraph`, `list`, `table`, `figure`, `chart`, `callout`, `pullquote`, `pagebreak`. The authoritative schema with every field is in `renderer/references/content-schema.md`; mirror `renderer/references/examples/report.content.json`.
+
+## design.md theming
+
+A `design.md` is a markdown file with YAML front-matter design tokens (colors, typography, spacing, rounded) plus a human-readable body. The loader parses the front-matter, resolves `{path.to.token}` references, validates the tokens, and produces the theme the components consume. Colors and typography names map onto the document's palette and text styles. If a token reference is broken or a referenced font cannot be resolved, the render **fails loudly** rather than producing a silently wrong PDF. With no `design.md`, the bundled default theme (standard PDF font families, a neutral professional palette) is used. See `renderer/references/design-md-spec.md`.
+
+Custom brand fonts are supported: drop TTF/WOFF static-weight files into `renderer/assets/fonts/` and reference the family from the design.md `fonts` mapping. Variable fonts are rejected (the PDF format does not support them) — ship explicit weights.
+
+## Templates
+
+- **report** — cover, table of contents, executive summary, sequential sections, appendix. The general-purpose business document.
+- **researchDoc** — cover with authors, abstract, numbered sections, references appendix; supports pull quotes.
+- **sixPager** — Amazon-style six narrative sections (Introduction, Goals, Tenets, State of the Business, Lessons Learned, Strategic Priorities) plus an unlimited appendix for tables and charts.
+- **playbook** — operational guide: each section is a "play" with step lists, callouts, and owner/RACI tables.
+
+All templates share the cover → TOC → sections → appendix spine, a fixed header/footer with page numbers, and a navigable bookmark outline.
+
+## Failure modes
+
+- **`node` not found** — install Node (18–22) and re-run. The hosted claude.ai sandbox is unsupported.
+- **content JSON invalid** — the error names the failing field; fix it against `references/content-schema.md`.
+- **broken design.md token reference** — the error names the unresolved `{token}`; fix the design.md.
+- **unresolved or variable font** — the error names the family; add a static-weight file to `assets/fonts/` or use a standard family.
+- **a block taller than a page** — split it (e.g. break a huge table into sections); the renderer keeps headings with following content via `minPresenceAhead`, not by forcing oversized blocks onto one page.
+
+## Examples
+
+Generate a report from notes, default theme:
+
+```bash
+# after writing /tmp/report.content.json
+node install-check.mjs
+node --import tsx render.tsx --content /tmp/report.content.json --out ./quarterly-report.pdf
+```
+
+Generate a branded six-pager with a company design.md:
+
+```bash
+node install-check.mjs
+node --import tsx render.tsx \
+  --content /tmp/sixpager.content.json \
+  --design ./brand/design.md \
+  --out ./strategy-sixpager.pdf \
+  --template sixPager
+```
+
+<!-- ref-format:start -->
+
+### Reference formatting & readability
+
+These rules govern references — when you point the reader at a real file, standard, section, commit, or issue. (A token named only as an example, with no real target, is a code specimen in backticks, like any code identifier.) Every reference must resolve: render it as a real link whose target exists, and prefer the most stable link form so it does not rot. Render the same kind of reference the same way everywhere:
+
+- Code specimens — backticks, e.g. `buildReviewComments`, `reviewOutput.ts`. A backticked token names a thing as an example; it is not a reference and carries no link.
+- Files, docs, skills, agents, and actions you point the reader at — link them, e.g. `[release field spec](<repo-blob-url>/docs/06-release-field.md)`. Use a repo-relative path in repository files and the absolute `<repo-blob-url>` form in generated output posted outside the repo (PR/issue bodies, review comments, release notes), where relative paths do not resolve.
+- Standards and conventions — ALWAYS link the versioned RFC by its stable ID, e.g. `[RFC-0001](<repo-blob-url>/rfc/0001-reference-formatting.md)`; an Accepted RFC is immutable except through an explicit version bump, so the link never rots.
+- Sections — link the heading by its anchor. Same document: a bare `#anchor`, e.g. `[Phase 6](#phase-6-reply-to-review-threads)`. Another document: `path#anchor` — a repo-relative path in repository files, the absolute `<repo-blob-url>/path#anchor` form in generated output. A GitHub anchor is the heading lower-cased, spaces turned to hyphens, punctuation dropped.
+- Commit SHAs — ALWAYS a link, e.g. `[0328a61](<repo-commit-url>/0328a61)`; a commit is immutable. If you cannot build the URL, leave the bare SHA un-backticked.
+- Issue / PR references — leave the bare number (GitHub auto-links it) or write a full link.
+
+Backticks suppress GitHub autolinking: a commit SHA or issue/PR number inside a code span renders as dead text — that is why a backticked SHA was un-clickable in a prior review. Never wrap a SHA or issue/PR number in backticks; link it, or leave it bare so GitHub auto-links it.
+
+Write the most helpful, readable output you can: plain, direct prose; every reference resolvable; explain the "why", not the obvious "what".
+
+<!-- ref-format:end -->

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/.gitignore
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.pdf
+.pdf-create-ok

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/assets/fonts/README.md
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/assets/fonts/README.md
@@ -1,0 +1,35 @@
+# Bundled fonts
+
+The default theme renders with the **standard PDF font families** — `Helvetica`,
+`Times-Roman`, and `Courier` — which are built into every PDF reader. This is a
+deliberate choice: no binary font files ship in the repo, the skill works
+offline with zero font-resolution risk, and it stays small to copy standalone.
+
+## Adding brand fonts
+
+To use a custom typeface, drop its **static-weight** `.ttf` or `.woff` files in
+this directory and reference them from a `design.md`:
+
+```yaml
+fonts:
+  - family: Inter
+    weights:
+      "400": Inter-Regular.ttf
+      "700": Inter-Bold.ttf
+    italics:
+      "400": Inter-Italic.ttf
+typography:
+  body:
+    fontFamily: Inter
+  h1:
+    fontFamily: Inter
+    fontWeight: 700
+```
+
+File names in `weights`/`italics` resolve against this directory. Absolute paths
+are also accepted.
+
+> Variable fonts are **not** supported — the PDF format needs discrete weights,
+> and `@react-pdf/renderer` fails on them. Ship one file per weight. The renderer
+> validates every referenced font before rendering and fails loudly if a family
+> is missing, remote, or looks like a variable font.

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/BlockRenderer.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/BlockRenderer.tsx
@@ -1,0 +1,49 @@
+import { View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { Block } from "../schemas/blockSchema";
+import { contentWidth } from "../theme/pageMetrics";
+import { useTheme } from "../theme/themeContext";
+import { Chart } from "./Chart";
+import { Table } from "./Table";
+import { Body } from "./primitives/Body";
+import { Callout } from "./primitives/Callout";
+import { Figure } from "./primitives/Figure";
+import { Heading } from "./primitives/Heading";
+import { ListBlock } from "./primitives/ListBlock";
+import { PullQuote } from "./primitives/PullQuote";
+
+/** Dispatch a content block to its component. The `never` default enforces exhaustiveness. */
+export function BlockRenderer({ block }: { block: Block }): ReactElement | null {
+  const theme = useTheme();
+  const width = contentWidth(theme);
+  switch (block.type) {
+    case "heading":
+      return (
+        <Heading level={block.level} id={block.id}>
+          {block.text}
+        </Heading>
+      );
+    case "paragraph":
+      return <Body content={block.content} />;
+    case "list":
+      return <ListBlock block={block} />;
+    case "table":
+      return <Table block={block} />;
+    case "figure":
+      return <Figure block={block} contentWidth={width} />;
+    case "chart":
+      return <Chart block={block} maxWidth={width} />;
+    case "callout":
+      return <Callout block={block} />;
+    case "pullquote":
+      return <PullQuote block={block} />;
+    case "pagebreak":
+      return <View break />;
+    default: {
+      const exhaustive: never = block;
+      void exhaustive;
+      return null;
+    }
+  }
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/Chart.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/Chart.tsx
@@ -10,6 +10,14 @@ import { Caption } from "./primitives/Caption";
 type ChartData = Extract<Block, { type: "chart" }>;
 
 const padding = { left: 44, right: 16, top: 14, bottom: 30 };
+const gridSteps = 4;
+const axisLabelFontSize = 7;
+const groupFillRatio = 0.8; // grouped bars span this fraction of a category slot
+const barWidthRatio = 0.9; // each bar fills this fraction of its sub-slot
+const stackedWidthRatio = 0.6; // a stacked bar spans this fraction of a category slot
+const areaFillOpacity = 0.18;
+const lineStrokeWidth = 1.5;
+const donutHoleRatio = 0.55; // inner radius as a fraction of the outer radius
 
 function seriesColors(spec: ChartSpec, theme: Theme): string[] {
   return (
@@ -39,39 +47,53 @@ function polar(cx: number, cy: number, radius: number, angleDeg: number): [numbe
   return [cx + radius * Math.cos(rad), cy + radius * Math.sin(rad)];
 }
 
-function cartesian(spec: ChartSpec, theme: Theme, colors: string[]): ReactNode[] {
+interface CartesianGeometry {
+  categories: string[];
+  plotW: number;
+  plotH: number;
+  baseY: number;
+  yMax: number;
+  scaleY: (value: number) => number;
+}
+
+/** Compute the shared plot geometry and y-scale for a cartesian chart. */
+function cartesianGeometry(spec: ChartSpec): CartesianGeometry {
   const categories = spec.series[0].points.map((point) => String(point.x));
   const plotW = spec.width - padding.left - padding.right;
   const plotH = spec.height - padding.top - padding.bottom;
   const baseY = padding.top + plotH;
-
-  const stacked = spec.kind === "stackedBar";
-  const seriesMax = Math.max(
-    ...spec.series.flatMap((series) => series.points.map((point) => point.y)),
-    0,
-  );
+  const seriesMax = Math.max(...spec.series.flatMap((series) => series.points.map((point) => point.y)), 0);
   const stackedMax = Math.max(
     ...categories.map((_, index) =>
       spec.series.reduce((sum, series) => sum + (series.points[index]?.y ?? 0), 0),
     ),
     0,
   );
-  const yMax = niceCeil(stacked ? stackedMax : seriesMax);
+  const yMax = niceCeil(spec.kind === "stackedBar" ? stackedMax : seriesMax);
   const scaleY = (value: number): number => baseY - (value / yMax) * plotH;
+  return { categories, plotW, plotH, baseY, yMax, scaleY };
+}
 
+/** Horizontal position of a category: evenly spread for line/area, slot-centered for bars. */
+function categoryX(spec: ChartSpec, geo: CartesianGeometry, index: number): number {
+  const { categories, plotW } = geo;
+  if (spec.kind === "line" || spec.kind === "area") {
+    return padding.left + (categories.length === 1 ? plotW / 2 : (index / (categories.length - 1)) * plotW);
+  }
+  return padding.left + (index + 0.5) * (plotW / categories.length);
+}
+
+function drawGridlines(geo: CartesianGeometry, theme: Theme): ReactNode[] {
   const nodes: ReactNode[] = [];
-
-  // Gridlines + y-axis labels.
-  const steps = 4;
-  for (let step = 0; step <= steps; step += 1) {
-    const value = (yMax / steps) * step;
-    const y = scaleY(value);
+  for (let step = 0; step <= gridSteps; step += 1) {
+    const value = (geo.yMax / gridSteps) * step;
+    const y = geo.scaleY(value);
     nodes.push(
       <Line
         key={`grid-${step}`}
         x1={padding.left}
         y1={y}
-        x2={padding.left + plotW}
+        x2={padding.left + geo.plotW}
         y2={y}
         strokeWidth={0.5}
         stroke={theme.colors.border}
@@ -82,7 +104,7 @@ function cartesian(spec: ChartSpec, theme: Theme, colors: string[]): ReactNode[]
         key={`ylabel-${step}`}
         x={padding.left - 6}
         y={y + 3}
-        style={{ fontSize: 7, fontFamily: theme.text.caption.fontFamily }}
+        style={{ fontSize: axisLabelFontSize, fontFamily: theme.text.caption.fontFamily }}
         fill={theme.colors.muted}
         textAnchor="end"
       >
@@ -90,108 +112,112 @@ function cartesian(spec: ChartSpec, theme: Theme, colors: string[]): ReactNode[]
       </SvgText>,
     );
   }
-
-  // X-axis category labels.
-  categories.forEach((label, index) => {
-    const x =
-      spec.kind === "line" || spec.kind === "area"
-        ? padding.left + (categories.length === 1 ? plotW / 2 : (index / (categories.length - 1)) * plotW)
-        : padding.left + (index + 0.5) * (plotW / categories.length);
-    nodes.push(
-      <SvgText
-        key={`xlabel-${index}`}
-        x={x}
-        y={baseY + 12}
-        style={{ fontSize: 7, fontFamily: theme.text.caption.fontFamily }}
-        fill={theme.colors.muted}
-        textAnchor="middle"
-      >
-        {label}
-      </SvgText>,
-    );
-  });
-
-  if (spec.kind === "bar") {
-    const groupW = plotW / categories.length;
-    const barW = (groupW * 0.8) / spec.series.length;
-    spec.series.forEach((series, seriesIndex) => {
-      series.points.forEach((point, index) => {
-        const x = padding.left + index * groupW + groupW * 0.1 + seriesIndex * barW;
-        const top = scaleY(point.y);
-        nodes.push(
-          <Rect
-            key={`bar-${seriesIndex}-${index}`}
-            x={x}
-            y={top}
-            width={barW * 0.9}
-            height={baseY - top}
-            fill={colors[seriesIndex % colors.length]}
-          />,
-        );
-      });
-    });
-  } else if (spec.kind === "stackedBar") {
-    const groupW = plotW / categories.length;
-    const barW = groupW * 0.6;
-    categories.forEach((_, index) => {
-      let runningTop = baseY;
-      spec.series.forEach((series, seriesIndex) => {
-        const value = series.points[index]?.y ?? 0;
-        const segmentHeight = (value / yMax) * plotH;
-        runningTop -= segmentHeight;
-        nodes.push(
-          <Rect
-            key={`stack-${seriesIndex}-${index}`}
-            x={padding.left + index * groupW + (groupW - barW) / 2}
-            y={runningTop}
-            width={barW}
-            height={segmentHeight}
-            fill={colors[seriesIndex % colors.length]}
-          />,
-        );
-      });
-    });
-  } else {
-    // line and area
-    const xAt = (index: number): number =>
-      padding.left + (categories.length === 1 ? plotW / 2 : (index / (categories.length - 1)) * plotW);
-    spec.series.forEach((series, seriesIndex) => {
-      const color = colors[seriesIndex % colors.length];
-      const points = series.points.map((point, index) => `${xAt(index)},${scaleY(point.y)}`).join(" ");
-      if (spec.kind === "area") {
-        const first = xAt(0);
-        const last = xAt(series.points.length - 1);
-        nodes.push(
-          <Path
-            key={`area-${seriesIndex}`}
-            d={`M ${first},${baseY} L ${points.split(" ").join(" L ")} L ${last},${baseY} Z`}
-            fill={color}
-            fillOpacity={0.18}
-          />,
-        );
-      }
-      nodes.push(
-        <Path
-          key={`line-${seriesIndex}`}
-          d={`M ${points.split(" ").join(" L ")}`}
-          stroke={color}
-          strokeWidth={1.5}
-          fill="none"
-        />,
-      );
-    });
-  }
-
   return nodes;
 }
 
-function pie(spec: ChartSpec, theme: Theme, colors: string[]): ReactNode[] {
+function drawAxisLabels(spec: ChartSpec, geo: CartesianGeometry, theme: Theme): ReactNode[] {
+  return geo.categories.map((label, index) => (
+    <SvgText
+      key={`xlabel-${index}`}
+      x={categoryX(spec, geo, index)}
+      y={geo.baseY + 12}
+      style={{ fontSize: axisLabelFontSize, fontFamily: theme.text.caption.fontFamily }}
+      fill={theme.colors.muted}
+      textAnchor="middle"
+    >
+      {label}
+    </SvgText>
+  ));
+}
+
+function drawBars(spec: ChartSpec, geo: CartesianGeometry, colors: string[]): ReactNode[] {
+  const groupW = geo.plotW / geo.categories.length;
+  const groupPad = (1 - groupFillRatio) / 2;
+  const barW = (groupW * groupFillRatio) / spec.series.length;
+  return spec.series.flatMap((series, seriesIndex) =>
+    series.points.map((point, index) => {
+      const x = padding.left + index * groupW + groupW * groupPad + seriesIndex * barW;
+      const top = geo.scaleY(point.y);
+      return (
+        <Rect
+          key={`bar-${seriesIndex}-${index}`}
+          x={x}
+          y={top}
+          width={barW * barWidthRatio}
+          height={geo.baseY - top}
+          fill={colors[seriesIndex % colors.length]}
+        />
+      );
+    }),
+  );
+}
+
+function drawStackedBars(spec: ChartSpec, geo: CartesianGeometry, colors: string[]): ReactNode[] {
+  const groupW = geo.plotW / geo.categories.length;
+  const barW = groupW * stackedWidthRatio;
+  const nodes: ReactNode[] = [];
+  geo.categories.forEach((_, index) => {
+    let runningTop = geo.baseY;
+    spec.series.forEach((series, seriesIndex) => {
+      const segmentHeight = ((series.points[index]?.y ?? 0) / geo.yMax) * geo.plotH;
+      runningTop -= segmentHeight;
+      nodes.push(
+        <Rect
+          key={`stack-${seriesIndex}-${index}`}
+          x={padding.left + index * groupW + (groupW - barW) / 2}
+          y={runningTop}
+          width={barW}
+          height={segmentHeight}
+          fill={colors[seriesIndex % colors.length]}
+        />,
+      );
+    });
+  });
+  return nodes;
+}
+
+function drawLineArea(spec: ChartSpec, geo: CartesianGeometry, colors: string[]): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  spec.series.forEach((series, seriesIndex) => {
+    const color = colors[seriesIndex % colors.length];
+    const points = series.points.map((point, index) => `${categoryX(spec, geo, index)},${geo.scaleY(point.y)}`);
+    const polyline = points.join(" L ");
+    if (spec.kind === "area") {
+      const first = categoryX(spec, geo, 0);
+      const last = categoryX(spec, geo, series.points.length - 1);
+      nodes.push(
+        <Path
+          key={`area-${seriesIndex}`}
+          d={`M ${first},${geo.baseY} L ${polyline} L ${last},${geo.baseY} Z`}
+          fill={color}
+          fillOpacity={areaFillOpacity}
+        />,
+      );
+    }
+    nodes.push(
+      <Path key={`line-${seriesIndex}`} d={`M ${polyline}`} stroke={color} strokeWidth={lineStrokeWidth} fill="none" />,
+    );
+  });
+  return nodes;
+}
+
+/** Draw a bar, stacked-bar, line, or area chart by composing the focused helpers. */
+function cartesian(spec: ChartSpec, theme: Theme, colors: string[]): ReactNode[] {
+  const geo = cartesianGeometry(spec);
+  const nodes = [...drawGridlines(geo, theme), ...drawAxisLabels(spec, geo, theme)];
+  if (spec.kind === "stackedBar") nodes.push(...drawStackedBars(spec, geo, colors));
+  else if (spec.kind === "bar") nodes.push(...drawBars(spec, geo, colors));
+  else nodes.push(...drawLineArea(spec, geo, colors));
+  return nodes;
+}
+
+function pie(spec: ChartSpec, colors: string[]): ReactNode[] {
   const series = spec.series[0];
   const total = series.points.reduce((sum, point) => sum + Math.abs(point.y), 0) || 1;
   const cx = spec.width / 2;
   const cy = spec.height / 2;
   const radius = Math.min(spec.width, spec.height) / 2 - padding.top;
-  const innerRadius = spec.kind === "donut" ? radius * 0.55 : 0;
+  const innerRadius = spec.kind === "donut" ? radius * donutHoleRatio : 0;
 
   let angle = 0;
   return series.points.map((point, index) => {
@@ -257,7 +283,7 @@ export function Chart({ block, maxWidth }: { block: ChartData; maxWidth: number 
   return (
     <View wrap={false} style={{ marginVertical: theme.spacing.md }}>
       <Svg width={width} height={height} viewBox={`0 0 ${block.spec.width} ${block.spec.height}`}>
-        {isPie ? pie(block.spec, theme, colors) : cartesian(block.spec, theme, colors)}
+        {isPie ? pie(block.spec, colors) : cartesian(block.spec, theme, colors)}
       </Svg>
       <Legend spec={block.spec} colors={colors} />
       {block.caption ? <Caption>{block.caption}</Caption> : null}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/Chart.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/Chart.tsx
@@ -1,0 +1,266 @@
+import { Line, Path, Rect, Svg, Text as SvgText, Text, View } from "@react-pdf/renderer";
+import type { ReactElement, ReactNode } from "react";
+
+import type { Block } from "../schemas/blockSchema";
+import type { ChartSpec } from "../schemas/chartSpecSchema";
+import { useTheme } from "../theme/themeContext";
+import type { Theme } from "../theme/themeInterface";
+import { Caption } from "./primitives/Caption";
+
+type ChartData = Extract<Block, { type: "chart" }>;
+
+const padding = { left: 44, right: 16, top: 14, bottom: 30 };
+
+function seriesColors(spec: ChartSpec, theme: Theme): string[] {
+  return (
+    spec.palette ?? [
+      theme.colors.primary,
+      theme.colors.accent,
+      theme.colors.success,
+      theme.colors.warning,
+      theme.colors.info,
+      theme.colors.danger,
+      theme.colors.neutral,
+    ]
+  );
+}
+
+/** Round a value up to a clean axis maximum (1/2/5 × 10^n). */
+function niceCeil(value: number): number {
+  if (value <= 0) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  const normalized = value / magnitude;
+  const step = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return step * magnitude;
+}
+
+function polar(cx: number, cy: number, radius: number, angleDeg: number): [number, number] {
+  const rad = ((angleDeg - 90) * Math.PI) / 180;
+  return [cx + radius * Math.cos(rad), cy + radius * Math.sin(rad)];
+}
+
+function cartesian(spec: ChartSpec, theme: Theme, colors: string[]): ReactNode[] {
+  const categories = spec.series[0].points.map((point) => String(point.x));
+  const plotW = spec.width - padding.left - padding.right;
+  const plotH = spec.height - padding.top - padding.bottom;
+  const baseY = padding.top + plotH;
+
+  const stacked = spec.kind === "stackedBar";
+  const seriesMax = Math.max(
+    ...spec.series.flatMap((series) => series.points.map((point) => point.y)),
+    0,
+  );
+  const stackedMax = Math.max(
+    ...categories.map((_, index) =>
+      spec.series.reduce((sum, series) => sum + (series.points[index]?.y ?? 0), 0),
+    ),
+    0,
+  );
+  const yMax = niceCeil(stacked ? stackedMax : seriesMax);
+  const scaleY = (value: number): number => baseY - (value / yMax) * plotH;
+
+  const nodes: ReactNode[] = [];
+
+  // Gridlines + y-axis labels.
+  const steps = 4;
+  for (let step = 0; step <= steps; step += 1) {
+    const value = (yMax / steps) * step;
+    const y = scaleY(value);
+    nodes.push(
+      <Line
+        key={`grid-${step}`}
+        x1={padding.left}
+        y1={y}
+        x2={padding.left + plotW}
+        y2={y}
+        strokeWidth={0.5}
+        stroke={theme.colors.border}
+      />,
+    );
+    nodes.push(
+      <SvgText
+        key={`ylabel-${step}`}
+        x={padding.left - 6}
+        y={y + 3}
+        style={{ fontSize: 7, fontFamily: theme.text.caption.fontFamily }}
+        fill={theme.colors.muted}
+        textAnchor="end"
+      >
+        {String(Math.round(value))}
+      </SvgText>,
+    );
+  }
+
+  // X-axis category labels.
+  categories.forEach((label, index) => {
+    const x =
+      spec.kind === "line" || spec.kind === "area"
+        ? padding.left + (categories.length === 1 ? plotW / 2 : (index / (categories.length - 1)) * plotW)
+        : padding.left + (index + 0.5) * (plotW / categories.length);
+    nodes.push(
+      <SvgText
+        key={`xlabel-${index}`}
+        x={x}
+        y={baseY + 12}
+        style={{ fontSize: 7, fontFamily: theme.text.caption.fontFamily }}
+        fill={theme.colors.muted}
+        textAnchor="middle"
+      >
+        {label}
+      </SvgText>,
+    );
+  });
+
+  if (spec.kind === "bar") {
+    const groupW = plotW / categories.length;
+    const barW = (groupW * 0.8) / spec.series.length;
+    spec.series.forEach((series, seriesIndex) => {
+      series.points.forEach((point, index) => {
+        const x = padding.left + index * groupW + groupW * 0.1 + seriesIndex * barW;
+        const top = scaleY(point.y);
+        nodes.push(
+          <Rect
+            key={`bar-${seriesIndex}-${index}`}
+            x={x}
+            y={top}
+            width={barW * 0.9}
+            height={baseY - top}
+            fill={colors[seriesIndex % colors.length]}
+          />,
+        );
+      });
+    });
+  } else if (spec.kind === "stackedBar") {
+    const groupW = plotW / categories.length;
+    const barW = groupW * 0.6;
+    categories.forEach((_, index) => {
+      let runningTop = baseY;
+      spec.series.forEach((series, seriesIndex) => {
+        const value = series.points[index]?.y ?? 0;
+        const segmentHeight = (value / yMax) * plotH;
+        runningTop -= segmentHeight;
+        nodes.push(
+          <Rect
+            key={`stack-${seriesIndex}-${index}`}
+            x={padding.left + index * groupW + (groupW - barW) / 2}
+            y={runningTop}
+            width={barW}
+            height={segmentHeight}
+            fill={colors[seriesIndex % colors.length]}
+          />,
+        );
+      });
+    });
+  } else {
+    // line and area
+    const xAt = (index: number): number =>
+      padding.left + (categories.length === 1 ? plotW / 2 : (index / (categories.length - 1)) * plotW);
+    spec.series.forEach((series, seriesIndex) => {
+      const color = colors[seriesIndex % colors.length];
+      const points = series.points.map((point, index) => `${xAt(index)},${scaleY(point.y)}`).join(" ");
+      if (spec.kind === "area") {
+        const first = xAt(0);
+        const last = xAt(series.points.length - 1);
+        nodes.push(
+          <Path
+            key={`area-${seriesIndex}`}
+            d={`M ${first},${baseY} L ${points.split(" ").join(" L ")} L ${last},${baseY} Z`}
+            fill={color}
+            fillOpacity={0.18}
+          />,
+        );
+      }
+      nodes.push(
+        <Path
+          key={`line-${seriesIndex}`}
+          d={`M ${points.split(" ").join(" L ")}`}
+          stroke={color}
+          strokeWidth={1.5}
+          fill="none"
+        />,
+      );
+    });
+  }
+
+  return nodes;
+}
+
+function pie(spec: ChartSpec, theme: Theme, colors: string[]): ReactNode[] {
+  const series = spec.series[0];
+  const total = series.points.reduce((sum, point) => sum + Math.abs(point.y), 0) || 1;
+  const cx = spec.width / 2;
+  const cy = spec.height / 2;
+  const radius = Math.min(spec.width, spec.height) / 2 - padding.top;
+  const innerRadius = spec.kind === "donut" ? radius * 0.55 : 0;
+
+  let angle = 0;
+  return series.points.map((point, index) => {
+    const sweep = (Math.abs(point.y) / total) * 360;
+    const start = angle;
+    const end = angle + sweep;
+    angle = end;
+    const largeArc = sweep > 180 ? 1 : 0;
+    const [ox1, oy1] = polar(cx, cy, radius, start);
+    const [ox2, oy2] = polar(cx, cy, radius, end);
+    const color = colors[index % colors.length];
+    if (innerRadius === 0) {
+      const d = `M ${cx},${cy} L ${ox1},${oy1} A ${radius},${radius} 0 ${largeArc} 1 ${ox2},${oy2} Z`;
+      return <Path key={`slice-${index}`} d={d} fill={color} />;
+    }
+    const [ix1, iy1] = polar(cx, cy, innerRadius, start);
+    const [ix2, iy2] = polar(cx, cy, innerRadius, end);
+    const d =
+      `M ${ox1},${oy1} A ${radius},${radius} 0 ${largeArc} 1 ${ox2},${oy2} ` +
+      `L ${ix2},${iy2} A ${innerRadius},${innerRadius} 0 ${largeArc} 0 ${ix1},${iy1} Z`;
+    return <Path key={`slice-${index}`} d={d} fill={color} />;
+  });
+}
+
+function Legend({ spec, colors }: { spec: ChartSpec; colors: string[] }): ReactElement {
+  const theme = useTheme();
+  const isPie = spec.kind === "pie" || spec.kind === "donut";
+  const items = isPie
+    ? spec.series[0].points.map((point) => String(point.x))
+    : spec.series.map((series) => series.name);
+  return (
+    <View style={{ flexDirection: "row", flexWrap: "wrap", marginTop: theme.spacing.xs }}>
+      {items.map((label, index) => (
+        <View key={index} style={{ flexDirection: "row", alignItems: "center", marginRight: theme.spacing.md }}>
+          <View
+            style={{
+              width: 8,
+              height: 8,
+              backgroundColor: colors[index % colors.length],
+              marginRight: 4,
+              borderRadius: 1,
+            }}
+          />
+          <Text style={theme.text.caption}>{label}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+/**
+ * A chart drawn with @react-pdf/renderer's SVG primitives — bar, stacked bar,
+ * line, area, pie, and donut. Vector output, no native canvas dependency.
+ */
+export function Chart({ block, maxWidth }: { block: ChartData; maxWidth: number }): ReactElement {
+  const theme = useTheme();
+  const colors = seriesColors(block.spec, theme);
+  const width = Math.min(block.spec.width, maxWidth);
+  const scale = width / block.spec.width;
+  const height = block.spec.height * scale;
+  const isPie = block.spec.kind === "pie" || block.spec.kind === "donut";
+
+  return (
+    <View wrap={false} style={{ marginVertical: theme.spacing.md }}>
+      <Svg width={width} height={height} viewBox={`0 0 ${block.spec.width} ${block.spec.height}`}>
+        {isPie ? pie(block.spec, theme, colors) : cartesian(block.spec, theme, colors)}
+      </Svg>
+      <Legend spec={block.spec} colors={colors} />
+      {block.caption ? <Caption>{block.caption}</Caption> : null}
+    </View>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/CoverPage.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/CoverPage.tsx
@@ -1,0 +1,48 @@
+import { Page, Text, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { Cover, Metadata } from "../schemas/contentSchema";
+import { useTheme } from "../theme/themeContext";
+
+export function CoverPage({ cover, metadata }: { cover?: Cover; metadata: Metadata }): ReactElement {
+  const theme = useTheme();
+  const title = cover?.title ?? metadata.title;
+  const subtitle = cover?.subtitle ?? metadata.subtitle;
+  return (
+    <Page size={theme.page.size} bookmark={{ title: "Cover" }} style={{ backgroundColor: theme.colors.background }}>
+      <View
+        style={{
+          backgroundColor: theme.colors.primary,
+          paddingHorizontal: 56,
+          paddingVertical: 64,
+          minHeight: 300,
+          justifyContent: "flex-end",
+        }}
+      >
+        {cover?.eyebrow ? (
+          <Text style={{ ...theme.text.label, color: theme.colors.onPrimary, marginBottom: theme.spacing.sm }}>
+            {cover.eyebrow}
+          </Text>
+        ) : null}
+        <Text style={{ ...theme.text.display, color: theme.colors.onPrimary }}>{title}</Text>
+      </View>
+      <View style={{ paddingHorizontal: 56, paddingTop: 32 }}>
+        {subtitle ? (
+          <Text style={{ ...theme.text.h2, fontWeight: "normal", color: theme.colors.muted }}>{subtitle}</Text>
+        ) : null}
+        <View style={{ marginTop: 24 }}>
+          {metadata.authors.length > 0 ? (
+            <Text style={{ ...theme.text.body, marginBottom: 2 }}>{metadata.authors.join(", ")}</Text>
+          ) : null}
+          {metadata.org ? <Text style={theme.text.caption}>{metadata.org}</Text> : null}
+          {metadata.date ? <Text style={theme.text.caption}>{metadata.date}</Text> : null}
+        </View>
+      </View>
+      {cover?.footnote ? (
+        <View style={{ position: "absolute", bottom: 40, left: 56, right: 56 }}>
+          <Text style={theme.text.caption}>{cover.footnote}</Text>
+        </View>
+      ) : null}
+    </Page>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/Table.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/Table.tsx
@@ -1,0 +1,93 @@
+import { Text, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { Block } from "../schemas/blockSchema";
+import { useTheme } from "../theme/themeContext";
+import { Caption } from "./primitives/Caption";
+import { InlineRuns } from "./primitives/InlineText";
+
+type TableData = Extract<Block, { type: "table" }>;
+
+/** Column widths as percentage strings: explicit fractions when given, else evenly split. */
+function columnWidths(columns: TableData["columns"]): string[] {
+  const explicit = columns.every((column) => typeof column.width === "number");
+  if (explicit) {
+    const total = columns.reduce((sum, column) => sum + (column.width ?? 0), 0) || 1;
+    return columns.map((column) => `${(((column.width ?? 0) / total) * 100).toFixed(3)}%`);
+  }
+  return columns.map(() => `${(100 / columns.length).toFixed(3)}%`);
+}
+
+/**
+ * A themed table built from flexbox rows. Each row is `wrap={false}` (a single
+ * row never splits) while the table itself wraps, so long tables paginate
+ * cleanly. (Header rows do not repeat across pages — a react-pdf limitation.)
+ */
+export function Table({ block }: { block: TableData }): ReactElement {
+  const theme = useTheme();
+  const widths = columnWidths(block.columns);
+  const cellBase = {
+    fontSize: theme.text.body.fontSize - 0.5,
+    fontFamily: theme.text.body.fontFamily,
+    padding: theme.spacing.sm,
+  };
+
+  return (
+    <View style={{ marginVertical: theme.spacing.md }}>
+      <View
+        style={{
+          borderWidth: 0.5,
+          borderColor: theme.colors.border,
+          borderRadius: theme.rounded.sm,
+        }}
+      >
+        <View wrap={false} style={{ flexDirection: "row", backgroundColor: theme.colors.primary }}>
+          {block.columns.map((column, index) => (
+            <Text
+              key={index}
+              style={{
+                ...theme.text.label,
+                color: theme.colors.onPrimary,
+                width: widths[index],
+                padding: theme.spacing.sm,
+                textAlign: column.align ?? "left",
+              }}
+            >
+              {column.header}
+            </Text>
+          ))}
+        </View>
+        {block.rows.map((row, rowIndex) => (
+          <View
+            key={rowIndex}
+            wrap={false}
+            style={{
+              flexDirection: "row",
+              backgroundColor: rowIndex % 2 === 1 ? theme.colors.surface : theme.colors.background,
+              borderTopWidth: 0.5,
+              borderTopColor: theme.colors.border,
+            }}
+          >
+            {block.columns.map((column, cellIndex) => {
+              const cell = row[cellIndex];
+              return (
+                <Text
+                  key={cellIndex}
+                  style={{
+                    ...cellBase,
+                    color: theme.colors.text,
+                    width: widths[cellIndex],
+                    textAlign: column.align ?? "left",
+                  }}
+                >
+                  {cell ? <InlineRuns content={cell} /> : ""}
+                </Text>
+              );
+            })}
+          </View>
+        ))}
+      </View>
+      {block.caption ? <Caption>{block.caption}</Caption> : null}
+    </View>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/TableOfContents.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/TableOfContents.tsx
@@ -1,0 +1,49 @@
+import { Link, Text, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { TocEntry } from "../render/collectTocEntries";
+import type { PageNumberStore } from "../render/pageNumberStore";
+import { useTheme } from "../theme/themeContext";
+
+/**
+ * A table of contents. Each row links to its section anchor; the page number is
+ * read from the store (populated during the layout pass, finalized on the
+ * second pass), and a PDF bookmark gives a navigable sidebar outline.
+ */
+export function TableOfContents({
+  entries,
+  store,
+}: {
+  entries: TocEntry[];
+  store: PageNumberStore;
+}): ReactElement {
+  const theme = useTheme();
+  return (
+    <View bookmark={{ title: "Contents" }} style={{ marginBottom: theme.spacing.lg }}>
+      <Text style={{ ...theme.text.h1, marginBottom: theme.spacing.md }}>Contents</Text>
+      {entries.map((entry) => (
+        <View
+          key={entry.id}
+          style={{
+            flexDirection: "row",
+            justifyContent: "space-between",
+            marginBottom: theme.spacing.xs,
+            marginLeft: entry.level === 2 ? theme.spacing.md : 0,
+          }}
+        >
+          <Link src={`#${entry.id}`} style={{ textDecoration: "none", flex: 1, paddingRight: theme.spacing.sm }}>
+            <Text
+              style={{
+                ...theme.text.body,
+                color: entry.level === 2 ? theme.colors.muted : theme.colors.text,
+              }}
+            >
+              {entry.title}
+            </Text>
+          </Link>
+          <Text style={{ ...theme.text.body, color: theme.colors.muted }} render={() => String(store.get(entry.id) ?? "")} />
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/layout/Columns.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/layout/Columns.tsx
@@ -1,0 +1,10 @@
+import { View } from "@react-pdf/renderer";
+import type { ReactElement, ReactNode } from "react";
+
+import { useTheme } from "../../theme/themeContext";
+
+/** A horizontal row of equal-gutter columns. Children control their own widths (e.g. `flex: 1`). */
+export function Columns({ children }: { children: ReactNode }): ReactElement {
+  const theme = useTheme();
+  return <View style={{ flexDirection: "row", gap: theme.spacing.gutter }}>{children}</View>;
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/layout/PageShell.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/layout/PageShell.tsx
@@ -1,0 +1,78 @@
+import { Page, Text, View } from "@react-pdf/renderer";
+import type { ReactElement, ReactNode } from "react";
+
+import type { Metadata } from "../../schemas/contentSchema";
+import { useTheme } from "../../theme/themeContext";
+
+/**
+ * The standard content page: margins, a fixed running header (org/title and
+ * optional confidentiality) and a fixed footer with the document title and
+ * `page / total` numbers that repeat on every page.
+ */
+export function PageShell({
+  children,
+  metadata,
+}: {
+  children: ReactNode;
+  metadata: Metadata;
+}): ReactElement {
+  const theme = useTheme();
+  const { margins } = theme.page;
+  return (
+    <Page
+      size={theme.page.size}
+      style={{
+        backgroundColor: theme.colors.background,
+        color: theme.colors.text,
+        fontFamily: theme.text.body.fontFamily,
+        fontSize: theme.text.body.fontSize,
+        paddingTop: margins.top,
+        paddingBottom: margins.bottom,
+        paddingLeft: margins.left,
+        paddingRight: margins.right,
+      }}
+    >
+      <View
+        fixed
+        style={{
+          position: "absolute",
+          top: 28,
+          left: margins.left,
+          right: margins.right,
+          flexDirection: "row",
+          justifyContent: "space-between",
+        }}
+      >
+        <Text style={{ ...theme.text.label, color: theme.colors.muted }}>
+          {metadata.org ?? metadata.title}
+        </Text>
+        {metadata.confidentiality ? (
+          <Text style={{ ...theme.text.label, color: theme.colors.muted }}>{metadata.confidentiality}</Text>
+        ) : null}
+      </View>
+
+      <View>{children}</View>
+
+      <View
+        fixed
+        style={{
+          position: "absolute",
+          bottom: 28,
+          left: margins.left,
+          right: margins.right,
+          flexDirection: "row",
+          justifyContent: "space-between",
+          borderTopWidth: 0.5,
+          borderTopColor: theme.colors.border,
+          paddingTop: 4,
+        }}
+      >
+        <Text style={theme.text.caption}>{metadata.title}</Text>
+        <Text
+          style={theme.text.caption}
+          render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`}
+        />
+      </View>
+    </Page>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/layout/Section.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/layout/Section.tsx
@@ -1,0 +1,64 @@
+import { Text, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { Section as SectionData } from "../../schemas/contentSchema";
+import type { PageNumberStore } from "../../render/pageNumberStore";
+import { useTheme } from "../../theme/themeContext";
+import { BlockRenderer } from "../BlockRenderer";
+import { Heading } from "../primitives/Heading";
+
+interface SectionProps {
+  section: SectionData;
+  store: PageNumberStore;
+  level?: 1 | 2 | 3;
+  /** Optional leading number, e.g. "2" or "2.1", prepended to the title. */
+  numberLabel?: string;
+  /** "banded" renders the title in a filled bar (used by the playbook template). */
+  variant?: "plain" | "banded";
+}
+
+/**
+ * A document section: a probe records its first page for the TOC, a bookmark adds
+ * it to the outline, the `id` is its internal link target, then its blocks render.
+ */
+export function Section({
+  section,
+  store,
+  level = 1,
+  numberLabel,
+  variant = "plain",
+}: SectionProps): ReactElement {
+  const theme = useTheme();
+  const title = numberLabel ? `${numberLabel} ${section.title}` : section.title;
+  return (
+    <View id={section.id} bookmark={{ title }} style={{ marginBottom: theme.spacing.md }}>
+      <Text
+        style={{ height: 0, fontSize: 1 }}
+        render={({ pageNumber }) => {
+          store.set(section.id, pageNumber);
+          return "";
+        }}
+      />
+      {variant === "banded" ? (
+        <View
+          minPresenceAhead={theme.spacing.keepWithNext}
+          style={{
+            backgroundColor: theme.colors.primary,
+            paddingVertical: theme.spacing.sm,
+            paddingHorizontal: theme.spacing.md,
+            borderRadius: theme.rounded.sm,
+            marginTop: theme.spacing.lg,
+            marginBottom: theme.spacing.sm,
+          }}
+        >
+          <Text style={{ ...theme.text.h3, color: theme.colors.onPrimary }}>{title}</Text>
+        </View>
+      ) : (
+        <Heading level={level}>{title}</Heading>
+      )}
+      {section.blocks.map((block, index) => (
+        <BlockRenderer key={index} block={block} />
+      ))}
+    </View>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Body.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Body.tsx
@@ -1,0 +1,15 @@
+import { Text } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { RichText } from "../../schemas/blockSchema";
+import { useTheme } from "../../theme/themeContext";
+import { InlineRuns } from "./InlineText";
+
+export function Body({ content }: { content: RichText }): ReactElement {
+  const theme = useTheme();
+  return (
+    <Text style={{ ...theme.text.body, marginBottom: theme.spacing.sm }} orphans={2} widows={2}>
+      <InlineRuns content={content} />
+    </Text>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Callout.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Callout.tsx
@@ -1,0 +1,37 @@
+import { Text, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { Block } from "../../schemas/blockSchema";
+import { useTheme } from "../../theme/themeContext";
+import { InlineRuns } from "./InlineText";
+
+type CalloutData = Extract<Block, { type: "callout" }>;
+
+export function Callout({ block }: { block: CalloutData }): ReactElement {
+  const theme = useTheme();
+  const toneColor = theme.colors[block.tone];
+  return (
+    <View
+      wrap={false}
+      style={{
+        marginVertical: theme.spacing.sm,
+        padding: theme.spacing.md,
+        paddingLeft: theme.spacing.md + 4,
+        backgroundColor: theme.colors.surface,
+        borderLeftWidth: 3,
+        borderLeftColor: toneColor,
+        borderTopRightRadius: theme.rounded.md,
+        borderBottomRightRadius: theme.rounded.md,
+      }}
+    >
+      {block.title ? (
+        <Text style={{ ...theme.text.h3, color: toneColor, marginBottom: theme.spacing.xs }}>
+          {block.title}
+        </Text>
+      ) : null}
+      <Text style={theme.text.body}>
+        <InlineRuns content={block.content} />
+      </Text>
+    </View>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Caption.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Caption.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import { useTheme } from "../../theme/themeContext";
+
+export function Caption({ children }: { children: string }): ReactElement {
+  const theme = useTheme();
+  return <Text style={{ ...theme.text.caption, marginTop: theme.spacing.xs }}>{children}</Text>;
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Figure.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Figure.tsx
@@ -1,0 +1,25 @@
+import { Image, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { Block } from "../../schemas/blockSchema";
+import { useTheme } from "../../theme/themeContext";
+import { Caption } from "./Caption";
+
+type FigureData = Extract<Block, { type: "figure" }>;
+
+export function Figure({
+  block,
+  contentWidth,
+}: {
+  block: FigureData;
+  contentWidth: number;
+}): ReactElement {
+  const theme = useTheme();
+  const width = Math.round(contentWidth * block.widthPct);
+  return (
+    <View style={{ marginVertical: theme.spacing.md, alignItems: "center" }}>
+      <Image src={block.src} style={{ width }} />
+      {block.caption ? <Caption>{block.caption}</Caption> : null}
+    </View>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Heading.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/Heading.tsx
@@ -1,0 +1,30 @@
+import { Text } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import { useTheme } from "../../theme/themeContext";
+
+interface HeadingProps {
+  level: 1 | 2 | 3;
+  children: string;
+  /** Link-target id for internal references. */
+  id?: string;
+}
+
+/**
+ * A heading that stays attached to the content beneath it via `minPresenceAhead`
+ * (rather than `wrap={false}`, which throws on blocks taller than a page).
+ */
+export function Heading({ level, children, id }: HeadingProps): ReactElement {
+  const theme = useTheme();
+  const style = { 1: theme.text.h1, 2: theme.text.h2, 3: theme.text.h3 }[level];
+  const marginTop = level === 1 ? theme.spacing.lg : theme.spacing.md;
+  return (
+    <Text
+      id={id}
+      minPresenceAhead={theme.spacing.keepWithNext}
+      style={{ ...style, marginTop, marginBottom: theme.spacing.sm }}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/InlineText.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/InlineText.tsx
@@ -1,0 +1,47 @@
+import { Link, Text } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { RichText } from "../../schemas/blockSchema";
+import { useTheme } from "../../theme/themeContext";
+
+/**
+ * Render rich text as inline runs. Returns a fragment of nested <Text>/<Link>
+ * elements meant to sit inside a styled parent <Text>, so emphasis and links
+ * flow inline rather than stacking as blocks.
+ */
+export function InlineRuns({ content }: { content: RichText }): ReactElement {
+  const theme = useTheme();
+  return (
+    <>
+      {content.map((mark, index) => {
+        const isLink = Boolean(mark.href || mark.anchor);
+        const style = {
+          fontFamily: mark.code ? theme.text.mono.fontFamily : undefined,
+          fontWeight: mark.bold ? ("bold" as const) : undefined,
+          fontStyle: mark.italic ? ("italic" as const) : undefined,
+          color: isLink ? theme.colors.primary : undefined,
+          textDecoration: isLink ? ("underline" as const) : undefined,
+        };
+        if (mark.href) {
+          return (
+            <Link key={index} src={mark.href} style={style}>
+              {mark.text}
+            </Link>
+          );
+        }
+        if (mark.anchor) {
+          return (
+            <Link key={index} src={`#${mark.anchor}`} style={style}>
+              {mark.text}
+            </Link>
+          );
+        }
+        return (
+          <Text key={index} style={style}>
+            {mark.text}
+          </Text>
+        );
+      })}
+    </>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/ListBlock.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/ListBlock.tsx
@@ -1,0 +1,26 @@
+import { Text, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { Block } from "../../schemas/blockSchema";
+import { useTheme } from "../../theme/themeContext";
+import { InlineRuns } from "./InlineText";
+
+type ListBlockData = Extract<Block, { type: "list" }>;
+
+export function ListBlock({ block }: { block: ListBlockData }): ReactElement {
+  const theme = useTheme();
+  return (
+    <View style={{ marginBottom: theme.spacing.sm }}>
+      {block.items.map((item, index) => (
+        <View key={index} style={{ flexDirection: "row", marginBottom: theme.spacing.xs }}>
+          <Text style={{ ...theme.text.body, width: 18, color: theme.colors.muted }}>
+            {block.ordered ? `${index + 1}.` : "•"}
+          </Text>
+          <Text style={{ ...theme.text.body, flex: 1 }}>
+            <InlineRuns content={item} />
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/PullQuote.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/components/primitives/PullQuote.tsx
@@ -1,0 +1,29 @@
+import { Text, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import type { Block } from "../../schemas/blockSchema";
+import { useTheme } from "../../theme/themeContext";
+
+type PullQuoteData = Extract<Block, { type: "pullquote" }>;
+
+export function PullQuote({ block }: { block: PullQuoteData }): ReactElement {
+  const theme = useTheme();
+  return (
+    <View
+      wrap={false}
+      style={{
+        marginVertical: theme.spacing.md,
+        paddingLeft: theme.spacing.md,
+        borderLeftWidth: 2,
+        borderLeftColor: theme.colors.primary,
+      }}
+    >
+      <Text style={theme.text.quote}>{block.text}</Text>
+      {block.attribution ? (
+        <Text style={{ ...theme.text.caption, marginTop: theme.spacing.xs }}>
+          — {block.attribution}
+        </Text>
+      ) : null}
+    </View>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/install-check.mjs
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/install-check.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Idempotent on-demand dependency installer for the pdf:create renderer.
+ *
+ * Runs `npm install --omit=dev` only when the install marker is absent, so the
+ * first render bootstraps the renderer's pinned dependencies and every later
+ * render is instant and offline-capable. Run from the renderer directory:
+ *
+ *   node install-check.mjs
+ *
+ * Because it resolves its own directory from import.meta.url, it works whether
+ * the skill runs as the autopilot plugin or is copied standalone into
+ * ~/.claude/skills/.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const marker = join(here, "node_modules", ".pdf-create-ok");
+const rendererEntry = join(here, "node_modules", "@react-pdf", "renderer", "package.json");
+
+const nodeMajor = Number(process.versions.node.split(".")[0]);
+if (nodeMajor > 22) {
+  console.warn(
+    `pdf:create: Node ${process.versions.node} detected. @react-pdf/renderer is most tested on Node 18-22; ` +
+      `use the repo .nvmrc (22) if you hit rendering issues.`,
+  );
+}
+
+if (existsSync(marker) && existsSync(rendererEntry)) {
+  process.exit(0);
+}
+
+console.error("pdf:create: installing renderer dependencies (one-time, ~30s)...");
+try {
+  execFileSync("npm", ["install", "--omit=dev", "--no-audit", "--no-fund", "--prefer-offline"], {
+    cwd: here,
+    stdio: "inherit",
+  });
+} catch {
+  console.error(
+    "pdf:create: dependency install failed. Ensure Node and npm are on PATH and you have " +
+      "network access for the first run.",
+  );
+  process.exit(1);
+}
+
+writeFileSync(marker, "ok\n");
+process.exit(0);

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/lib/paths.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/lib/paths.ts
@@ -1,0 +1,16 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Absolute paths into the renderer, resolved from this module's own URL.
+ *
+ * Resolving from `import.meta.url` (never `process.cwd()` or a plugin-only env
+ * var) is what makes the skill portable: the same code finds its bundled assets
+ * whether it runs as the autopilot plugin or is copied into `~/.claude/skills/`.
+ */
+const libDir = dirname(fileURLToPath(import.meta.url));
+
+export const rendererDir = join(libDir, "..");
+export const assetsDir = join(rendererDir, "assets");
+export const fontsDir = join(assetsDir, "fonts");
+export const examplesDir = join(rendererDir, "references", "examples");

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/package-lock.json
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/package-lock.json
@@ -1,0 +1,1282 @@
+{
+  "name": "pdf-create-renderer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pdf-create-renderer",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/renderer": "4.5.1",
+        "gray-matter": "4.0.3",
+        "react": "19.2.7",
+        "tsx": "4.22.4",
+        "zod": "3.23.8"
+      },
+      "devDependencies": {
+        "@types/react": "19.2.17"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/package.json
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "pdf-create-renderer",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Bundled @react-pdf/renderer pipeline for the pdf:create skill",
+  "license": "MIT",
+  "scripts": {
+    "render": "tsx render.tsx",
+    "test": "node --import tsx --test test/*.test.ts"
+  },
+  "dependencies": {
+    "@react-pdf/renderer": "4.5.1",
+    "gray-matter": "4.0.3",
+    "react": "19.2.7",
+    "tsx": "4.22.4",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.17"
+  }
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/references/content-schema.md
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/references/content-schema.md
@@ -1,0 +1,87 @@
+# Content JSON schema
+
+The renderer consumes one JSON document validated by `schemas/contentSchema.ts`.
+Produce a file that conforms to this shape, then pass its path with `--content`.
+A complete worked example is in `examples/report.content.json`.
+
+## Top level
+
+| Field           | Type                                                  | Required | Notes                                            |
+| --------------- | ---------------------------------------------------- | -------- | ------------------------------------------------ |
+| `schemaVersion` | `1`                                                  | yes      | Always `1`.                                      |
+| `template`      | `report` \| `researchDoc` \| `sixPager` \| `playbook` | yes      | Overridable with `--template`.                   |
+| `metadata`      | object                                               | yes      | See below.                                       |
+| `cover`         | object                                               | no       | Cover page content; falls back to `metadata`.    |
+| `toc`           | boolean                                              | no       | Default `true`. Table of contents.               |
+| `sections`      | array of section                                     | yes      | At least one.                                    |
+| `appendix`      | array of section                                     | no       | Rendered after a page break.                     |
+
+### `metadata`
+
+`title` (required), `subtitle`, `authors` (string array), `date`, `org`,
+`confidentiality`. `title` is used in the PDF metadata and the running footer.
+
+### `cover`
+
+`title` (required), `eyebrow`, `subtitle`, `footnote`. Shown on the cover page
+(report, researchDoc, playbook). The six-pager uses a memo header instead.
+
+### `section`
+
+`id` (required, unique — it is the internal link/anchor target), `title`
+(required), `tocLevel` (`1` or `2`, default `1`), `blocks` (at least one).
+
+## Blocks
+
+Every block has a `type`. The union:
+
+- **heading** — `level` (1–3), `text`, optional `id`. For sub-headings inside a
+  section; the section title is rendered automatically.
+- **paragraph** — `content`: rich text (see below).
+- **list** — `ordered` (boolean, default false), `items`: array of rich text.
+- **table** — `columns` (`{ header, width?, align? }`; `width` is a 0–1 fraction),
+  `rows` (array of rows; each row is an array of rich-text cells), `caption?`.
+- **figure** — `src` (PNG/JPG path or data URI; **SVG is rejected**), `alt`,
+  `caption?`, `widthPct` (0–1, default 1).
+- **chart** — `spec` (see Charts), `caption?`.
+- **callout** — `tone` (`info` \| `success` \| `warning` \| `danger` \| `neutral`),
+  `title?`, `content`: rich text.
+- **pullquote** — `text`, `attribution?`.
+- **pagebreak** — forces a new page.
+
+### Rich text
+
+An array of runs: `{ text, bold?, italic?, code?, href?, anchor? }`. `href` is an
+external link; `anchor` links to a section `id` within the document.
+
+```json
+[{ "text": "Revenue grew " }, { "text": "18%", "bold": true }, { "text": " QoQ." }]
+```
+
+### Charts
+
+`spec` fields: `kind` (`bar` \| `line` \| `area` \| `pie` \| `donut` \| `stackedBar`),
+`series` (array of `{ name, points: [{ x, y }] }`), `xLabel?`, `yLabel?`,
+`width?` (default 480), `height?` (default 280), `palette?` (array of hex colors).
+For `pie`/`donut`, the first series' points are the slices.
+
+```json
+{
+  "type": "chart",
+  "spec": {
+    "kind": "bar",
+    "series": [{ "name": "Revenue", "points": [{ "x": "Q1", "y": 120 }, { "x": "Q2", "y": 142 }] }]
+  },
+  "caption": "Quarterly revenue."
+}
+```
+
+## Tips
+
+- Put styling in the theme (design.md), not the content. The content carries
+  meaning; the theme carries appearance.
+- Give every section a stable, unique `id` so the TOC, bookmarks, and internal
+  links resolve.
+- For a six-pager, provide exactly six sections (Introduction, Goals, Tenets,
+  State of the Business, Lessons Learned, Strategic Priorities); push tables and
+  charts into the `appendix`.

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/references/design-md-spec.md
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/references/design-md-spec.md
@@ -1,0 +1,73 @@
+# design.md theming
+
+A `design.md` carries a brand's visual identity as YAML front-matter design
+tokens plus a human-readable body. The renderer parses the front-matter,
+resolves `{path.to.token}` references, validates it, and overlays it onto the
+default theme — so a brand file only declares what differs. See
+`examples/brand.design.md`.
+
+## Front-matter tokens
+
+| Key          | Shape                                                              | Maps to                                   |
+| ------------ | ----------------------------------------------------------------- | ----------------------------------------- |
+| `name`       | string                                                            | Theme name.                               |
+| `version`    | string                                                            | Informational.                            |
+| `colors`     | flat or nested map of name → hex (or `{token}` ref)               | The document palette.                     |
+| `typography` | map of name → `{ fontFamily, fontSize, fontWeight, lineHeight, letterSpacing, textTransform, fontStyle, color }` | Text styles. |
+| `spacing`    | map of name → length                                              | Spacing scale (matching keys override).   |
+| `rounded`    | map of name → length                                              | Corner radii (matching keys override).    |
+| `fonts`      | array of `{ family, weights, italics }`                           | Custom font registration.                 |
+
+### Token references
+
+Any value may be a `{path.to.token}` reference (or embed one). References are
+resolved before validation; an unknown or cyclic reference fails the render
+loudly (exit 4).
+
+```yaml
+colors:
+  brand:
+    primary: "#6d28d9"
+  primary: "{colors.brand.primary}"
+```
+
+### Color mapping
+
+Palette slots are filled by matching token names (case-insensitive, by full
+dot-path or leaf name), with sensible fallbacks: `background`, `surface`, `text`,
+`muted`, `primary`, `onPrimary`, `border`, `accent`, and tones `info`, `success`,
+`warning`, `danger`, `neutral`. Unmatched colors are ignored; unfilled slots keep
+their default.
+
+### Typography mapping
+
+Slots `display`, `h1`, `h2`, `h3`, `body`, `caption`, `quote`, `label`, `mono`
+are matched by name (with aliases — e.g. `heading1`→`h1`, `paragraph`→`body`,
+`code`→`mono`). `fontSize`/`letterSpacing` accept `px`, `pt`, `rem`, `em`, or a
+number (points); `1rem` = `12pt`. `lineHeight` is a unitless multiple.
+
+### Lengths
+
+`px` → ×0.75 pt, `rem` → ×12 pt, `em` → × the element's size, bare number → pt.
+
+## Fonts
+
+The default theme uses standard PDF families (`Helvetica`, `Times-Roman`,
+`Courier`) — no files needed. For a custom typeface, drop static-weight `.ttf`/
+`.woff` files in `assets/fonts/` and declare them:
+
+```yaml
+fonts:
+  - family: Inter
+    weights:
+      "400": Inter-Regular.ttf
+      "700": Inter-Bold.ttf
+    italics:
+      "400": Inter-Italic.ttf
+typography:
+  body: { fontFamily: Inter }
+```
+
+Variable fonts are rejected — the PDF format needs discrete weights. The renderer
+verifies every referenced font exists before rendering and fails loudly (exit 5)
+on a missing, remote, or variable font, rather than hanging.

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/references/examples/brand.design.md
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/references/examples/brand.design.md
@@ -1,0 +1,47 @@
+---
+version: alpha
+name: Acme Brand
+colors:
+  brand:
+    primary: "#6d28d9"
+    secondary: "#db2777"
+  primary: "{colors.brand.primary}"
+  accent: "{colors.brand.secondary}"
+  background: "#ffffff"
+  surface: "#f5f3ff"
+  text: "#111827"
+  muted: "#6b7280"
+  border: "#e5e7eb"
+typography:
+  body:
+    fontFamily: Helvetica
+    fontSize: 11
+    lineHeight: 1.5
+  h1:
+    fontFamily: Helvetica
+    fontSize: 24
+    fontWeight: 700
+  display:
+    fontFamily: Helvetica
+    fontSize: 34
+    fontWeight: 700
+spacing:
+  md: 14
+---
+
+# Acme Brand
+
+A small example `design.md` for the `pdf:create` skill. It demonstrates token
+references (`{colors.brand.primary}`), a partial typography scale, and a spacing
+override. Everything not specified here falls back to the renderer's default
+theme, so a brand file only needs to declare what differs.
+
+## Colors
+
+The primary and accent colors reference the brand palette via `{path.to.token}`
+syntax, which the loader resolves before building the theme.
+
+## Typography
+
+Uses the standard `Helvetica` family at brand sizes. To use a custom typeface,
+add a `fonts` mapping and drop static-weight files in `assets/fonts/`.

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/references/examples/report.content.json
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/references/examples/report.content.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": 1,
+  "template": "report",
+  "metadata": {
+    "title": "Quarterly Business Review",
+    "subtitle": "Q2 2026 performance and outlook",
+    "authors": ["Jane Doe", "Sam Patel"],
+    "date": "Q2 2026",
+    "org": "Acme Corporation",
+    "confidentiality": "Confidential"
+  },
+  "cover": {
+    "eyebrow": "Quarterly Review",
+    "title": "Q2 2026 Business Review",
+    "subtitle": "Revenue, product, and the road to Q3",
+    "footnote": "Prepared for the Acme leadership team. Do not distribute."
+  },
+  "toc": true,
+  "sections": [
+    {
+      "id": "summary",
+      "title": "Executive Summary",
+      "blocks": [
+        {
+          "type": "paragraph",
+          "content": [
+            { "text": "Revenue grew " },
+            { "text": "18% quarter over quarter", "bold": true },
+            { "text": ", driven by enterprise expansion and stronger retention." }
+          ]
+        },
+        {
+          "type": "callout",
+          "tone": "success",
+          "title": "On track for the annual plan",
+          "content": [{ "text": "Every top-line target for the quarter was met or exceeded." }]
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            [{ "text": "Net revenue retention reached 121%." }],
+            [{ "text": "Two of three product bets shipped on schedule." }],
+            [{ "text": "Gross margin improved by 3 points." }]
+          ]
+        }
+      ]
+    },
+    {
+      "id": "performance",
+      "title": "Performance",
+      "blocks": [
+        {
+          "type": "paragraph",
+          "content": [{ "text": "Quarterly revenue continued its upward trend across both segments." }]
+        },
+        {
+          "type": "chart",
+          "spec": {
+            "kind": "bar",
+            "series": [
+              {
+                "name": "Revenue ($M)",
+                "points": [
+                  { "x": "Q3'25", "y": 98 },
+                  { "x": "Q4'25", "y": 112 },
+                  { "x": "Q1'26", "y": 120 },
+                  { "x": "Q2'26", "y": 142 }
+                ]
+              }
+            ]
+          },
+          "caption": "Quarterly revenue, last four quarters ($M)."
+        },
+        {
+          "type": "table",
+          "columns": [
+            { "header": "Segment", "width": 0.5 },
+            { "header": "Revenue", "width": 0.25, "align": "right" },
+            { "header": "Growth", "width": 0.25, "align": "right" }
+          ],
+          "rows": [
+            [[{ "text": "Enterprise" }], [{ "text": "$96M" }], [{ "text": "+22%" }]],
+            [[{ "text": "Mid-market" }], [{ "text": "$46M" }], [{ "text": "+11%" }]]
+          ],
+          "caption": "Revenue by segment."
+        }
+      ]
+    },
+    {
+      "id": "outlook",
+      "title": "Outlook",
+      "blocks": [
+        {
+          "type": "paragraph",
+          "content": [{ "text": "We enter Q3 with healthy pipeline coverage and a focused roadmap." }]
+        },
+        {
+          "type": "pullquote",
+          "text": "The next quarter is about turning expansion momentum into durable, profitable growth.",
+          "attribution": "Jane Doe, CEO"
+        }
+      ]
+    }
+  ],
+  "appendix": [
+    {
+      "id": "data",
+      "title": "Supporting Data",
+      "blocks": [
+        {
+          "type": "table",
+          "columns": [{ "header": "Metric" }, { "header": "Value", "align": "right" }],
+          "rows": [
+            [[{ "text": "Net revenue retention" }], [{ "text": "121%" }]],
+            [[{ "text": "Gross margin" }], [{ "text": "74%" }]],
+            [[{ "text": "Logo churn" }], [{ "text": "1.2%" }]]
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/render.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/render.tsx
@@ -1,0 +1,149 @@
+import { mkdirSync, readFileSync, statSync } from "node:fs";
+import { dirname } from "node:path";
+import { parseArgs } from "node:util";
+
+import { renderToFile } from "@react-pdf/renderer";
+import { createElement } from "react";
+import { ZodError } from "zod";
+
+import { ThemeContext } from "./theme/themeContext";
+import { assertFontsResolve } from "./theme/assertFontsResolve";
+import { contrastRatio } from "./theme/contrast";
+import { registerFonts } from "./theme/registerFonts";
+import { resolveTheme } from "./theme/loadDesignMd";
+import { contentSchema, templateNameSchema } from "./schemas/contentSchema";
+import { createPageNumberStore } from "./render/pageNumberStore";
+import { contentError, exitCodeFor, renderError, usageError } from "./render/errors";
+import { templateRegistry } from "./templates/templateRegistry";
+
+const usage =
+  "Usage: render.tsx --content <content.json> --out <output.pdf> " +
+  "[--design <design.md>] [--template <report|researchDoc|sixPager|playbook>] [--strict-contrast]";
+
+function parseCliArgs(): {
+  content: string;
+  out: string;
+  design?: string;
+  template?: string;
+  strictContrast: boolean;
+} {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      options: {
+        content: { type: "string" },
+        out: { type: "string" },
+        design: { type: "string" },
+        template: { type: "string" },
+        "strict-contrast": { type: "boolean", default: false },
+      },
+    });
+  } catch (error) {
+    throw usageError(`${(error as Error).message}\n${usage}`);
+  }
+  const { values } = parsed;
+  if (!values.content || !values.out) throw usageError(`--content and --out are required.\n${usage}`);
+  return {
+    content: values.content,
+    out: values.out,
+    design: values.design,
+    template: values.template,
+    strictContrast: values["strict-contrast"] ?? false,
+  };
+}
+
+function loadContent(path: string): ReturnType<typeof contentSchema.parse> {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    throw contentError(`Could not read content JSON at ${path}`);
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (error) {
+    throw contentError(`Invalid JSON in ${path}: ${(error as Error).message}`);
+  }
+  try {
+    return contentSchema.parse(json);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const issues = error.errors
+        .map((issue) => `  - ${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("\n");
+      throw contentError(`Content JSON failed validation:\n${issues}`);
+    }
+    throw error;
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseCliArgs();
+  const content = loadContent(args.content);
+
+  const templateName = args.template ?? content.template;
+  const validTemplate = templateNameSchema.safeParse(templateName);
+  if (!validTemplate.success) {
+    throw usageError(
+      `Unknown template "${templateName}". Valid: ${templateNameSchema.options.join(", ")}.`,
+    );
+  }
+
+  const theme = resolveTheme(args.design);
+
+  const ratio = contrastRatio(theme.text.body.color ?? theme.colors.text, theme.colors.background);
+  if (ratio !== null && ratio < 4.5) {
+    const message = `Body text vs background contrast is ${ratio.toFixed(2)}:1 (WCAG AA wants >= 4.5:1).`;
+    if (args.strictContrast) throw renderError(message);
+    console.warn(`pdf:create: ${message}`);
+  }
+
+  assertFontsResolve(theme);
+  registerFonts(theme);
+
+  if (validTemplate.data === "sixPager" && content.sections.length !== 6) {
+    console.warn(
+      `pdf:create: sixPager has ${content.sections.length} sections; the format expects 6 ` +
+        `(Introduction, Goals, Tenets, State of the Business, Lessons Learned, Strategic Priorities).`,
+    );
+  }
+
+  const store = createPageNumberStore();
+  const Template = templateRegistry[validTemplate.data];
+  const element = createElement(
+    ThemeContext.Provider,
+    { value: theme },
+    createElement(Template, { content, store }),
+  );
+
+  mkdirSync(dirname(args.out), { recursive: true });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const watchdog = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          renderError(
+            "Rendering timed out after 60s — likely a missing/variable font or a block taller than a page.",
+          ),
+        ),
+      60_000,
+    );
+  });
+  try {
+    await Promise.race([renderToFile(element, args.out), watchdog]);
+  } catch (error) {
+    throw renderError(`Failed to render PDF: ${(error as Error).message}`);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const sizeKb = (statSync(args.out).size / 1024).toFixed(1);
+  console.log(`pdf:create: wrote ${args.out} (${sizeKb} KB)`);
+}
+
+main().catch((error: unknown) => {
+  console.error(`pdf:create: ${(error as Error).message}`);
+  process.exit(exitCodeFor(error));
+});

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/render/collectTocEntries.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/render/collectTocEntries.ts
@@ -1,0 +1,14 @@
+import type { Content, Section } from "../schemas/contentSchema";
+
+export interface TocEntry {
+  id: string;
+  title: string;
+  level: 1 | 2;
+}
+
+/** Flatten body sections and the appendix into an ordered list of TOC entries. */
+export function collectTocEntries(content: Content): TocEntry[] {
+  const entries = (sections: Section[]): TocEntry[] =>
+    sections.map((section) => ({ id: section.id, title: section.title, level: section.tocLevel }));
+  return [...entries(content.sections), ...entries(content.appendix)];
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/render/errors.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/render/errors.ts
@@ -1,0 +1,38 @@
+/**
+ * Typed, exit-code-bearing errors for the render pipeline.
+ *
+ * Factories (not classes) keep the module functional while attaching a numeric
+ * `code` to each Error so `render.tsx` can map a failure to a deterministic
+ * process exit code the calling skill can branch on.
+ */
+export interface CodedError extends Error {
+  code: number;
+}
+
+function makeError(name: string, code: number): (message: string) => CodedError {
+  return (message: string): CodedError => {
+    const error = new Error(message) as CodedError;
+    error.name = name;
+    error.code = code;
+    return error;
+  };
+}
+
+/** Bad CLI arguments or unknown template (exit 2). */
+export const usageError = makeError("UsageError", 2);
+/** Content JSON failed schema validation (exit 3). */
+export const contentError = makeError("ContentError", 3);
+/** design.md parsing / token resolution failed (exit 4). */
+export const themeError = makeError("ThemeError", 4);
+/** A required font could not be resolved (exit 5). */
+export const fontResolutionError = makeError("FontResolutionError", 5);
+/** A chart spec could not be rendered (exit 6). */
+export const chartError = makeError("ChartError", 6);
+/** PDF rendering threw or timed out (exit 7). */
+export const renderError = makeError("RenderError", 7);
+
+/** Resolve a thrown value to its exit code, defaulting to 1 for unexpected errors. */
+export function exitCodeFor(error: unknown): number {
+  const code = (error as CodedError | undefined)?.code;
+  return typeof code === "number" ? code : 1;
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/render/pageNumberStore.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/render/pageNumberStore.ts
@@ -1,0 +1,24 @@
+/**
+ * Records the first page each section lands on during layout, so the table of
+ * contents can print real page numbers.
+ *
+ * @react-pdf/renderer evaluates `render` callbacks during a layout pass before
+ * the final pass. A probe inside each section writes its page here; TOC rows
+ * read it back. Only the first page seen for an id is kept.
+ */
+export interface PageNumberStore {
+  set(id: string, page: number): void;
+  get(id: string): number | undefined;
+}
+
+export function createPageNumberStore(): PageNumberStore {
+  const pages = new Map<string, number>();
+  return {
+    set(id, page) {
+      if (!pages.has(id)) pages.set(id, page);
+    },
+    get(id) {
+      return pages.get(id);
+    },
+  };
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/schemas/blockSchema.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/schemas/blockSchema.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+import { chartSpecSchema } from "./chartSpecSchema";
+
+/** An inline run of text with optional emphasis or a link. */
+export const inlineMarkSchema = z.object({
+  text: z.string(),
+  bold: z.boolean().optional(),
+  italic: z.boolean().optional(),
+  code: z.boolean().optional(),
+  /** External link target. */
+  href: z.string().url().optional(),
+  /** Internal link to a section `id` (rendered as `#<anchor>`). */
+  anchor: z.string().optional(),
+});
+export type InlineMark = z.infer<typeof inlineMarkSchema>;
+
+/** Rich text is an ordered list of inline runs. */
+export const richTextSchema = z.array(inlineMarkSchema).min(1);
+export type RichText = z.infer<typeof richTextSchema>;
+
+export const headingBlockSchema = z.object({
+  type: z.literal("heading"),
+  level: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  text: z.string(),
+  id: z.string().optional(),
+});
+
+export const paragraphBlockSchema = z.object({
+  type: z.literal("paragraph"),
+  content: richTextSchema,
+});
+
+export const listBlockSchema = z.object({
+  type: z.literal("list"),
+  ordered: z.boolean().default(false),
+  items: z.array(richTextSchema).min(1),
+});
+
+export const tableColumnSchema = z.object({
+  header: z.string(),
+  /** Column width as a fraction of table width (0–1); evenly split when omitted. */
+  width: z.number().min(0).max(1).optional(),
+  align: z.enum(["left", "center", "right"]).optional(),
+});
+
+export const tableBlockSchema = z.object({
+  type: z.literal("table"),
+  columns: z.array(tableColumnSchema).min(1),
+  rows: z.array(z.array(richTextSchema)).min(1),
+  caption: z.string().optional(),
+});
+
+/** SVG sources are rejected — @react-pdf/renderer's <Image> cannot decode them. */
+const rasterImageSrc = z
+  .string()
+  .refine((value) => !/^data:image\/svg\+xml/i.test(value) && !/\.svg($|[?#])/i.test(value), {
+    message: "SVG images are unsupported by <Image>; pre-render to PNG or JPG",
+  });
+
+export const figureBlockSchema = z.object({
+  type: z.literal("figure"),
+  src: rasterImageSrc,
+  alt: z.string(),
+  caption: z.string().optional(),
+  /** Image width as a fraction of the content width (0–1). */
+  widthPct: z.number().min(0).max(1).default(1),
+});
+
+export const chartBlockSchema = z.object({
+  type: z.literal("chart"),
+  spec: chartSpecSchema,
+  caption: z.string().optional(),
+});
+
+export const calloutBlockSchema = z.object({
+  type: z.literal("callout"),
+  tone: z.enum(["info", "success", "warning", "danger", "neutral"]).default("info"),
+  title: z.string().optional(),
+  content: richTextSchema,
+});
+
+export const pullQuoteBlockSchema = z.object({
+  type: z.literal("pullquote"),
+  text: z.string(),
+  attribution: z.string().optional(),
+});
+
+export const pageBreakBlockSchema = z.object({
+  type: z.literal("pagebreak"),
+});
+
+/** The block model — a discriminated union on `type`. */
+export const blockSchema = z.discriminatedUnion("type", [
+  headingBlockSchema,
+  paragraphBlockSchema,
+  listBlockSchema,
+  tableBlockSchema,
+  figureBlockSchema,
+  chartBlockSchema,
+  calloutBlockSchema,
+  pullQuoteBlockSchema,
+  pageBreakBlockSchema,
+]);
+export type Block = z.infer<typeof blockSchema>;

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/schemas/chartSpecSchema.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/schemas/chartSpecSchema.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/** A single data point. `x` is a category label (string) or numeric position. */
+export const chartPointSchema = z.object({
+  x: z.union([z.string(), z.number()]),
+  y: z.number(),
+});
+
+/** A named data series — one bar group, line, or pie's worth of points. */
+export const chartSeriesSchema = z.object({
+  name: z.string(),
+  points: z.array(chartPointSchema).min(1),
+});
+
+/**
+ * A declarative chart, rendered to vector graphics with @react-pdf/renderer's
+ * own SVG primitives (no native canvas dependency, fully portable).
+ */
+export const chartSpecSchema = z.object({
+  kind: z.enum(["bar", "line", "area", "pie", "donut", "stackedBar"]),
+  series: z.array(chartSeriesSchema).min(1),
+  xLabel: z.string().optional(),
+  yLabel: z.string().optional(),
+  width: z.number().positive().default(480),
+  height: z.number().positive().default(280),
+  palette: z.array(z.string()).optional(),
+});
+
+export type ChartSpec = z.infer<typeof chartSpecSchema>;
+export type ChartSeries = z.infer<typeof chartSeriesSchema>;
+export type ChartPoint = z.infer<typeof chartPointSchema>;

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/schemas/contentSchema.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/schemas/contentSchema.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+import { blockSchema } from "./blockSchema";
+
+export const metadataSchema = z.object({
+  title: z.string(),
+  subtitle: z.string().optional(),
+  authors: z.array(z.string()).default([]),
+  date: z.string().optional(),
+  org: z.string().optional(),
+  confidentiality: z.string().optional(),
+});
+export type Metadata = z.infer<typeof metadataSchema>;
+
+export const coverSchema = z.object({
+  eyebrow: z.string().optional(),
+  title: z.string(),
+  subtitle: z.string().optional(),
+  footnote: z.string().optional(),
+});
+export type Cover = z.infer<typeof coverSchema>;
+
+export const sectionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  /** Heading depth in the table of contents (1 = top level, 2 = nested). */
+  tocLevel: z.union([z.literal(1), z.literal(2)]).default(1),
+  blocks: z.array(blockSchema).min(1),
+});
+export type Section = z.infer<typeof sectionSchema>;
+
+export const templateNameSchema = z.enum(["report", "researchDoc", "sixPager", "playbook"]);
+export type TemplateName = z.infer<typeof templateNameSchema>;
+
+/** The single document object the renderer consumes — the stable Claude↔renderer contract. */
+export const contentSchema = z.object({
+  schemaVersion: z.literal(1),
+  template: templateNameSchema,
+  metadata: metadataSchema,
+  cover: coverSchema.optional(),
+  toc: z.boolean().default(true),
+  sections: z.array(sectionSchema).min(1),
+  appendix: z.array(sectionSchema).default([]),
+});
+export type Content = z.infer<typeof contentSchema>;

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/templates/playbookTemplate.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/templates/playbookTemplate.tsx
@@ -1,0 +1,34 @@
+import { Document, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import { CoverPage } from "../components/CoverPage";
+import { TableOfContents } from "../components/TableOfContents";
+import { PageShell } from "../components/layout/PageShell";
+import { Section } from "../components/layout/Section";
+import { Heading } from "../components/primitives/Heading";
+import { collectTocEntries } from "../render/collectTocEntries";
+import type { TemplateProps } from "./templateProps";
+
+/** Operational playbook: each section is a "play" with a banded header. */
+export function playbookTemplate({ content, store }: TemplateProps): ReactElement {
+  const entries = collectTocEntries(content);
+  return (
+    <Document title={content.metadata.title} author={content.metadata.authors.join(", ")}>
+      <CoverPage cover={content.cover} metadata={content.metadata} />
+      <PageShell metadata={content.metadata}>
+        {content.toc ? <TableOfContents entries={entries} store={store} /> : null}
+        {content.sections.map((section) => (
+          <Section key={section.id} section={section} store={store} variant="banded" />
+        ))}
+        {content.appendix.length > 0 ? (
+          <View break>
+            <Heading level={1}>Appendix</Heading>
+            {content.appendix.map((section) => (
+              <Section key={section.id} section={section} store={store} variant="banded" />
+            ))}
+          </View>
+        ) : null}
+      </PageShell>
+    </Document>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/templates/reportTemplate.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/templates/reportTemplate.tsx
@@ -1,0 +1,34 @@
+import { Document, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import { CoverPage } from "../components/CoverPage";
+import { TableOfContents } from "../components/TableOfContents";
+import { PageShell } from "../components/layout/PageShell";
+import { Section } from "../components/layout/Section";
+import { Heading } from "../components/primitives/Heading";
+import { collectTocEntries } from "../render/collectTocEntries";
+import type { TemplateProps } from "./templateProps";
+
+/** General-purpose business report: cover, contents, sequential sections, appendix. */
+export function reportTemplate({ content, store }: TemplateProps): ReactElement {
+  const entries = collectTocEntries(content);
+  return (
+    <Document title={content.metadata.title} author={content.metadata.authors.join(", ")}>
+      <CoverPage cover={content.cover} metadata={content.metadata} />
+      <PageShell metadata={content.metadata}>
+        {content.toc ? <TableOfContents entries={entries} store={store} /> : null}
+        {content.sections.map((section) => (
+          <Section key={section.id} section={section} store={store} />
+        ))}
+        {content.appendix.length > 0 ? (
+          <View break>
+            <Heading level={1}>Appendix</Heading>
+            {content.appendix.map((section) => (
+              <Section key={section.id} section={section} store={store} />
+            ))}
+          </View>
+        ) : null}
+      </PageShell>
+    </Document>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/templates/researchDocTemplate.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/templates/researchDocTemplate.tsx
@@ -1,0 +1,34 @@
+import { Document, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import { CoverPage } from "../components/CoverPage";
+import { TableOfContents } from "../components/TableOfContents";
+import { PageShell } from "../components/layout/PageShell";
+import { Section } from "../components/layout/Section";
+import { Heading } from "../components/primitives/Heading";
+import { collectTocEntries } from "../render/collectTocEntries";
+import type { TemplateProps } from "./templateProps";
+
+/** Academic-style document: author-forward cover, numbered sections, references appendix. */
+export function researchDocTemplate({ content, store }: TemplateProps): ReactElement {
+  const entries = collectTocEntries(content);
+  return (
+    <Document title={content.metadata.title} author={content.metadata.authors.join(", ")}>
+      <CoverPage cover={content.cover} metadata={content.metadata} />
+      <PageShell metadata={content.metadata}>
+        {content.toc ? <TableOfContents entries={entries} store={store} /> : null}
+        {content.sections.map((section, index) => (
+          <Section key={section.id} section={section} store={store} numberLabel={`${index + 1}.`} />
+        ))}
+        {content.appendix.length > 0 ? (
+          <View break>
+            <Heading level={1}>References</Heading>
+            {content.appendix.map((section) => (
+              <Section key={section.id} section={section} store={store} />
+            ))}
+          </View>
+        ) : null}
+      </PageShell>
+    </Document>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/templates/sixPagerTemplate.tsx
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/templates/sixPagerTemplate.tsx
@@ -1,0 +1,57 @@
+import { Document, Text, View } from "@react-pdf/renderer";
+import type { ReactElement } from "react";
+
+import { TableOfContents } from "../components/TableOfContents";
+import { PageShell } from "../components/layout/PageShell";
+import { Section } from "../components/layout/Section";
+import { Heading } from "../components/primitives/Heading";
+import { collectTocEntries } from "../render/collectTocEntries";
+import { useTheme } from "../theme/themeContext";
+import type { TemplateProps } from "./templateProps";
+
+/**
+ * Amazon-style six-pager: a memo header (no cover page), six numbered narrative
+ * sections, and an unlimited appendix for tables and charts.
+ */
+export function sixPagerTemplate({ content, store }: TemplateProps): ReactElement {
+  const theme = useTheme();
+  const meta = content.metadata;
+  const entries = collectTocEntries(content);
+  const byline = [meta.org, meta.date, meta.authors.join(", ")].filter(Boolean).join("  ·  ");
+  return (
+    <Document title={meta.title} author={meta.authors.join(", ")}>
+      <PageShell metadata={meta}>
+        <View
+          style={{
+            borderBottomWidth: 2,
+            borderBottomColor: theme.colors.primary,
+            paddingBottom: theme.spacing.sm,
+            marginBottom: theme.spacing.md,
+          }}
+        >
+          <Text style={theme.text.h1}>{meta.title}</Text>
+          {meta.subtitle ? (
+            <Text style={{ ...theme.text.body, color: theme.colors.muted, marginTop: 2 }}>
+              {meta.subtitle}
+            </Text>
+          ) : null}
+          {byline ? (
+            <Text style={{ ...theme.text.caption, marginTop: theme.spacing.xs }}>{byline}</Text>
+          ) : null}
+        </View>
+        {content.toc ? <TableOfContents entries={entries} store={store} /> : null}
+        {content.sections.map((section, index) => (
+          <Section key={section.id} section={section} store={store} numberLabel={`${index + 1}.`} />
+        ))}
+        {content.appendix.length > 0 ? (
+          <View break>
+            <Heading level={1}>Appendix</Heading>
+            {content.appendix.map((section) => (
+              <Section key={section.id} section={section} store={store} />
+            ))}
+          </View>
+        ) : null}
+      </PageShell>
+    </Document>
+  );
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/templates/templateProps.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/templates/templateProps.ts
@@ -1,0 +1,11 @@
+import type { ReactElement } from "react";
+
+import type { PageNumberStore } from "../render/pageNumberStore";
+import type { Content } from "../schemas/contentSchema";
+
+export interface TemplateProps {
+  content: Content;
+  store: PageNumberStore;
+}
+
+export type TemplateComponent = (props: TemplateProps) => ReactElement;

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/templates/templateRegistry.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/templates/templateRegistry.ts
@@ -1,0 +1,14 @@
+import type { TemplateName } from "../schemas/contentSchema";
+import { playbookTemplate } from "./playbookTemplate";
+import { reportTemplate } from "./reportTemplate";
+import { researchDocTemplate } from "./researchDocTemplate";
+import { sixPagerTemplate } from "./sixPagerTemplate";
+import type { TemplateComponent } from "./templateProps";
+
+/** Maps a content `template` name to its component. */
+export const templateRegistry: Record<TemplateName, TemplateComponent> = {
+  report: reportTemplate,
+  researchDoc: researchDocTemplate,
+  sixPager: sixPagerTemplate,
+  playbook: playbookTemplate,
+};

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/test/assertFontsResolve.test.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/test/assertFontsResolve.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { assertFontsResolve } from "../theme/assertFontsResolve";
+import { defaultTheme } from "../theme/defaultTheme";
+import type { Theme } from "../theme/themeInterface";
+
+function withBodyFamily(family: string, fonts: Theme["fonts"] = []): Theme {
+  return {
+    ...defaultTheme,
+    text: { ...defaultTheme.text, body: { ...defaultTheme.text.body, fontFamily: family } },
+    fonts,
+  };
+}
+
+test("passes for the default standard-font theme", () => {
+  assert.doesNotThrow(() => assertFontsResolve(defaultTheme));
+});
+
+test("throws when a used family is neither standard nor registered", () => {
+  assert.throws(() => assertFontsResolve(withBodyFamily("GhostFont")), /GhostFont/);
+});
+
+test("throws on a remote font source", () => {
+  const theme = withBodyFamily("Web", [{ family: "Web", sources: [{ src: "http://x/font.ttf" }] }]);
+  assert.throws(() => assertFontsResolve(theme), /remote/);
+});
+
+test("throws on a variable-font file", () => {
+  const theme = withBodyFamily("Var", [
+    { family: "Var", sources: [{ src: "/fonts/Inter-VariableFont_wght.ttf" }] },
+  ]);
+  assert.throws(() => assertFontsResolve(theme), /variable font/);
+});

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/test/contentSchema.test.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/test/contentSchema.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { contentSchema } from "../schemas/contentSchema";
+
+const valid = {
+  schemaVersion: 1,
+  template: "report",
+  metadata: { title: "Test" },
+  sections: [
+    { id: "s", title: "Section", blocks: [{ type: "paragraph", content: [{ text: "hi" }] }] },
+  ],
+};
+
+test("parses a minimal valid document and applies defaults", () => {
+  const parsed = contentSchema.parse(valid);
+  assert.equal(parsed.toc, true);
+  assert.deepEqual(parsed.appendix, []);
+  assert.equal(parsed.metadata.authors.length, 0);
+});
+
+test("rejects an unknown block type", () => {
+  assert.throws(() =>
+    contentSchema.parse({
+      ...valid,
+      sections: [{ id: "s", title: "S", blocks: [{ type: "bogus" }] }],
+    }),
+  );
+});
+
+test("rejects an SVG figure source", () => {
+  assert.throws(() =>
+    contentSchema.parse({
+      ...valid,
+      sections: [{ id: "s", title: "S", blocks: [{ type: "figure", src: "diagram.svg", alt: "x" }] }],
+    }),
+  );
+});
+
+test("rejects an empty section", () => {
+  assert.throws(() =>
+    contentSchema.parse({ ...valid, sections: [{ id: "s", title: "S", blocks: [] }] }),
+  );
+});
+
+test("parses every block type", () => {
+  const parsed = contentSchema.parse({
+    ...valid,
+    sections: [
+      {
+        id: "s",
+        title: "S",
+        blocks: [
+          { type: "heading", level: 2, text: "H" },
+          { type: "paragraph", content: [{ text: "p" }] },
+          { type: "list", items: [[{ text: "i" }]] },
+          { type: "table", columns: [{ header: "c" }], rows: [[[{ text: "v" }]]] },
+          { type: "figure", src: "image.png", alt: "a" },
+          { type: "chart", spec: { kind: "bar", series: [{ name: "n", points: [{ x: "a", y: 1 }] }] } },
+          { type: "callout", content: [{ text: "c" }] },
+          { type: "pullquote", text: "q" },
+          { type: "pagebreak" },
+        ],
+      },
+    ],
+  });
+  assert.equal(parsed.sections[0].blocks.length, 9);
+});

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/test/contrast.test.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/test/contrast.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { contrastRatio } from "../theme/contrast";
+
+test("white on black is near-maximal contrast", () => {
+  const ratio = contrastRatio("#ffffff", "#000000");
+  assert.ok(ratio !== null && ratio > 20);
+});
+
+test("returns null for an unparseable color", () => {
+  assert.equal(contrastRatio("not-a-color", "#000000"), null);
+});
+
+test("flags low contrast below the AA threshold", () => {
+  const ratio = contrastRatio("#cccccc", "#ffffff");
+  assert.ok(ratio !== null && ratio < 4.5);
+});

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/test/makeTheme.test.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/test/makeTheme.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { DesignMdTokens } from "../theme/designMdSchema";
+import { defaultTheme } from "../theme/defaultTheme";
+import { fontsDir } from "../lib/paths";
+import { makeTheme } from "../theme/makeTheme";
+
+const tokens = (value: unknown): DesignMdTokens => value as DesignMdTokens;
+
+test("converts 1rem to 12pt", () => {
+  const theme = makeTheme(tokens({ typography: { body: { fontSize: "1rem" } } }), { fontsDir });
+  assert.equal(theme.text.body.fontSize, 12);
+});
+
+test("overlays colors onto the default palette", () => {
+  const theme = makeTheme(tokens({ colors: { primary: "#123456" } }), { fontsDir });
+  assert.equal(theme.colors.primary, "#123456");
+  assert.equal(theme.colors.background, defaultTheme.colors.background);
+});
+
+test("maps a leaf color name from a nested tree", () => {
+  const theme = makeTheme(tokens({ colors: { brand: { primary: "#abcdef" } } }), { fontsDir });
+  assert.equal(theme.colors.primary, "#abcdef");
+});
+
+test("empty tokens reproduce the default theme typography", () => {
+  const theme = makeTheme(tokens({}), { fontsDir });
+  assert.equal(theme.text.body.fontFamily, defaultTheme.text.body.fontFamily);
+  assert.equal(theme.text.h1.fontSize, defaultTheme.text.h1.fontSize);
+});
+
+test("resolves custom font file paths against the fonts dir", () => {
+  const theme = makeTheme(tokens({ fonts: [{ family: "Inter", weights: { "400": "Inter-Regular.ttf" } }] }), {
+    fontsDir,
+  });
+  assert.equal(theme.fonts.length, 1);
+  assert.ok(theme.fonts[0].sources[0].src.endsWith("Inter-Regular.ttf"));
+  assert.ok(theme.fonts[0].sources[0].src.startsWith("/"));
+});

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/test/resolveTokenRefs.test.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/test/resolveTokenRefs.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveTokenRefs } from "../theme/resolveTokenRefs";
+
+test("resolves a nested reference", () => {
+  const out = resolveTokenRefs({
+    colors: { brand: { primary: "#fff" }, primary: "{colors.brand.primary}" },
+  });
+  assert.equal((out.colors as Record<string, unknown>).primary, "#fff");
+});
+
+test("resolves an embedded reference", () => {
+  const out = resolveTokenRefs({ x: "1", y: "v-{x}" });
+  assert.equal(out.y, "v-1");
+});
+
+test("throws on an unknown reference", () => {
+  assert.throws(() => resolveTokenRefs({ a: "{nope.missing}" }), /Unknown token reference/);
+});
+
+test("throws on a cyclic reference", () => {
+  assert.throws(() => resolveTokenRefs({ a: "{b}", b: "{a}" }), /Cyclic token reference/);
+});

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/test/smokeRender.test.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/test/smokeRender.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { renderToBuffer } from "@react-pdf/renderer";
+import { createElement } from "react";
+
+import { contentSchema } from "../schemas/contentSchema";
+import type { TemplateName } from "../schemas/contentSchema";
+import { createPageNumberStore } from "../render/pageNumberStore";
+import { assertFontsResolve } from "../theme/assertFontsResolve";
+import { defaultTheme } from "../theme/defaultTheme";
+import { examplesDir } from "../lib/paths";
+import { registerFonts } from "../theme/registerFonts";
+import { ThemeContext } from "../theme/themeContext";
+import { templateRegistry } from "../templates/templateRegistry";
+
+async function renderToPdf(content: ReturnType<typeof contentSchema.parse>): Promise<Buffer> {
+  assertFontsResolve(defaultTheme);
+  registerFonts(defaultTheme);
+  const store = createPageNumberStore();
+  const Template = templateRegistry[content.template];
+  const element = createElement(
+    ThemeContext.Provider,
+    { value: defaultTheme },
+    createElement(Template, { content, store }),
+  );
+  return renderToBuffer(element);
+}
+
+test("renders the example report to a valid PDF", async () => {
+  const raw = readFileSync(join(examplesDir, "report.content.json"), "utf8");
+  const content = contentSchema.parse(JSON.parse(raw));
+  const buffer = await renderToPdf(content);
+  assert.equal(buffer.subarray(0, 5).toString("latin1"), "%PDF-");
+  assert.ok(buffer.length > 3000, `expected a non-trivial PDF, got ${buffer.length} bytes`);
+});
+
+const templates: TemplateName[] = ["report", "researchDoc", "sixPager", "playbook"];
+for (const template of templates) {
+  test(`renders the ${template} template`, async () => {
+    const content = contentSchema.parse({
+      schemaVersion: 1,
+      template,
+      metadata: { title: "Smoke Test", authors: ["Tester"], org: "Acme", date: "2026" },
+      cover: { title: "Smoke Test" },
+      sections: [
+        {
+          id: "alpha",
+          title: "Alpha",
+          blocks: [
+            { type: "paragraph", content: [{ text: "Hello " }, { text: "world", bold: true }] },
+            { type: "list", items: [[{ text: "one" }], [{ text: "two" }]] },
+            { type: "callout", tone: "info", content: [{ text: "Note." }] },
+          ],
+        },
+        {
+          id: "beta",
+          title: "Beta",
+          blocks: [
+            {
+              type: "table",
+              columns: [{ header: "Key" }, { header: "Value", align: "right" }],
+              rows: [[[{ text: "a" }], [{ text: "1" }]]],
+            },
+            {
+              type: "chart",
+              spec: { kind: "bar", series: [{ name: "S", points: [{ x: "Q1", y: 10 }, { x: "Q2", y: 20 }] }] },
+            },
+          ],
+        },
+      ],
+      appendix: [
+        { id: "app", title: "Appendix A", blocks: [{ type: "paragraph", content: [{ text: "end" }] }] },
+      ],
+    });
+    const buffer = await renderToPdf(content);
+    assert.equal(buffer.subarray(0, 5).toString("latin1"), "%PDF-");
+    assert.ok(buffer.length > 2000);
+  });
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/assertFontsResolve.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/assertFontsResolve.ts
@@ -1,0 +1,54 @@
+import { existsSync } from "node:fs";
+
+import { fontResolutionError } from "../render/errors";
+import type { Theme } from "./themeInterface";
+
+/** Standard PDF font families that need no registration. */
+export const standardFamilies = new Set(["Helvetica", "Times-Roman", "Courier"]);
+
+/**
+ * Verify every font the theme uses can actually be rendered, BEFORE any
+ * `Font.register` call. @react-pdf/renderer hangs silently on a missing or
+ * variable font, so this turns those into a loud, named failure instead.
+ */
+export function assertFontsResolve(theme: Theme): void {
+  const problems: string[] = [];
+  const registered = new Set(theme.fonts.map((face) => face.family));
+
+  const usedFamilies = new Set(Object.values(theme.text).map((style) => style.fontFamily));
+  for (const family of usedFamilies) {
+    if (standardFamilies.has(family) || registered.has(family)) continue;
+    problems.push(
+      `Font family "${family}" is used but is neither a standard PDF family ` +
+        `(${[...standardFamilies].join(", ")}) nor registered. Add it to the design.md "fonts" ` +
+        `mapping with a static-weight file in assets/fonts/, or use a standard family.`,
+    );
+  }
+
+  for (const face of theme.fonts) {
+    for (const source of face.sources) {
+      const { src } = source;
+      if (/^https?:\/\//i.test(src)) {
+        problems.push(
+          `Font "${face.family}" uses a remote src (${src}); bundle the file under assets/fonts/ ` +
+            `so rendering is offline and deterministic.`,
+        );
+        continue;
+      }
+      if (!/\.(ttf|woff)$/i.test(src)) {
+        problems.push(`Font "${face.family}" must be a .ttf or .woff file: ${src}`);
+      }
+      if (/variablefont|\[wght\]|-vf\b/i.test(src)) {
+        problems.push(
+          `Font "${face.family}" looks like a variable font (${src}); the PDF format needs ` +
+            `static weights — provide separate files per weight.`,
+        );
+      }
+      if (!existsSync(src)) {
+        problems.push(`Font file not found for "${face.family}": ${src}`);
+      }
+    }
+  }
+
+  if (problems.length > 0) throw fontResolutionError(problems.join("\n"));
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/contrast.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/contrast.ts
@@ -1,0 +1,25 @@
+/** WCAG contrast utilities used to warn about hard-to-read brand palettes. */
+function hexToRgb(hex: string): [number, number, number] | null {
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!match) return null;
+  const value = Number.parseInt(match[1], 16);
+  return [(value >> 16) & 255, (value >> 8) & 255, value & 255];
+}
+
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const channel = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/** Contrast ratio (1–21) between two hex colors, or null if either cannot be parsed. */
+export function contrastRatio(foreground: string, background: string): number | null {
+  const fg = hexToRgb(foreground);
+  const bg = hexToRgb(background);
+  if (!fg || !bg) return null;
+  const lighter = Math.max(relativeLuminance(fg), relativeLuminance(bg));
+  const darker = Math.min(relativeLuminance(fg), relativeLuminance(bg));
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/defaultTheme.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/defaultTheme.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "./themeInterface";
+
+/**
+ * The bundled default theme. It uses the standard PDF font families (Helvetica,
+ * Times-Roman, Courier) so the skill renders a clean, professional document with
+ * zero bundled font files and no font-resolution risk. A design.md overlays its
+ * tokens onto this base, so a partial brand spec still yields a complete theme.
+ */
+export const defaultTheme: Theme = {
+  name: "Default",
+  version: "1.0",
+  colors: {
+    background: "#ffffff",
+    surface: "#f5f7fa",
+    text: "#1a1d23",
+    muted: "#5b6470",
+    primary: "#1d4ed8",
+    onPrimary: "#ffffff",
+    border: "#dfe3e8",
+    accent: "#0ea5e9",
+    info: "#2563eb",
+    success: "#15803d",
+    warning: "#b45309",
+    danger: "#b91c1c",
+    neutral: "#52606d",
+  },
+  text: {
+    display: { fontFamily: "Helvetica", fontSize: 30, fontWeight: "bold", lineHeight: 1.15, color: "#1a1d23" },
+    h1: { fontFamily: "Helvetica", fontSize: 21, fontWeight: "bold", lineHeight: 1.2, color: "#1a1d23" },
+    h2: { fontFamily: "Helvetica", fontSize: 15.5, fontWeight: "bold", lineHeight: 1.25, color: "#1a1d23" },
+    h3: { fontFamily: "Helvetica", fontSize: 12.5, fontWeight: "bold", lineHeight: 1.3, color: "#1a1d23" },
+    body: { fontFamily: "Helvetica", fontSize: 10.5, lineHeight: 1.5, color: "#1a1d23" },
+    caption: { fontFamily: "Helvetica", fontSize: 8.5, lineHeight: 1.4, color: "#5b6470" },
+    quote: { fontFamily: "Times-Roman", fontSize: 13.5, fontStyle: "italic", lineHeight: 1.4, color: "#1a1d23" },
+    label: {
+      fontFamily: "Helvetica",
+      fontSize: 8,
+      fontWeight: "bold",
+      letterSpacing: 1.1,
+      textTransform: "uppercase",
+      lineHeight: 1.2,
+      color: "#5b6470",
+    },
+    mono: { fontFamily: "Courier", fontSize: 9.5, lineHeight: 1.45, color: "#1a1d23" },
+  },
+  spacing: { xs: 3, sm: 6, md: 12, lg: 20, xl: 32, gutter: 16, keepWithNext: 56 },
+  rounded: { sm: 2, md: 4, lg: 8 },
+  fonts: [],
+  page: { size: "A4", margins: { top: 64, right: 56, bottom: 64, left: 56 } },
+};

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/designMdSchema.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/designMdSchema.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+/**
+ * Lenient schema for design.md YAML front-matter. The spec is alpha and tools
+ * emit varied shapes, so unknown keys pass through and most fields are optional;
+ * `makeTheme` overlays whatever is present onto the complete default theme.
+ */
+const lengthValue = z.union([z.string(), z.number()]);
+
+export const typographyTokenSchema = z.object({
+  fontFamily: z.string().optional(),
+  fontSize: lengthValue.optional(),
+  fontWeight: lengthValue.optional(),
+  lineHeight: lengthValue.optional(),
+  letterSpacing: lengthValue.optional(),
+  textTransform: z.string().optional(),
+  fontStyle: z.string().optional(),
+  color: z.string().optional(),
+});
+export type TypographyToken = z.infer<typeof typographyTokenSchema>;
+
+/** A custom font family: weight → bundled file name (resolved under assets/fonts). */
+export const fontFaceTokenSchema = z.object({
+  family: z.string(),
+  weights: z.record(z.string(), z.string()).optional(),
+  italics: z.record(z.string(), z.string()).optional(),
+});
+
+/** Colors may be flat (`primary: "#..."`) or nested (`brand: { primary: "#..." }`). */
+const colorTree: z.ZodType<unknown> = z.lazy(() =>
+  z.union([z.string(), z.record(z.string(), colorTree)]),
+);
+
+export const designMdSchema = z
+  .object({
+    version: z.string().optional(),
+    name: z.string().optional(),
+    colors: z.record(z.string(), colorTree).optional(),
+    typography: z.record(z.string(), typographyTokenSchema).optional(),
+    spacing: z.record(z.string(), lengthValue).optional(),
+    rounded: z.record(z.string(), lengthValue).optional(),
+    fonts: z.array(fontFaceTokenSchema).optional(),
+  })
+  .passthrough();
+
+export type DesignMdTokens = z.infer<typeof designMdSchema>;

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/loadDesignMd.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/loadDesignMd.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+
+import matter from "gray-matter";
+import { ZodError } from "zod";
+
+import { fontsDir } from "../lib/paths";
+import { themeError } from "../render/errors";
+import { designMdSchema } from "./designMdSchema";
+import { defaultTheme } from "./defaultTheme";
+import { makeTheme } from "./makeTheme";
+import { resolveTokenRefs } from "./resolveTokenRefs";
+import type { Theme } from "./themeInterface";
+
+/** Parse a design.md file into a theme; throws a themed (exit 4) error on any problem. */
+export function loadDesignMd(path: string): Theme {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    throw themeError(`Could not read design.md at ${path}`);
+  }
+
+  let frontMatter: Record<string, unknown>;
+  try {
+    frontMatter = matter(raw).data as Record<string, unknown>;
+  } catch (error) {
+    throw themeError(`Invalid YAML front-matter in ${path}: ${(error as Error).message}`);
+  }
+
+  let theme: Theme;
+  try {
+    const resolved = resolveTokenRefs(frontMatter);
+    const tokens = designMdSchema.parse(resolved);
+    theme = makeTheme(tokens, { fontsDir });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const issues = error.errors
+        .map((issue) => `  - ${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("\n");
+      throw themeError(`design.md token validation failed in ${path}:\n${issues}`);
+    }
+    throw themeError(`Could not build theme from ${path}: ${(error as Error).message}`);
+  }
+
+  return theme;
+}
+
+/** Resolve a theme from an optional design.md path, falling back to the bundled default. */
+export function resolveTheme(designPath?: string): Theme {
+  return designPath ? loadDesignMd(designPath) : defaultTheme;
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/makeTheme.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/makeTheme.ts
@@ -1,0 +1,178 @@
+import { isAbsolute, join } from "node:path";
+
+import type { DesignMdTokens, TypographyToken } from "./designMdSchema";
+import { defaultTheme } from "./defaultTheme";
+import { cssLengthToPt } from "./unitToPt";
+import type {
+  FontWeight,
+  Theme,
+  ThemeFontFace,
+  ThemePalette,
+  ThemeTextStyle,
+  ThemeTextStyles,
+} from "./themeInterface";
+
+export interface MakeThemeOptions {
+  /** Directory bundled font files are resolved against. */
+  fontsDir: string;
+}
+
+/**
+ * Build a complete theme by overlaying resolved design.md tokens onto the
+ * default theme. Anything the design.md omits keeps its default, so a partial
+ * brand spec still produces a full, valid theme.
+ */
+export function makeTheme(tokens: DesignMdTokens, options: MakeThemeOptions): Theme {
+  const colors = flattenColors(tokens.colors);
+  return {
+    name: tokens.name ?? defaultTheme.name,
+    version: tokens.version ?? defaultTheme.version,
+    colors: mapPalette(colors),
+    text: mapTypography(tokens.typography),
+    spacing: mapScale(tokens.spacing, defaultTheme.spacing),
+    rounded: mapScale(tokens.rounded, defaultTheme.rounded),
+    fonts: mapFonts(tokens.fonts, options.fontsDir),
+    page: defaultTheme.page,
+  };
+}
+
+/** Flatten a (possibly nested) color tree to a lookup keyed by dot-path and by leaf name (lowercased). */
+function flattenColors(input: DesignMdTokens["colors"]): Record<string, string> {
+  const out: Record<string, string> = {};
+  const walk = (value: unknown, path: string[]): void => {
+    if (typeof value === "string") {
+      out[path.join(".").toLowerCase()] = value;
+      const leaf = path[path.length - 1].toLowerCase();
+      if (!(leaf in out)) out[leaf] = value;
+      return;
+    }
+    if (value && typeof value === "object") {
+      for (const [key, child] of Object.entries(value)) walk(child, [...path, key]);
+    }
+  };
+  if (input) walk(input, []);
+  return out;
+}
+
+function firstColor(colors: Record<string, string>, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = colors[name.toLowerCase()];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function mapPalette(colors: Record<string, string>): ThemePalette {
+  const base = defaultTheme.colors;
+  const pick = (slot: keyof ThemePalette, ...alts: string[]): string =>
+    firstColor(colors, [slot, ...alts]) ?? base[slot];
+  return {
+    background: pick("background", "bg", "base", "canvas"),
+    surface: pick("surface", "card", "panel"),
+    text: pick("text", "foreground", "fg", "ink", "primary.text"),
+    muted: pick("muted", "secondary", "subtle", "text.secondary"),
+    primary: pick("primary", "brand", "brand.primary", "accent.primary"),
+    onPrimary: pick("onPrimary", "on-primary", "onprimary", "primary.foreground"),
+    border: pick("border", "outline", "divider"),
+    accent: pick("accent", "brand.secondary"),
+    info: pick("info", "blue"),
+    success: pick("success", "green", "positive"),
+    warning: pick("warning", "amber", "yellow", "caution"),
+    danger: pick("danger", "red", "error", "negative", "destructive"),
+    neutral: pick("neutral", "gray", "grey"),
+  };
+}
+
+function normalizeWeight(weight: string | number | undefined): FontWeight | undefined {
+  if (weight === undefined) return undefined;
+  const numeric = Number(weight);
+  if (Number.isFinite(numeric)) return numeric;
+  return weight === "bold" ? "bold" : "normal";
+}
+
+function mergeTextStyle(base: ThemeTextStyle, token: TypographyToken): ThemeTextStyle {
+  const lineHeight = token.lineHeight === undefined ? base.lineHeight : Number(token.lineHeight);
+  return {
+    fontFamily: token.fontFamily ?? base.fontFamily,
+    fontSize: token.fontSize === undefined ? base.fontSize : cssLengthToPt(token.fontSize),
+    fontWeight: normalizeWeight(token.fontWeight) ?? base.fontWeight,
+    lineHeight: Number.isFinite(lineHeight) ? lineHeight : base.lineHeight,
+    letterSpacing:
+      token.letterSpacing === undefined ? base.letterSpacing : cssLengthToPt(token.letterSpacing),
+    textTransform: (token.textTransform as ThemeTextStyle["textTransform"]) ?? base.textTransform,
+    fontStyle: (token.fontStyle as ThemeTextStyle["fontStyle"]) ?? base.fontStyle,
+    color: token.color ?? base.color,
+  };
+}
+
+function firstToken(
+  typography: DesignMdTokens["typography"],
+  names: string[],
+): TypographyToken | undefined {
+  if (!typography) return undefined;
+  const lower = new Map(Object.entries(typography).map(([key, value]) => [key.toLowerCase(), value]));
+  for (const name of names) {
+    const value = lower.get(name.toLowerCase());
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function mapTypography(typography: DesignMdTokens["typography"]): ThemeTextStyles {
+  const base = defaultTheme.text;
+  const slot = (key: keyof ThemeTextStyles, ...alts: string[]): ThemeTextStyle => {
+    const token = firstToken(typography, [key, ...alts]);
+    return token ? mergeTextStyle(base[key], token) : base[key];
+  };
+  return {
+    display: slot("display", "hero", "title"),
+    h1: slot("h1", "heading1", "heading", "title"),
+    h2: slot("h2", "heading2", "subtitle"),
+    h3: slot("h3", "heading3"),
+    body: slot("body", "paragraph", "text", "base"),
+    caption: slot("caption", "small", "footnote"),
+    quote: slot("quote", "blockquote"),
+    label: slot("label", "eyebrow", "overline"),
+    mono: slot("mono", "code"),
+  };
+}
+
+function mapScale<T extends Record<string, number>>(
+  scale: Record<string, string | number> | undefined,
+  base: T,
+): T {
+  if (!scale) return base;
+  const out = { ...base };
+  for (const key of Object.keys(base) as (keyof T)[]) {
+    const value = scale[key as string];
+    if (value === undefined) continue;
+    try {
+      out[key] = cssLengthToPt(value) as T[keyof T];
+    } catch {
+      // Keep the default when a token value cannot be parsed as a length.
+    }
+  }
+  return out;
+}
+
+function mapFonts(
+  fonts: DesignMdTokens["fonts"],
+  fontsDir: string,
+): ThemeFontFace[] {
+  if (!fonts) return [];
+  const resolve = (file: string): string => (isAbsolute(file) ? file : join(fontsDir, file));
+  return fonts.map((face) => {
+    const sources = [
+      ...Object.entries(face.weights ?? {}).map(([weight, file]) => ({
+        src: resolve(file),
+        fontWeight: normalizeWeight(weight),
+      })),
+      ...Object.entries(face.italics ?? {}).map(([weight, file]) => ({
+        src: resolve(file),
+        fontWeight: normalizeWeight(weight),
+        fontStyle: "italic" as const,
+      })),
+    ];
+    return { family: face.family, sources };
+  });
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/pageMetrics.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/pageMetrics.ts
@@ -1,0 +1,20 @@
+import type { Theme } from "./themeInterface";
+
+/** Page dimensions in points for the supported page sizes. */
+const pageSizes = {
+  A4: { width: 595.28, height: 841.89 },
+  LETTER: { width: 612, height: 792 },
+} as const;
+
+export function pageWidth(theme: Theme): number {
+  return pageSizes[theme.page.size].width;
+}
+
+export function pageHeight(theme: Theme): number {
+  return pageSizes[theme.page.size].height;
+}
+
+/** Width available for content between the left and right page margins. */
+export function contentWidth(theme: Theme): number {
+  return pageWidth(theme) - theme.page.margins.left - theme.page.margins.right;
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/registerFonts.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/registerFonts.ts
@@ -1,0 +1,25 @@
+import { Font } from "@react-pdf/renderer";
+
+import type { Theme } from "./themeInterface";
+
+/**
+ * Register the theme's custom fonts with @react-pdf/renderer. Standard families
+ * need no registration. Call `assertFontsResolve` first so this never registers
+ * a missing or variable font (which would hang rendering).
+ */
+export function registerFonts(theme: Theme): void {
+  for (const face of theme.fonts) {
+    Font.register({
+      family: face.family,
+      fonts: face.sources.map((source) => ({
+        src: source.src,
+        fontWeight: source.fontWeight,
+        fontStyle: source.fontStyle,
+      })),
+    });
+  }
+
+  // Disable hyphenation for cleaner business typography (react-pdf otherwise
+  // splits words with the Knuth-Plass algorithm).
+  Font.registerHyphenationCallback((word) => [word]);
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/resolveTokenRefs.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/resolveTokenRefs.ts
@@ -1,0 +1,61 @@
+/**
+ * Resolve W3C-design-tokens-style `{path.to.token}` references in a parsed
+ * design.md token tree.
+ *
+ * A value may be a whole reference (`"{colors.brand.primary}"`) or embed one
+ * (`"1px solid {colors.border}"`). Resolution is recursive with cycle and
+ * unknown-reference detection, both of which throw — broken brand tokens must
+ * fail loudly, never silently produce a wrong color.
+ */
+type TokenTree = Record<string, unknown>;
+
+function flattenInto(value: unknown, prefix: string, out: Map<string, unknown>): void {
+  if (value === null || typeof value !== "object") {
+    out.set(prefix, value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    out.set(prefix, value);
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    flattenInto(child, prefix ? `${prefix}.${key}` : key, out);
+  }
+}
+
+export function resolveTokenRefs<T extends TokenTree>(tokens: T): T {
+  const flat = new Map<string, unknown>();
+  flattenInto(tokens, "", flat);
+
+  const cache = new Map<string, unknown>();
+  const inProgress = new Set<string>();
+
+  function resolvePath(path: string): unknown {
+    if (cache.has(path)) return cache.get(path);
+    if (!flat.has(path)) throw new Error(`Unknown token reference: {${path}}`);
+    if (inProgress.has(path)) throw new Error(`Cyclic token reference at {${path}}`);
+    inProgress.add(path);
+    const resolved = resolveValue(flat.get(path));
+    inProgress.delete(path);
+    cache.set(path, resolved);
+    return resolved;
+  }
+
+  function resolveValue(value: unknown): unknown {
+    if (typeof value !== "string") return value;
+    const whole = /^\{([^}]+)\}$/.exec(value.trim());
+    if (whole) return resolvePath(whole[1].trim());
+    return value.replace(/\{([^}]+)\}/g, (_, path: string) => String(resolvePath(path.trim())));
+  }
+
+  function mapStrings(value: unknown): unknown {
+    if (typeof value === "string") return resolveValue(value);
+    if (Array.isArray(value)) return value.map(mapStrings);
+    if (value && typeof value === "object") {
+      return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, mapStrings(v)]));
+    }
+    return value;
+  }
+
+  return mapStrings(tokens) as T;
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/themeContext.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/themeContext.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+import { defaultTheme } from "./defaultTheme";
+import type { Theme } from "./themeInterface";
+
+/** Carries the resolved theme to every component; defaults to the bundled theme. */
+export const ThemeContext = createContext<Theme>(defaultTheme);
+
+export function useTheme(): Theme {
+  return useContext(ThemeContext);
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/themeInterface.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/themeInterface.ts
@@ -1,0 +1,91 @@
+/** Font weight as accepted by @react-pdf/renderer. */
+export type FontWeight = number | "normal" | "bold";
+
+export interface ThemeTextStyle {
+  fontFamily: string;
+  /** Size in points. */
+  fontSize: number;
+  fontWeight?: FontWeight;
+  /** Unitless multiple of font size. */
+  lineHeight?: number;
+  /** Letter spacing in points. */
+  letterSpacing?: number;
+  textTransform?: "none" | "uppercase" | "lowercase" | "capitalize";
+  fontStyle?: "normal" | "italic";
+  color?: string;
+}
+
+export interface ThemeFontSource {
+  /** Absolute file path (bundled font) or, discouraged, a URL. */
+  src: string;
+  fontWeight?: FontWeight;
+  fontStyle?: "normal" | "italic";
+}
+
+export interface ThemeFontFace {
+  family: string;
+  sources: ThemeFontSource[];
+}
+
+export interface ThemePalette {
+  background: string;
+  surface: string;
+  text: string;
+  muted: string;
+  primary: string;
+  onPrimary: string;
+  border: string;
+  accent: string;
+  info: string;
+  success: string;
+  warning: string;
+  danger: string;
+  neutral: string;
+}
+
+export interface ThemeTextStyles {
+  display: ThemeTextStyle;
+  h1: ThemeTextStyle;
+  h2: ThemeTextStyle;
+  h3: ThemeTextStyle;
+  body: ThemeTextStyle;
+  caption: ThemeTextStyle;
+  quote: ThemeTextStyle;
+  label: ThemeTextStyle;
+  mono: ThemeTextStyle;
+}
+
+export interface ThemeSpacing {
+  xs: number;
+  sm: number;
+  md: number;
+  lg: number;
+  xl: number;
+  gutter: number;
+  /** Minimum points that must remain on the page after a heading (keep-with-next). */
+  keepWithNext: number;
+}
+
+export interface ThemeRounded {
+  sm: number;
+  md: number;
+  lg: number;
+}
+
+export interface ThemePageConfig {
+  size: "A4" | "LETTER";
+  margins: { top: number; right: number; bottom: number; left: number };
+}
+
+/** The fully resolved theme every component reads via context. */
+export interface Theme {
+  name: string;
+  version: string;
+  colors: ThemePalette;
+  text: ThemeTextStyles;
+  spacing: ThemeSpacing;
+  rounded: ThemeRounded;
+  /** Custom fonts to register; empty when using the standard PDF families. */
+  fonts: ThemeFontFace[];
+  page: ThemePageConfig;
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/theme/unitToPt.ts
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/theme/unitToPt.ts
@@ -1,0 +1,26 @@
+/**
+ * Convert a CSS-style length to PDF points.
+ *
+ * PDF uses points; CSS design tokens are usually px or rem. Using the CSS
+ * convention 1rem = 16px and 1px = 0.75pt gives 1rem = 12pt. Bare numbers are
+ * treated as points. `em` is resolved against `basePt` (the element's own size).
+ */
+export function cssLengthToPt(value: string | number, basePt = 12): number {
+  if (typeof value === "number") return value;
+  const match = /^(-?\d*\.?\d+)\s*(px|pt|rem|em)?$/.exec(value.trim());
+  if (!match) throw new Error(`Unrecognized length: "${value}"`);
+  const amount = Number(match[1]);
+  const unit = match[2] ?? "pt";
+  switch (unit) {
+    case "pt":
+      return amount;
+    case "px":
+      return amount * 0.75;
+    case "rem":
+      return amount * 12;
+    case "em":
+      return amount * basePt;
+    default:
+      throw new Error(`Unsupported unit: ${unit}`);
+  }
+}

--- a/claude-plugins/autopilot/skills/pdf:create/renderer/tsconfig.json
+++ b/claude-plugins/autopilot/skills/pdf:create/renderer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docs/10-pdf-create-skill.md
+++ b/docs/10-pdf-create-skill.md
@@ -1,0 +1,163 @@
+# The `pdf:create` skill
+
+> Chapter 10 of the [repository docs](../README.md#repository-docs).
+
+`pdf:create` generates beautiful, brand-themed, multi-page PDFs — reports,
+research docs, six-pagers, playbooks — from structured content. It is the
+plugin's first **bundled-asset** skill: alongside its [`SKILL.md`](../claude-plugins/autopilot/skills/pdf:create/SKILL.md)
+it ships a self-contained Node sub-project (`renderer/`) built on
+`@react-pdf/renderer` (direct rendering, no headless browser). This chapter
+documents the machinery that makes it work and stay decoupled — read it before
+changing the skill's layout, its dependency story, or the monorepo's workspace
+and formatting config.
+
+## Render pipeline
+
+The skill keeps rendering out of the model's context: Claude only assembles a
+small content JSON, and a Node script ([`render.tsx`](../claude-plugins/autopilot/skills/pdf:create/renderer/render.tsx))
+deterministically turns it into a themed PDF.
+
+```text
+┌────────────────┐
+│     Claude     │
+└───────┬────────┘
+        │ ①
+        ▼
+┌────────────────┐
+│  content.json  │
+└───────┬────────┘
+        │ ②
+        ▼
+┌────────────────┐
+│   render.tsx   │
+└───────┬────────┘
+        │ ③
+        ▼
+┌────────────────┐  ④   ┌────────────────┐
+│  Zod validate  │      │   design.md    │
+└───────┬────────┘      │   (optional)   │
+        │               └───────┬────────┘
+        ▼                       │ ④
+┌────────────────┐◀─────────────┘
+│ theme resolve  │
+└───────┬────────┘
+        │ ⑤
+        ▼
+┌────────────────┐
+│ register fonts │
+└───────┬────────┘
+        │ ⑥
+        ▼
+┌────────────────┐
+│  pick template │
+└───────┬────────┘
+        │ ⑦
+        ▼
+┌────────────────┐
+│   output.pdf   │
+└────────────────┘
+```
+
+**Flow Legend:**
+
+- ① Claude assembles a content JSON (the `Write` tool) from the user's content and template choice.
+- ② The content JSON path is passed to `render.tsx`, run with `node --import tsx`.
+- ③ `render.tsx` validates the content JSON against `contentSchema` (Zod); a failure exits non-zero with the offending field.
+- ④ Theme resolution: with a `design.md`, `loadDesignMd` → `resolveTokenRefs` → `makeTheme`; otherwise the bundled `defaultTheme`.
+- ⑤ `assertFontsResolve` fails loudly on a missing or variable font, then `registerFonts` registers any custom faces.
+- ⑥ The template named by the content (or `--template`) is looked up in `templateRegistry`.
+- ⑦ `renderToFile` writes the output `.pdf`.
+
+## Skill layout
+
+```text
+claude-plugins/autopilot/skills/pdf:create/
+├── SKILL.md                 # the only file the plugin validator sees
+└── renderer/                # self-contained Node project (colon-free path)
+    ├── package.json         # private, exact-pinned deps; not a workspace member
+    ├── package-lock.json    # committed for deterministic installs
+    ├── install-check.mjs    # idempotent on-demand installer (marker-guarded)
+    ├── render.tsx           # CLI entry
+    ├── lib/paths.ts         # import.meta.url self-location
+    ├── schemas/             # contentSchema, blockSchema, chartSpecSchema (Zod)
+    ├── theme/               # design.md loader, token resolver, makeTheme, fonts
+    ├── components/          # primitives, layout, Table, Chart, TOC, BlockRenderer
+    ├── templates/           # report, researchDoc, sixPager, playbook + registry
+    ├── assets/fonts/        # drop-in dir for brand fonts (default uses std fonts)
+    ├── references/          # content-schema + design-md docs and examples
+    └── test/                # node:test unit + smoke-render tests
+```
+
+The skill folder keeps the colon (`pdf:create`) to match the other 15 colon
+skills, but the Node sub-project lives under a **colon-free `renderer/`** so
+`npm`/`node` never run from a path containing `:` (npm warns and may misparse a
+colon in a script path).
+
+## Portability — works without the plugin
+
+The skill is a movable, hermetic unit. To use it outside this plugin, copy the
+`pdf:create/` folder into `~/.claude/skills/`; it behaves identically.
+
+- **Self-location.** [`lib/paths.ts`](../claude-plugins/autopilot/skills/pdf:create/renderer/lib/paths.ts)
+  resolves every bundled path from `import.meta.url` — never `process.cwd()` or a
+  plugin-only env var — so fonts and examples resolve wherever the folder is copied.
+- **No cross-dependencies.** The `SKILL.md` makes no `Skill(autopilot:*)` calls
+  and lists no `MCP(...)` tools, so nothing breaks when the plugin is absent.
+- **On-demand install.** [`install-check.mjs`](../claude-plugins/autopilot/skills/pdf:create/renderer/install-check.mjs)
+  runs `npm install --omit=dev` only when its `node_modules/.pdf-create-ok` marker
+  is missing, so the first render bootstraps dependencies (~30s) and every later
+  render is instant and offline-capable. The runtime dependency set is pure-JS
+  (no native builds), keeping installs portable.
+- **Node requirement.** Rendering needs a local Node runtime (18–22 recommended;
+  it warns on newer majors). It runs in local Claude Code and in Claude Desktop
+  with a local runtime, but **not** in the hosted claude.ai web sandbox, which has
+  no Node toolchain. If `node` is absent the skill says so rather than failing
+  cryptically.
+
+## Decoupling from the monorepo
+
+The renderer is a Node + React sub-project inside a Bun + TypeScript monorepo. It
+is deliberately invisible to the workspace tooling — **do not "fix" these
+exclusions**:
+
+- **Bun workspace.** The root `workspaces` globs are single-level
+  (`claude-plugins/*`), so a sub-project four levels deeper is never a member; a
+  defensive `!claude-plugins/autopilot/skills/**` negation guards against a future
+  glob broadening. React is never hoisted into the root `bun.lock`.
+- **Turbo / typecheck.** Turbo runs tasks only in workspace members, so it never
+  discovers the renderer; the monorepo `typecheck` does not cover it. The
+  renderer's own tests run with `node --import tsx --test` (not wired into CI).
+- **Prettier.** Root `format`/`format:check` target `**/*.{md,json}`, which would
+  otherwise match the renderer's JSON/Markdown and lockfile, so `renderer/` is
+  listed in `.prettierignore`.
+- **Licenses audit.** The licenses workflow triggers on any `**/package.json` but
+  no-ops here, because its audit is gated on a repo-root `licenses:audit` script
+  that does not exist.
+
+## Inputs
+
+Two contracts, both documented and exemplified inside the renderer:
+
+- **Content JSON** — the document model Claude writes. Full schema in
+  [`references/content-schema.md`](../claude-plugins/autopilot/skills/pdf:create/renderer/references/content-schema.md),
+  worked example in
+  [`references/examples/report.content.json`](../claude-plugins/autopilot/skills/pdf:create/renderer/references/examples/report.content.json).
+- **design.md** — an optional brand spec whose tokens become the theme. Format
+  and token-mapping rules in
+  [`references/design-md-spec.md`](../claude-plugins/autopilot/skills/pdf:create/renderer/references/design-md-spec.md).
+
+## Fonts
+
+The default theme uses the standard PDF families (`Helvetica`, `Times-Roman`,
+`Courier`) — no binary font files ship in the repo, and there is zero
+font-resolution risk offline. Brand fonts are opt-in: drop static-weight
+`.ttf`/`.woff` files in `renderer/assets/fonts/` and reference them from a
+`design.md`. Variable fonts are rejected (the PDF format needs discrete weights),
+and every referenced font is verified before rendering.
+
+## Versioning
+
+Adding the skill is a `feat`. Per the [release field spec](./06-release-field.md),
+the `claude-plugin` version source is `plugin.json` and the version bump is made
+by the conventional-commit-driven release pipeline in the release PR — not in the
+feature PR.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     ".github/actions/validate-actions",
     ".github/actions/perf-report-action",
     "claude-plugins/*",
-    "packages/*"
+    "packages/*",
+    "!claude-plugins/autopilot/skills/**"
   ],
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
Adds `pdf:create`, the autopilot plugin's first document-generation skill: it turns structured content plus an optional Google `design.md` into a polished, multi-page PDF (report, research doc, six-pager, or playbook) using a bundled, self-contained `@react-pdf/renderer` pipeline — direct rendering, no headless browser. Rendering is deterministic and runs outside the model's context: the skill writes a Zod-validated content JSON and a Node script turns it into a themed PDF. See the [pdf:create skill doc](https://github.com/awinogradov/code-assistants/blob/main/docs/10-pdf-create-skill.md).

- The skill folder is self-contained and portable: no cross-skill or MCP dependencies, paths self-locate via `import.meta.url`, and dependencies install on demand behind a marker, so copying it into `~/.claude/skills/` works without the plugin (a local Node runtime is required).
- The render pipeline validates content and `design.md` with Zod, maps design tokens to a theme (fonts, colors, WCAG contrast), fails loudly on missing or variable fonts, and ships a themed component library, SVG-primitive charts, paginating tables, a bookmark + two-pass page-number TOC, and four templates.
- The bundled Node sub-project lives under a colon-free `renderer/` and stays decoupled from the Bun workspace via a `workspaces` negation and a `.prettierignore` entry; charts avoid native canvas deps and fonts default to the standard PDF families to keep the skill portable and free of committed binaries.
- The skills link-resolution test now skips `node_modules` so bundled dependency READMEs are not validated.

---

**Release notes:**

- Added `/autopilot:pdf-create`: generate beautiful, brand-themed, multi-page PDFs (report, research doc, six-pager, playbook) from structured content, optionally themed by a Google `design.md`.
- Self-contained and portable — copy its folder into `~/.claude/skills/` to use it without the plugin (requires a local Node runtime).

---

**Issues:**

Closes #336
