### PR TITLE
MAINTENANCE: Dedup and progress-tracking fixes for autopilot skills

### DIFF
--- a/claude-plugins/autopilot/skills/ask:gemini/SKILL.md
+++ b/claude-plugins/autopilot/skills/ask:gemini/SKILL.md
@@ -63,6 +63,8 @@ Parse `$ARGUMENTS` for an optional task description and optional `--model` / `--
 
 ## Critical Evaluation of Gemini Output
 
+<!-- The model-agnostic peer-evaluation guidance below (the four bullets and the colleague framing) is shared with [ask:codex](../ask:codex/SKILL.md#critical-evaluation-of-codex-output); keep the two in sync. -->
+
 Gemini is powered by Google models with their own knowledge cutoffs and limitations. Treat Gemini as a **colleague, not an authority**.
 
 - **Trust your own knowledge** when confident. If Gemini claims something you know is wrong, push back directly.

--- a/claude-plugins/autopilot/skills/linear:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/linear:create/SKILL.md
@@ -63,7 +63,7 @@ Mirror `issue:create` so the body reflects real code, not hallucinated structure
 
 **Title:** capitalized, ≤ 80 characters, no trailing period, business-focused, NOT Conventional Commits, no prefix.
 
-**Body — section ordering is MANDATORY** (exact `## ` headings, no trailing colon, no bold):
+**Body — section ordering is MANDATORY** (exact `## ` headings, no trailing colon, no bold). The five-section spec is canonical in [issue:create Phase 5](../issue:create/SKILL.md#phase-5-generate-body) — keep this list in sync with it:
 
 1. `## Context` — 1-2 paragraphs on the situation and why it matters now.
 2. `## What` — the deliverable in plain terms.

--- a/claude-plugins/autopilot/skills/pr:monitor/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:monitor/SKILL.md
@@ -145,7 +145,7 @@ Store PR number, owner/repo (extract from url), title, and state.
    - Exit: "PR #N is already approved with all checks passing. No monitoring needed."
 6. If HEAD unchanged AND checks are not all passing:
    - Output: "PR #N is approved but has failing CI checks. Attempting to fix..."
-   - Run the **CI Fix Workflow** (see Phase 2.2a)
+   - Run the **CI Fix Workflow** (see [§2.2a](#22a-check-ci-status))
    - After fix, output: "CI fixes pushed. Starting monitoring..."
    - Continue to Phase 1.2
 
@@ -159,7 +159,7 @@ Store PR number, owner/repo (extract from url), title, and state.
 **If checks are failing** (any check in `statusCheckRollup` with `state` that is not `SUCCESS` and not `PENDING` and not `EXPECTED`):
 
 1. Output: "PR #N has failing CI checks. Attempting to fix..."
-2. Run the **CI Fix Workflow** (see Phase 2.2a)
+2. Run the **CI Fix Workflow** (see [§2.2a](#22a-check-ci-status))
 3. After fix, output: "CI fixes pushed. Starting monitoring..."
 4. Continue to Phase 1.2
 
@@ -296,19 +296,7 @@ For each failing check, extract the run-id from the `link` field: parse the URL 
 
 1. Output: "PR #N: All CI checks passing."
 
-**If `reviewDecision` is `APPROVED` AND all checks pass:**
-
-1. Record current HEAD: `git rev-parse HEAD` → store as `headBefore`
-2. Invoke `Skill(autopilot:pr-resolve)` to evaluate unresolved suggestions and nitpicks. The skill will exit early if no actionable comments remain. For each suggestion:
-   - If reasonable and improves the code → fix it
-   - If not applicable or doesn't make sense → reply explaining why
-3. Check if HEAD changed: `git rev-parse HEAD` → compare with `headBefore`
-4. If HEAD changed (pr:resolve pushed new commits):
-   - Output: "pr:resolve pushed fixes. Resuming monitoring for new CI and approval..."
-   - Set `cooldownRemaining = 3`
-   - Continue polling loop (go to 2.1)
-5. If HEAD unchanged:
-   - Exit to [Phase 3](#phase-3-exit) with status "approved"
+Approval is handled once per cycle by [§2.2](#22-check-pr-state), which runs before this phase: when it sees `APPROVED` with all checks passing it evaluates suggestions and exits. If approval landed here while CI was still pending in §2.2, the next poll's §2.2 catches it — this phase needs no duplicate approval handler.
 
 ### 2.3 Check for New Reviews
 

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -55,7 +55,7 @@ All phases MUST use Claude Code's built-in task system for progress tracking. Cr
 
 ### Task Setup (MANDATORY - do FIRST before any work)
 
-Create all 6 tasks using TaskCreate, in order, before starting any work:
+Create all 9 tasks using TaskCreate, in order, before starting any work:
 
 | #   | Subject              | ActiveForm             | Source    |
 | --- | -------------------- | ---------------------- | --------- |
@@ -65,6 +65,9 @@ Create all 6 tasks using TaskCreate, in order, before starting any work:
 | 4   | Review with experts  | Reviewing with experts | skill     |
 | 5   | Validate plan scores | Validating plan scores | skill     |
 | 6   | Output final plan    | Outputting final plan  | skill     |
+| 7   | Commit changes       | Committing changes     | autopilot |
+| 8   | Create PR            | Creating PR            | autopilot |
+| 9   | Monitor PR           | Monitoring PR          | autopilot |
 
 Create each task with:
 
@@ -90,7 +93,7 @@ $ARGUMENTS
 
 **FIRST**, set up task tracking:
 
-1. Create all 6 tasks as defined in the Task Progress Protocol above (call TaskCreate 6 times)
+1. Create all 9 tasks as defined in the Task Progress Protocol above (call TaskCreate 9 times)
 2. Call TaskUpdate to set task 1 ("Resolve input") to `status: "in_progress"`
 
 ### Codebase Context and Issue Resolution (MANDATORY - DO FIRST)
@@ -358,13 +361,15 @@ After all implementation steps and verification are complete, execute the follow
 
 ### Step 1: Auto-Commit
 
-Invoke `Skill(autopilot:commits-create)` with arguments `--autopilot`. The `--autopilot` flag suppresses commits:create's commit-strategy prompt (Phase 3), commit-message confirmation (Phase 4), and PR-update offer (Phase 5). Follow the skill's full workflow — do NOT run `git commit` directly.
+Call TaskUpdate to set task 7 ("Commit changes") to `status: "in_progress"`. Invoke `Skill(autopilot:commits-create)` with arguments `--autopilot`. The `--autopilot` flag suppresses commits:create's commit-strategy prompt (Phase 3), commit-message confirmation (Phase 4), and PR-update offer (Phase 5). Follow the skill's full workflow — do NOT run `git commit` directly.
 
 If the commit fails due to a pre-commit hook, check `git status` for modified files (hook may have auto-formatted), re-stage with `git add -u`, and retry the commit once. If still fails, report the error and stop.
 
-After committing, push: `git push -u origin <branch>`
+After committing, push: `git push -u origin <branch>`. Then set task 7 ("Commit changes") to `completed`.
 
 ### Step 2: Auto-Create PR
+
+Call TaskUpdate to set task 8 ("Create PR") to `status: "in_progress"`.
 
 **CRITICAL — direct `gh pr create` and `gh pr edit` are FORBIDDEN in autopilot.** ALL PR creation and updates MUST go through `Skill(autopilot:pr-create)` and `Skill(autopilot:pr-update)`. Direct CLI calls produce PRs in the incorrect format. If a skill call fails or times out, report the error and stop — do NOT fall back to direct CLI commands.
 
@@ -375,7 +380,7 @@ After committing, push: `git push -u origin <branch>`
 
 2. Invoke `Skill(autopilot:pr-create)` with arguments `--autopilot` (append `--release-notes` when the branch's commits include `feat:` or `fix:` types so user-facing notes are included). The `--autopilot` flag suppresses pr:create's Phase 5 confirmation. Release notes are added automatically for breaking changes regardless of the flag. NEVER run `gh pr create` directly — even if the skill fails or times out. If the skill errors, report the failure and stop. Do NOT fall back to direct CLI.
 
-Output the PR URL after creation.
+Output the PR URL after creation. Set task 8 ("Create PR") to `completed`.
 
 3. **Format check** — After creating or updating the PR, validate its format:
    - Run `gh pr view --json title,body`
@@ -392,7 +397,7 @@ Output the PR URL after creation.
 
 ### Step 3: Monitor PR
 
-Invoke `Skill(autopilot:pr-monitor)` in foreground mode (do NOT use the Agent tool with run_in_background). The skill will:
+Call TaskUpdate to set task 9 ("Monitor PR") to `status: "in_progress"`. Invoke `Skill(autopilot:pr-monitor)` in foreground mode (do NOT use the Agent tool with run_in_background). The skill will:
 - Poll every minute for review status
 - If changes requested: invoke pr:resolve interactively (user IS involved for review feedback)
 - Wait for approval or merge
@@ -403,7 +408,7 @@ Invoke `Skill(autopilot:pr-monitor)` in foreground mode (do NOT use the Agent to
 
 ### Completion
 
-Output:
+Set task 9 ("Monitor PR") to `completed`. Output:
 
 Autopilot complete.
 PR: <pr-url>


### PR DESCRIPTION
Continues the autopilot audit cleanup with the structural-dedup and wiring findings that are bounded enough to land safely. The largest content reductions (the pr:review rule-catalogue trim and the branch:create dialog collapse) and the remaining multi-file byte-reconciliations are tracked for a final focused pass.

- Remove pr:monitor's duplicate APPROVED-and-all-pass handler and link its CI-fix cross-references to the CI-status phase anchor
- Track run's commit, create-PR, and monitor phases as tasks 7-9 so the progress list no longer stalls at "Output final plan"
- Point linear:create's five-section body at the canonical issue:create Phase 5 spec
- Mark ask:gemini's model-agnostic peer-evaluation guidance as shared with ask:codex

---

**Release notes:**

- The autopilot run progress tracker now covers the commit, PR, and monitor phases, not just planning
