### PR TITLE
MAINTENANCE: Authenticate git for private plugin marketplaces

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -455,6 +455,15 @@ runs:
       run: |
         echo "dir=${{ github.action_path }}/../../../claude-plugins/autopilot" >> "$GITHUB_OUTPUT"
 
+    # github `marketplaces`/`plugins` sources clone over HTTPS in CI (no SSH key); the gh credential
+    # helper lets that clone authenticate to a private repo with bot_token.
+    - name: Authenticate git for private plugin marketplaces
+      if: steps.ctx.outputs.skip != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.bot_token }}
+      run: gh auth setup-git
+
     # ── Review mode ──
 
     - name: Force AI reviewer


### PR DESCRIPTION
A consumer that points `marketplaces` at a private repo (e.g. `platform-engineering=acclaim-ai/platform-engineering`) couldn't install the plugin in CI: the SDK clones github plugin sources over SSH, and with no SSH key present it retries HTTPS — which fails without a git credential helper (`could not read Username for 'https://github.com'`).

Adds a `gh auth setup-git` step (using `bot_token`) before the review/react runs, so the SDK's HTTPS clone authenticates to private marketplace repos.

Verified locally against the bundled CLI: with SSH disabled and the gh credential helper configured, `claude plugin marketplace add acclaim-ai/platform-engineering` retries over HTTPS and clones successfully; without it the clone fails auth.

Needed by platform-engineering's synced `code-review.yml`, which must fetch the `platform` plugin from `acclaim-ai/platform-engineering` (not `.`) so the workflow works in every downstream consumer repo, not just platform-engineering itself.
