### PR TITLE
MAINTENANCE: Low-severity cleanup across autopilot skills and agents

### DIFF
--- a/claude-plugins/autopilot/agents/analyze-pr-commits.md
+++ b/claude-plugins/autopilot/agents/analyze-pr-commits.md
@@ -84,4 +84,4 @@ Output ONLY the structured block. No preamble or commentary:
 [git diff --stat output, verbatim]
 ```
 
-Omit the "Issue Context" section if `fetchGithubIssue` is `false` or the fetch failed.
+Omit the "Issue Context" section if the `Fetch issue` flag is `false` or the fetch failed.

--- a/claude-plugins/autopilot/agents/resolve-assignees.md
+++ b/claude-plugins/autopilot/agents/resolve-assignees.md
@@ -1,7 +1,7 @@
 ---
 name: resolve-assignees
 description: Resolve candidate assignees for an issue from CODEOWNERS and Linear team members. Use when a creation skill needs an assignee picklist without polluting parent context.
-tools: Bash, Grep, MCP(linear:*)
+tools: Bash, MCP(linear:*)
 model: sonnet
 ---
 

--- a/claude-plugins/autopilot/agents/resolve-issue-context.md
+++ b/claude-plugins/autopilot/agents/resolve-issue-context.md
@@ -1,7 +1,7 @@
 ---
 name: resolve-issue-context
 description: Fetch issue context from GitHub (gh) or Linear (MCP, with a GraphQL fallback) and optionally auto-assign the current user (idempotent, opt-in via caller flag). Use when commands need structured issue data without polluting parent context.
-tools: Bash, Grep, MCP(linear:*)
+tools: Bash, MCP(linear:*)
 model: sonnet
 ---
 

--- a/claude-plugins/autopilot/agents/scan-and-analyze-todos.md
+++ b/claude-plugins/autopilot/agents/scan-and-analyze-todos.md
@@ -13,7 +13,7 @@ The invoking command provides in the prompt:
 
 - **Language**: `typescript`, `python`, or `go`
 - **Repository** in `owner/repo` format (e.g., `awinogradov/code-assistants`)
-- **Provider** (optional, `github` or `linear`; default `github`) — selects how referenced issues are checked in [Phase 3](#phase-3-analyze-with-github)
+- **Provider** (optional, `github` or `linear`; default `github`) — selects how referenced issues are checked in [Phase 3](#phase-3-analyze-issue-status)
 
 ## Phase 1: Scan
 
@@ -40,7 +40,7 @@ For each match, extract:
 - Whether the description contains a GitHub issue reference (`#\d+`) or, on a Linear project, a Linear id (`[A-Z]+-\d+`)
 - The `@see` URL if present — extract the GitHub issue number from a `github.com/.../issues/N` URL, or the Linear id from a `linear.app/.../issue/<ID>` URL
 
-## Phase 3: Analyze with GitHub
+## Phase 3: Analyze Issue Status
 
 For a **Linear** project (provider is `linear`), check a referenced ticket with `mcp__plugin_autopilot_linear__get_issue` instead of `gh issue view`: a `state.name` of `Done` or `Canceled` is **stale**, any other state is **linked** (or **needs link** when the `@see` is missing). The GitHub buckets below apply otherwise.
 

--- a/claude-plugins/autopilot/lib/linear/linearClient.mjs
+++ b/claude-plugins/autopilot/lib/linear/linearClient.mjs
@@ -18,7 +18,7 @@ const issueQuery = `
       description
       state { name }
       labels { nodes { name } }
-      comments { nodes { user { displayName } createdAt body } }
+      comments(orderBy: createdAt) { nodes { user { displayName } createdAt body } }
     }
   }
 `;

--- a/claude-plugins/autopilot/skills/linear:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/linear:create/SKILL.md
@@ -52,7 +52,7 @@ This workflow is not complete until [Phase 7](#phase-7-create-issue) calls `mcp_
 
 ## Phase 1: Gather Context
 
-Mirror `issue:create` so the body reflects real code, not hallucinated structure.
+Mirror `issue:create` so the body reflects real code, not hallucinated structure. Unlike `issue:create`, this skill deliberately omits related-issue/PR detection and the duplicate-warning check — Linear search is not wired through the MCP here, so surfacing related work is out of scope.
 
 1. Acquire the codebase snapshot once (prefer the committed pack): if `.repomix/pack.xml` exists at the repository root, call `mcp__repomix__attach_packed_output` with its path; otherwise `mcp__repomix__pack_codebase` with `compress: true`. Store the `outputId`.
 2. `mcp__repomix__grep_repomix_output` for files/symbols related to the hint, then `mcp__repomix__read_repomix_output` for the matched sections only.

--- a/claude-plugins/autopilot/skills/pr:review/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:review/SKILL.md
@@ -167,10 +167,7 @@ Review the diff against **all** checks below in a single pass and collect findin
 
 ### 2.1 Detect Stack
 
-Read `package.json` in the repository root (use Read tool or `grep_repomix_output`). Extract the `agents.rules` field value as the stack identifier.
-
-- If the file exists: store the `rules` value (e.g., `Bun`, `NodeJS+React`, `Bun+React+Tailwind`, `NodeJS+React+Tailwind`)
-- If the file does not exist or `rules` is missing: set stack to `unknown`
+Use the **Stack** already recorded in the [§1.5 Context Map](#15-context-map) — the `agents.rules` value (e.g. `Bun`, `NodeJS+React`, `Bun+React+Tailwind`, `NodeJS+React+Tailwind`), or `unknown` when `package.json` or the field is missing. Do not re-read `package.json` here; §1.5 already captured it.
 
 ### 2.2 Review Principles
 
@@ -955,7 +952,7 @@ Add an optional `suggestion` to an inline comment when the fix is concrete and m
 - "🔁 Follow-up review" prefix or any round-labeling preamble
 - CLAUDE.md compliance checklists
 - File/line change statistics
-- Hedging words: "should", "could", "might", "consider"
+- Hedging words: "should", "could", "might"
 - Duplicate content between reviewComment and inlineComments
 - Empty sections with "None", "N/A", or similar placeholders
 

--- a/claude-plugins/autopilot/skills/pr:review/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr:review
 description: Review a pull request and provide constructive feedback with structured verdict. Used by awinogradov/code-review-action
-argument-hint: "REPO: <owner/repo> PR_NUMBER: <number> REVIEWER: <bot-login> PR_AUTHOR: <author-login> RULES_DOC_URL: <url>"
+argument-hint: "REPO: <owner/repo> PR_NUMBER: <number> REVIEWER: <bot-login> PR_AUTHOR: <author-login> RULES_DOC_URL: <url> (all but RULES_DOC_URL fall back to gh when omitted)"
 allowed-tools:
   - Read
   - Glob

--- a/claude-plugins/autopilot/skills/pr:validate/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:validate/SKILL.md
@@ -192,7 +192,7 @@ If the `gh` call fails (auth/network), skip this section and validate format onl
 
 ## Comment Generation
 
-When the PR is **invalid**, generate a full GitHub PR comment in the `comment` field. Be sarcastic and use emojis generously. Address the PR author by @-mentioning PR_AUTHOR. Explain what went wrong, show how to fix it, and link to the [contributing guidelines](https://github.com/awinogradov/code-assistants/blob/main/CONTRIBUTING.md). When the PR is **valid**, set `comment` to an empty string.
+When the PR is **invalid**, generate a full GitHub PR comment in the `comment` field. Be sarcastic and use emojis generously. Address the PR author by @-mentioning PR_AUTHOR. Explain what went wrong, show how to fix it, and link to the [contributing guidelines](<repo-blob-url>/CONTRIBUTING.md). When the PR is **valid**, set `comment` to an empty string.
 
 ---
 

--- a/claude-plugins/autopilot/skills/preflight-check/SKILL.md
+++ b/claude-plugins/autopilot/skills/preflight-check/SKILL.md
@@ -40,11 +40,7 @@ Run:
 git branch --show-current
 ```
 
-Store the result as `currentBranch`.
-
-- If `currentBranch` is `main` or `master`, go to [Phase 1.5](#phase-15-detect-git-worktree).
-- If empty (detached HEAD), treat as not-main with no branch issue ID — go to [Phase 1.5](#phase-15-detect-git-worktree).
-- Otherwise, go to [Phase 1.5](#phase-15-detect-git-worktree).
+Store the result as `currentBranch`. An empty value means detached HEAD — treat it as not-`main` with no branch issue ID. Continue to [Phase 1.5](#phase-15-detect-git-worktree); the main-vs-feature decision happens there.
 
 ## Phase 1.5: Detect Git Worktree
 

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -415,18 +415,6 @@ PR: <pr-url>
 Status: <approved/merged>
 ```
 
-## Quiz Mode Format
-
-When clarification needed:
-
-```
-**Q[N]**: [Clear question]
-A) [Option with brief explanation]
-B) [Option with brief explanation]
-C) [Option with brief explanation]
-D) Other: ___
-```
-
 When you write the plan file, apply the reference-formatting rules inlined at the end of this skill (the **Reference formatting & readability** block below, RFC-0001 v3) to every reference it contains — link files, docs, skills, agents, and sections, and never leave a reference as bare text.
 
 <!-- ref-format:start -->

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run
 description: Plan, implement, commit, create PR, and monitor until approved
-argument-hint: "<task description, GitHub issue number, or GitHub issue URL>"
+argument-hint: "<task, GitHub/Linear issue (123, #123, ENG-123, or URL), or code-scanning alert (alert#N or URL)>"
 allowed-tools:
   - TaskCreate
   - TaskUpdate
@@ -44,6 +44,8 @@ Expected forms (same as `plan`):
 
 - `<task description>` — free-form description
 - `<GitHub-issue-number>` / `<GitHub-issue-URL>`
+- `<Linear-issue-id>` (e.g. `ENG-123`) or a Linear issue URL — when a `linear` tracker is configured
+- `<code-scanning-alert>` — `alert#<n>` or a code-scanning alert URL
 
 ## Input resolution
 

--- a/claude-plugins/autopilot/skills/todo-cleanup/SKILL.md
+++ b/claude-plugins/autopilot/skills/todo-cleanup/SKILL.md
@@ -111,7 +111,7 @@ If user selects "Cancel", stop without changes.
 
 ## Phase 4: Execute
 
-### 5a. Remove stale TODOs
+### 4a. Remove stale TODOs
 
 For each stale TODO:
 
@@ -129,7 +129,7 @@ For each stale TODO:
      ]
    - `multiSelect`: false
 
-### 5b. Create GitHub issues for unlinked TODOs
+### 4b. Create GitHub issues for unlinked TODOs
 
 1. **Group related TODOs** when possible:
    - TODOs in the same file within 10 lines of each other
@@ -155,7 +155,7 @@ For each stale TODO:
    e. Use Edit tool to add `@see` link on the line after the TODO comment:
    - TypeScript/Go: `// @see <issue-url>`
 
-### 5c. Add links for "referenced but not linked" TODOs
+### 4c. Add links for "referenced but not linked" TODOs
 
 1. Build the issue URL — GitHub: `https://github.com/<owner>/<repo>/issues/<N>`; Linear: the ticket URL (e.g. `https://linear.app/<org>/issue/<ID>`)
 2. Use Edit tool to add `@see` link on the line after the TODO:


### PR DESCRIPTION
The low-severity cleanup batch from the autopilot audit — small, self-contained fixes across skills and agents. Each is its own commit; linkResolution, referenceFormattingSync, and rulesDocUrlSync all pass.

- LOGIC-07: collapse preflight-check's no-op three-way branch (all routed to Phase 1.5) into one statement
- LOGIC-14: order the Linear GraphQL-fallback comments by createdAt so they match the MCP path
- LOGIC-15: pr:review §2.1 reuses the Stack already recorded in §1.5 instead of re-reading package.json
- PERF-05: drop the unused Grep grant from resolve-issue-context and resolve-assignees
- DOC-03: note in pr:review's hint that all inputs but RULES_DOC_URL fall back to gh
- DOC-04: use the portable repo-blob-url placeholder for pr:validate's CONTRIBUTING link (correct when synced downstream)
- DOC-05: delete run's dead Quiz Mode Format section
- DOC-06: analyze-pr-commits references the real "Fetch issue" flag, not fetchGithubIssue
- DOC-08: document run's Linear and code-scanning-alert input forms in the hint
- DOC-09: renumber todo-cleanup's Phase 4 subsections 5a/5b/5c to 4a/4b/4c
- DOC-10: rename scan-and-analyze's Phase 3 heading to be provider-neutral
- DOC-11: note that linear:create deliberately omits related-issue detection
- DOC-12: drop "consider" from pr:review's hedging-words exclusion (it's the skill's own suggestion tone)
