### PR TITLE
MAINTENANCE: Install consumer-declared plugins during AI code review

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -545,6 +545,8 @@ runs:
         CLAUDE_DISALLOWED_TOOLS: "Bash(gh pr review:*),Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(gh api * -X *:*),Bash(gh api * --method *:*),Bash(gh api * -f *:*),Bash(gh api * -F *:*),Bash(gh api * --field *:*),Bash(gh api * --raw-field *:*),Bash(gh api * --input *:*),Bash(gh api graphql:*)"
         CLAUDE_JSON_SCHEMA: '{"type":"object","properties":{"verdict":{"type":"string","enum":["approve","requestChanges","comment"]},"reviewComment":{"type":"string"},"inlineComments":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"line":{"type":"integer"},"body":{"type":"string"},"startLine":{"type":"integer"},"suggestion":{"type":"string"}},"required":["path","line","body"]}}},"required":["verdict","reviewComment"]}'
         CLAUDE_PLUGIN_DIR: ${{ steps.plugin.outputs.dir }}
+        # Install plugins the consumer repo declares in enabledPlugins; the SDK is cache-only without this.
+        CLAUDE_CODE_SYNC_PLUGIN_INSTALL: "1"
         CLAUDE_MCP_CONFIG: ${{ steps.mcp.outputs.path }}
         CLAUDE_SETTINGS: ${{ inputs.settings }}
         EXECUTION_OUTPUT_FILE: ${{ runner.temp }}/claude-execution-output.json
@@ -613,6 +615,8 @@ runs:
         CLAUDE_DISALLOWED_TOOLS: "Bash(gh pr review:*),Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(gh api * -X *:*),Bash(gh api * --method *:*),Bash(gh api * -f *:*),Bash(gh api * -F *:*),Bash(gh api * --field *:*),Bash(gh api * --raw-field *:*),Bash(gh api * --input *:*),Bash(gh api graphql:*)"
         CLAUDE_JSON_SCHEMA: '{"type":"object","properties":{"reply":{"type":"string"},"resolveComments":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string"},"line":{"type":"integer"}},"required":["path","line"]}},"updatedVerdict":{"type":["string","null"],"enum":["approve","requestChanges","comment",null]},"updatedReviewComment":{"type":["string","null"]}},"required":["reply"]}'
         CLAUDE_PLUGIN_DIR: ${{ steps.plugin.outputs.dir }}
+        # Install plugins the consumer repo declares in enabledPlugins; the SDK is cache-only without this.
+        CLAUDE_CODE_SYNC_PLUGIN_INSTALL: "1"
         CLAUDE_MCP_CONFIG: ${{ steps.mcp.outputs.path }}
         CLAUDE_SETTINGS: ${{ inputs.settings }}
         EXECUTION_OUTPUT_FILE: ${{ runner.temp }}/claude-reaction-output.json


### PR DESCRIPTION
The action runs the Agent SDK cache-only, so a consumer repo's `enabledPlugins` are never installed — pointing `review_prompt`/`react_prompt` at a consumer skill (e.g. `/platform:pr-review`) fails with "Unknown command".

Set `CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1` on the Code Review and React to Comment runs so the SDK installs whatever the consumer declares in `enabledPlugins`, resolved against the repo's own `.claude-plugin/marketplace.json` and any `extraKnownMarketplaces`. This generalizes to multiple plugins from multiple marketplaces with no per-plugin action config.

- Consumers with no `enabledPlugins` are unaffected (no-op install).
- The preflight "Explain failed checks" run is left cache-only — it uses a bare prompt and loads no plugin.

Verified against a downstream consumer that sets `review_prompt: /platform:pr-review` + `enabledPlugins`: its review previously failed with "Unknown command"; re-running it against this change should post a real review.
