### PR TITLE
MAINTENANCE: Trim token bloat in pr:review and branch:create

### DIFF
--- a/claude-plugins/autopilot/skills/branch:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/branch:create/SKILL.md
@@ -229,35 +229,25 @@ Present branch details and confirm using **AskUserQuestion tool**.
 
 **Preview substitution rules (MANDATORY):** The `<number>`, `<slug>`, `<issue title>`, `<prefix>`, and `<PREFIX>` tokens in the templates below are PLACEHOLDERS. Before invoking AskUserQuestion, substitute each placeholder with the concrete value you resolved in earlier phases (e.g., `<number>` → `123`, `<slug>` → `jwt-refresh`, `<issue title>` → `Add JWT token refresh endpoint`). NEVER pass the literal `issue-<number>-<slug>\n\nIssue: <issue title>...` string — every option's `preview` must contain the fully resolved branch preview string. No shorthand (`"..."`, `"<same>"`, empty string) is permitted; always write out the full resolved preview for every option.
 
-**For standard branches (with GitHub issue):**
-
-Tool parameters:
+**One dialog template for every branch kind.** Tool parameters:
 
 - `question`: "Review the branch name and choose an action."
 - `header`: "Create branch"
 - `options`: [
-  { label: "Create branch", description: "Create and push to origin with tracking", preview: "issue-<number>-<slug>\n\nIssue: <issue title>\nFrom: origin/main" },
-  { label: "Edit slug", description: "Modify the branch name slug", preview: "issue-<number>-<slug>\n\nIssue: <issue title>\nFrom: origin/main" }
+  { label: "Create branch", description: "Create and push to origin with tracking", preview: "<preview>" },
+  { label: "Edit slug", description: "Modify the branch name slug", preview: "<preview>" }
   ]
 - `multiSelect`: false
 
-Both options use the same `preview` content since the user is choosing an action, not content. The preview enables a side-by-side layout in the UI.
+Both options carry the same `<preview>` content since the user is choosing an action, not content; the shared preview enables a side-by-side layout in the UI. Substitute `<preview>` with the body for the resolved branch kind:
 
-**For Linear ticket branches**, use the same two-option structure with the resolved `<team>-<number>-<slug>` branch name and a `Ticket: <LINEAR-ID>` line in place of `Issue:`.
+| Branch kind    | `<preview>` body                                                   |
+| -------------- | ------------------------------------------------------------------ |
+| GitHub issue   | `issue-<number>-<slug>\n\nIssue: <issue title>\nFrom: origin/main` |
+| Special prefix | `<prefix>-<slug>\n\nType: <PREFIX>\nFrom: origin/main`             |
+| Linear ticket  | `<team>-<number>-<slug>\n\nTicket: <LINEAR-ID>\nFrom: origin/main` |
 
-**For special prefix branches:**
-
-Tool parameters:
-
-- `question`: "Review the branch name and choose an action."
-- `header`: "Create branch"
-- `options`: [
-  { label: "Create branch", description: "Create and push to origin with tracking", preview: "<prefix>-<slug>\n\nType: <PREFIX>\nFrom: origin/main" },
-  { label: "Edit slug", description: "Modify the branch name slug", preview: "<prefix>-<slug>\n\nType: <PREFIX>\nFrom: origin/main" }
-  ]
-- `multiSelect`: false
-
-Both options use the same `preview` content since the user is choosing an action, not content.
+When a custom description was provided, drop the `Issue:` line (no issue title to show) — e.g. `issue-<number>-<slug>\n\nFrom: origin/main`.
 
 Only proceed to [Phase 6](#phase-6-execute) after user selects "Create branch". If "Edit slug" selected, ask for new slug and regenerate branch name.
 
@@ -294,7 +284,9 @@ Only proceed to [Phase 6](#phase-6-execute) after user selects "Create branch". 
 
 ## Examples
 
-### Basic usage (auto-generated slug)
+Every example uses the one [Phase 5](#phase-5-verify-with-user) dialog template — only the resolved `<preview>` body changes per branch kind (see the table there). Two worked cases below; Linear and the other special prefixes follow identically.
+
+### GitHub issue (auto-generated slug)
 
 ```
 /autopilot:branch-create 123
@@ -303,14 +295,7 @@ Fetching GitHub issue #123...
 Title: "Add JWT token refresh endpoint for authentication service"
 ```
 
-AskUserQuestion with:
-
-- `question`: "Review the branch name and choose an action."
-- `header`: "Create branch"
-- `options`: [
-  { label: "Create branch", description: "Create and push to origin with tracking", preview: "issue-123-jwt-refresh\n\nIssue: Add JWT token refresh endpoint\nFrom: origin/main" },
-  { label: "Edit slug", description: "Modify the branch name slug", preview: "issue-123-jwt-refresh\n\nIssue: Add JWT token refresh endpoint\nFrom: origin/main" }
-  ]
+AskUserQuestion with the [Phase 5](#phase-5-verify-with-user) template, both options' `<preview>` resolved to `issue-123-jwt-refresh\n\nIssue: Add JWT token refresh endpoint\nFrom: origin/main`.
 
 User selects "Create branch".
 
@@ -319,116 +304,18 @@ User selects "Create branch".
 ✓ Pushed to origin with tracking
 ```
 
-### With custom description
-
-```
-/autopilot:branch-create 123 "api endpoint only"
-```
-
-AskUserQuestion with:
-
-- `question`: "Review the branch name and choose an action."
-- `header`: "Create branch"
-- `options`: [
-  { label: "Create branch", description: "Create and push to origin with tracking", preview: "issue-123-api-endpoint-only\n\nFrom: origin/main" },
-  { label: "Edit slug", description: "Modify the branch name slug", preview: "issue-123-api-endpoint-only\n\nFrom: origin/main" }
-  ]
-
-User selects "Create branch".
-
-```
-✓ Branch created: issue-123-api-endpoint-only
-✓ Pushed to origin with tracking
-```
-
-### Linear ticket (with --start)
-
-```
-/autopilot:branch-create ENG-123 --start
-```
-
-Fetches Linear ticket `ENG-123`, builds `eng-123-<slug>`, and moves the ticket to In Progress after creation.
-
-AskUserQuestion with:
-
-- `question`: "Review the branch name and choose an action."
-- `header`: "Create branch"
-- `options`: [
-  { label: "Create branch", description: "Create and push to origin with tracking", preview: "eng-123-jwt-refresh\n\nTicket: ENG-123\nFrom: origin/main" },
-  { label: "Edit slug", description: "Modify the branch name slug", preview: "eng-123-jwt-refresh\n\nTicket: ENG-123\nFrom: origin/main" }
-  ]
-
-User selects "Create branch".
-
-```
-✓ Branch created: eng-123-jwt-refresh
-✓ Pushed to origin with tracking
-✓ Ticket ENG-123 moved to In Progress
-```
-
 ### Special prefix (--hotfix)
 
 ```
 /autopilot:branch-create --hotfix "memory leak in editor"
 ```
 
-AskUserQuestion with:
-
-- `question`: "Review the branch name and choose an action."
-- `header`: "Create branch"
-- `options`: [
-  { label: "Create branch", description: "Create and push to origin with tracking", preview: "hotfix-memory-leak-editor\n\nType: HOTFIX\nFrom: origin/main" },
-  { label: "Edit slug", description: "Modify the branch name slug", preview: "hotfix-memory-leak-editor\n\nType: HOTFIX\nFrom: origin/main" }
-  ]
+AskUserQuestion with the [Phase 5](#phase-5-verify-with-user) template, both options' `<preview>` resolved to `hotfix-memory-leak-editor\n\nType: HOTFIX\nFrom: origin/main`.
 
 User selects "Create branch".
 
 ```
 ✓ Branch created: hotfix-memory-leak-editor
-✓ Pushed to origin with tracking
-```
-
-### Special prefix (--proposal)
-
-```
-/autopilot:branch-create --proposal "add vim keybindings"
-```
-
-AskUserQuestion with:
-
-- `question`: "Review the branch name and choose an action."
-- `header`: "Create branch"
-- `options`: [
-  { label: "Create branch", description: "Create and push to origin with tracking", preview: "proposal-add-vim-keybindings\n\nType: PROPOSAL\nFrom: origin/main" },
-  { label: "Edit slug", description: "Modify the branch name slug", preview: "proposal-add-vim-keybindings\n\nType: PROPOSAL\nFrom: origin/main" }
-  ]
-
-User selects "Create branch".
-
-```
-✓ Branch created: proposal-add-vim-keybindings
-✓ Pushed to origin with tracking
-```
-
-### Special prefix (--security)
-
-```
-/autopilot:branch-create --security "tainted format string"
-```
-
-AskUserQuestion with:
-
-- `question`: "Review the branch name and choose an action."
-- `header`: "Create branch"
-- `options`: [
-  { label: "Create branch", description: "Create and push to origin with tracking", preview: "security-tainted-format-string\n\nType: SECURITY\nFrom: origin/main" },
-  { label: "Edit slug", description: "Modify the branch name slug", preview: "security-tainted-format-string\n\nType: SECURITY\nFrom: origin/main" }
-  ]
-
-User selects "Create branch".
-
-```
-✓ Branch created: security-tainted-format-string
 ✓ Pushed to origin with tracking
 ```
 

--- a/claude-plugins/autopilot/skills/pr:review/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:review/SKILL.md
@@ -201,8 +201,6 @@ A variable from an outer scope, a similarly-named variable, or a copy-paste left
 
 Multiple async tasks reading/writing the same mutable object (array, object, or instance field) without synchronization; interleaved awaits can cause inconsistent state even in single-threaded async runtimes.
 
-- Example: two async tasks pushing to the same array with awaits between read and write.
-
 <a id="CHECK-BUG-004"></a>
 **CHECK-BUG-004: Incorrect serialization/deserialization** — Severity: blocker
 
@@ -260,8 +258,6 @@ A broken algorithm (MD5/SHA1 for security), a non-constant-time secret compariso
 **CHECK-SEC-005: Unsafe deserialization or dynamic evaluation of untrusted input** — Severity: blocker
 
 `eval`/`Function`, dynamic `import()`/`require()` with a user-controlled path, or deserializing attacker-controlled data into executable structures.
-
-- Example: `eval(req.body.expr)`; `require(userSuppliedPath)`.
 
 <a id="CHECK-SEC-006"></a>
 **CHECK-SEC-006: Secrets or PII written to logs or responses** — Severity: suggestion
@@ -373,8 +369,6 @@ Any code file longer than 1000 lines. Long files must be split.
 
 Name implies different behavior than the code does. `get*` that mutates state, `is*` that returns non-boolean, `validate*` that also transforms.
 
-- Example: `getUser()` that creates the user if not found.
-
 <a id="CHECK-CPLX-006"></a>
 **CHECK-CPLX-006: Inconsistent naming within module** — Severity: suggestion
 
@@ -399,8 +393,6 @@ Function accepts more than 9 total parameters or more than 6 positional, indicat
 
 Comments describing what the code does (obvious from the code) instead of why.
 
-- Example: `// increment counter` above `counter += 1`.
-
 #### Platform Standards
 
 <a id="CHECK-PLAT-001"></a>
@@ -414,8 +406,6 @@ GitHub issue references (`#123`, `Closes #123`) must NOT appear in commit messag
 **CHECK-PLAT-002: Lint or type suppression comment (@ts-ignore / @ts-expect-error / eslint-disable)** — Severity: blocker
 
 Zero tolerance for lint/type suppression comments. Any `@ts-ignore`, `@ts-expect-error`, `@ts-nocheck`, `eslint-disable`, `eslint-disable-next-line` is a blocker.
-
-- Example: `// @ts-ignore — TODO fix later`.
 
 <a id="CHECK-PLAT-003"></a>
 **CHECK-PLAT-003: Wrong validation library** — Severity: suggestion
@@ -501,8 +491,6 @@ Function mutates a passed-in object to "return" data through it instead of using
 
 Function marked `async` with no `await` — synchronous code wearing an async costume.
 
-- Example: `async function getConfig() { return { key: "value" }; }`.
-
 <a id="CHECK-AI-004"></a>
 **CHECK-AI-004: Logging every line of execution** — Severity: suggestion
 
@@ -513,14 +501,10 @@ Debug logging at entry, exit, and every intermediate step. Logs should capture d
 
 Type annotations on every local variable, including trivially obvious ones, adding noise without aiding understanding.
 
-- Example: `const items: string[] = []; const count: number = 0;`.
-
 <a id="CHECK-AI-006"></a>
 **CHECK-AI-006: Placeholder implementation left in production code** — Severity: blocker
 
 An empty stub body, a `throw new Error("Not implemented")`, or a `// TODO` placeholder in code that should be fully implemented.
-
-- Example: `function handleError(error: Error) { throw new Error("Not implemented"); }` in production.
 
 <a id="CHECK-DEAD-001"></a>
 **CHECK-DEAD-001: Dead code introduced by the diff** — Severity: suggestion
@@ -557,8 +541,6 @@ A data structure that grows without bound (cache, in-memory queue, log buffer) w
 **CHECK-CS-004: Error message doesn't help debugging** — Severity: suggestion
 
 An error message lacking enough context to diagnose — missing which value failed, what was expected, or what operation was attempted.
-
-- Example: `throw new Error("invalid input")` instead of including the offending value.
 
 <a id="CHECK-CS-005"></a>
 **CHECK-CS-005: Log message at wrong level** — Severity: suggestion
@@ -716,8 +698,6 @@ The string passed to an error constructor or `throw` must be static; put dynamic
 **CHECK-LOG-004: Asynchronous or fire-and-forget logging** — Severity: suggestion
 
 Log calls must be synchronous. Wrapping them in `setImmediate`, `process.nextTick`, a `Promise` callback, or `await`-ing them solely to defer risks dropping records on shutdown and makes ordering non-deterministic.
-
-- Example: `setImmediate(() => logger.info("Request processed."))` → call `logger.info(...)` directly.
 
 <a id="CHECK-LOG-005"></a>
 **CHECK-LOG-005: Logging an error at the throw site** — Severity: suggestion


### PR DESCRIPTION
Cuts token bloat in the two skills the audit flagged as the worst offenders, with no behavior change.

- pr:review (PERF-01): drop the redundant Example line from ten self-describing rules whose title and intent already convey the check. Every CHECK anchor, title, severity, and intent sentence is untouched — the anchor set stays at 86.
- branch:create (SIMP-01): collapse Phase 5's three near-identical confirmation dialogs into one template plus a per-kind preview table, and reduce the Examples from six repeated demos to two. Option labels, substitution rules, and the conflict dialog are unchanged.

Net ~133 fewer lines across the two skills; linkResolution, referenceFormattingSync, and rulesDocUrlSync all pass.
