### PR TITLE
HOTFIX: Allow Licenses workflow to run via workflow_dispatch

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -15,6 +15,7 @@ on:
       - "pnpm-lock.yaml"
       - "package-lock.json"
       - "LICENSES.md"
+  workflow_dispatch:
 
 concurrency:
   group: licenses-${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the Licenses workflow so the license audit can be run manually from the Actions UI, not only on dependency pull requests.

- Added a bare `workflow_dispatch:` entry to the `on:` block of `licenses.yml`, mirroring the trigger style already used by `upstream.yml`

---

Note: the `licenses-audit` action keys its steps off pull-request event context (`github.head_ref`, `github.event.pull_request.*`), so a manual dispatch runs in read-only audit mode — it passes when `LICENSES.md` is current and fails on drift, without auto-committing. Extending the action to auto-commit on dispatch is intentionally out of scope for this hotfix.
