### PR TITLE
Restore AI release notes by making the model configurable

### DIFF
--- a/.github/actions/release-action/README.md
+++ b/.github/actions/release-action/README.md
@@ -87,6 +87,7 @@ jobs:
 | `anthropic_api_key`    | no       | —                     | Anthropic API key. When set, generates human-readable release-note summaries.                                                             |
 | `anthropic_base_url`   | no       | —                     | Custom Anthropic API base URL for a gateway/proxy/compatible endpoint (full URL with scheme). Unset uses the default `api.anthropic.com`. |
 | `anthropic_auth_token` | no       | —                     | Bearer token for a custom Anthropic host (`Authorization: Bearer`). Alternative to `anthropic_api_key` — set one, not both.               |
+| `model`                | no       | `claude-sonnet-4-6`   | Anthropic model for AI-generated release notes. Overrides the built-in default; leave unset to use it.                                    |
 | `name`                 | no       | —                     | Service or library name for PR titles (e.g. `Dialog Manager` → `Release Dialog Manager 1.2.0`).                                           |
 | `branch`               | no       | `release-{version}`   | Release branch template. `{version}` is substituted. `create` mode only.                                                                  |
 | `linear_api_key`       | no       | —                     | Linear API key for ticket integration.                                                                                                    |

--- a/.github/actions/release-action/action.yml
+++ b/.github/actions/release-action/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: |
       Bearer auth token for a custom Anthropic host (sent as Authorization: Bearer). Alternative to anthropic_api_key — set one, not both.
     required: false
+  model:
+    description: |
+      Anthropic model for AI-generated release notes (e.g. claude-sonnet-4-6). Overrides the built-in default; leave unset to use it.
+    required: false
   name:
     description: |
       Service or library name for PR titles.
@@ -141,6 +145,7 @@ runs:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         ANTHROPIC_AUTH_TOKEN: ${{ inputs.anthropic_auth_token }}
         ANTHROPIC_BASE_URL: ${{ inputs.anthropic_base_url }}
+        ANTHROPIC_MODEL: ${{ inputs.model }}
         GH_TOKEN: ${{ inputs.bot_token }}
         LINEAR_API_KEY: ${{ inputs.linear_api_key }}
         LINEAR_KEYS: ${{ inputs.linear_keys }}
@@ -192,6 +197,7 @@ runs:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         ANTHROPIC_AUTH_TOKEN: ${{ inputs.anthropic_auth_token }}
         ANTHROPIC_BASE_URL: ${{ inputs.anthropic_base_url }}
+        ANTHROPIC_MODEL: ${{ inputs.model }}
       run: bun "${{ github.action_path }}/src/generateReleaseNotes.ts"
 
     - name: Update Release Notes File

--- a/.github/actions/release-action/src/generateReleaseNotes.test.ts
+++ b/.github/actions/release-action/src/generateReleaseNotes.test.ts
@@ -12,11 +12,13 @@ import {
   callAnthropicApi,
   generateWithApi,
   resolveAnthropicClientOptions,
+  resolveAnthropicModel,
   runReleaseNotes,
   verifyReleaseNotes,
 } from "./generateReleaseNotes.ts";
 import {
   buildUserMessage,
+  defaultAnthropicModel,
   filterChangelogForAi,
   readServiceContext,
   systemPrompt,
@@ -342,6 +344,7 @@ describe("callAnthropicApi", () => {
       { apiKey: "test-key" },
       "test prompt",
       "system prompt",
+      defaultAnthropicModel,
       mockMessages
     );
 
@@ -359,10 +362,30 @@ describe("callAnthropicApi", () => {
       },
     };
 
-    await callAnthropicApi({ apiKey: "test-key" }, "user msg", "my system prompt", mockMessages);
+    await callAnthropicApi(
+      { apiKey: "test-key" },
+      "user msg",
+      "my system prompt",
+      defaultAnthropicModel,
+      mockMessages
+    );
 
     expect(capturedSystem).toBe("my system prompt");
     expect(capturedUserContent).toBe("user msg");
+  });
+
+  test("forwards the model to the client", async () => {
+    let capturedModel: string | undefined;
+    const mockMessages: AnthropicMessages = {
+      create: async (params) => {
+        capturedModel = params.model;
+        return { content: [{ type: "text", text: "notes" }] };
+      },
+    };
+
+    await callAnthropicApi({ apiKey: "test-key" }, "user msg", "system", "my-model", mockMessages);
+
+    expect(capturedModel).toBe("my-model");
   });
 
   test("throws when API returns no text content", async () => {
@@ -373,7 +396,7 @@ describe("callAnthropicApi", () => {
     };
 
     await expect(
-      callAnthropicApi({ apiKey: "test-key" }, "test prompt", "system", mockMessages)
+      callAnthropicApi({ apiKey: "test-key" }, "test prompt", "system", defaultAnthropicModel, mockMessages)
     ).rejects.toThrow("Anthropic API returned no text content");
   });
 });
@@ -458,7 +481,7 @@ describe("generateWithApi", () => {
       const notesPath = join(dir, "release_notes.md");
       const bodyPath = join(dir, "missing-body");
 
-      await generateWithApi({ apiKey: "fake-key" }, notesPath, bodyPath, dir);
+      await generateWithApi({ apiKey: "fake-key" }, notesPath, bodyPath, defaultAnthropicModel, dir);
 
       expect(await Bun.file(notesPath).exists()).toBe(false);
     }));
@@ -473,7 +496,14 @@ describe("generateWithApi", () => {
         create: async () => ({ content: [{ type: "text", text: "Summary" }] }),
       };
 
-      await generateWithApi({ apiKey: "test-key" }, notesPath, bodyPath, dir, mockMessages);
+      await generateWithApi(
+        { apiKey: "test-key" },
+        notesPath,
+        bodyPath,
+        defaultAnthropicModel,
+        dir,
+        mockMessages
+      );
 
       const notes = await Bun.file(notesPath).text();
       expect(notes).toBe("Summary");
@@ -497,6 +527,7 @@ describe("generateWithApi", () => {
         { apiKey: "test-key" },
         join(dir, "notes.md"),
         join(dir, "body.md"),
+        defaultAnthropicModel,
         dir,
         mockMessages,
       );
@@ -531,6 +562,20 @@ describe("resolveAnthropicClientOptions", () => {
     expect(() =>
       resolveAnthropicClientOptions({ ANTHROPIC_API_KEY: "k", ANTHROPIC_AUTH_TOKEN: "t" })
     ).toThrow("not both");
+  });
+});
+
+describe("resolveAnthropicModel", () => {
+  test("returns the default when ANTHROPIC_MODEL is unset", () => {
+    expect(resolveAnthropicModel({})).toBe(defaultAnthropicModel);
+  });
+
+  test("treats a blank ANTHROPIC_MODEL as unset", () => {
+    expect(resolveAnthropicModel({ ANTHROPIC_MODEL: "   " })).toBe(defaultAnthropicModel);
+  });
+
+  test("returns the trimmed override when set", () => {
+    expect(resolveAnthropicModel({ ANTHROPIC_MODEL: " claude-custom-1 " })).toBe("claude-custom-1");
   });
 });
 

--- a/.github/actions/release-action/src/generateReleaseNotes.ts
+++ b/.github/actions/release-action/src/generateReleaseNotes.ts
@@ -17,8 +17,8 @@ import Anthropic from "@anthropic-ai/sdk";
 import { assertExclusiveAnthropicAuth } from "@code-assistants/actions-core/anthropicAuth";
 
 import {
-  anthropicModel,
   buildUserMessage,
+  defaultAnthropicModel,
   filterChangelogForAi,
   maxOutputTokens,
   readServiceContext,
@@ -72,11 +72,26 @@ export function resolveAnthropicClientOptions(
 }
 
 /**
+ * Resolve the Anthropic model from the environment, falling back to the default.
+ *
+ * GitHub renders an unset optional action input as `""`, so a blank
+ * `ANTHROPIC_MODEL` is treated as unset and the built-in
+ * {@link defaultAnthropicModel} applies — keeping the default in one place.
+ *
+ * @param env - Source environment, typically `process.env`.
+ * @returns The configured model id, or the default when unset/blank.
+ */
+export function resolveAnthropicModel(env: Record<string, string | undefined>): string {
+  return env.ANTHROPIC_MODEL?.trim() || defaultAnthropicModel;
+}
+
+/**
  * Call the Anthropic Messages API to generate release notes.
  *
  * @param clientOptions - Resolved Anthropic client auth/host options
  * @param userMessage - User message with changelog and context
  * @param system - System prompt with stable instructions
+ * @param model - Anthropic model id to call
  * @param messages - Optional messages client (for testing)
  * @returns Generated release notes text
  * @throws On API error or timeout
@@ -85,12 +100,13 @@ export async function callAnthropicApi(
   clientOptions: AnthropicClientOptions,
   userMessage: string,
   system: string,
+  model: string,
   messages?: AnthropicMessages
 ): Promise<string> {
   const client = messages ?? new Anthropic({ ...clientOptions, timeout: 120_000 }).messages;
 
   const message = await client.create({
-    model: anthropicModel,
+    model,
     max_tokens: maxOutputTokens,
     system,
     messages: [{ role: "user", content: userMessage }],
@@ -146,6 +162,7 @@ export async function generateWithApi(
   clientOptions: AnthropicClientOptions,
   notesPath: string,
   bodyPath: string,
+  model: string,
   cwd = process.cwd(),
   messages?: AnthropicMessages,
 ): Promise<void> {
@@ -166,7 +183,7 @@ export async function generateWithApi(
 
     const filtered = filterChangelogForAi(changelog);
     const userMessage = buildUserMessage(filtered, serviceContext, tickets, prDescriptions);
-    const notes = await callAnthropicApi(clientOptions, userMessage, systemPrompt, messages);
+    const notes = await callAnthropicApi(clientOptions, userMessage, systemPrompt, model, messages);
 
     await Bun.write(notesPath, notes, { createPath: true });
     console.log("Release notes generated");
@@ -190,6 +207,7 @@ export async function runReleaseNotes(
   messages?: AnthropicMessages,
 ): Promise<void> {
   const clientOptions = resolveAnthropicClientOptions(process.env);
+  const model = resolveAnthropicModel(process.env);
   // GitHub renders an unset optional action input as ""; strip a blank host/token so
   // the SDK's own env fallback cannot read it as a configured (blank) host.
   if (!process.env.ANTHROPIC_BASE_URL?.trim()) delete process.env.ANTHROPIC_BASE_URL;
@@ -198,7 +216,7 @@ export async function runReleaseNotes(
   const bodyPath = join(cwd, ".release_bot/body");
 
   if (clientOptions.apiKey || clientOptions.authToken) {
-    await generateWithApi(clientOptions, notesPath, bodyPath, cwd, messages);
+    await generateWithApi(clientOptions, notesPath, bodyPath, model, cwd, messages);
   }
 
   await verifyReleaseNotes(notesPath, bodyPath);

--- a/.github/actions/release-action/src/releaseNotesPrompt.ts
+++ b/.github/actions/release-action/src/releaseNotesPrompt.ts
@@ -17,7 +17,7 @@
  *   filterChangelogForAi,
  *   readServiceContext,
  *   buildUserMessage,
- *   anthropicModel,
+ *   defaultAnthropicModel,
  * } from "./releaseNotesPrompt.ts";
  *
  * const filtered = filterChangelogForAi(changelog);
@@ -29,8 +29,8 @@ import { join } from "node:path";
 
 import { Glob } from "bun";
 
-/** Anthropic model used for release notes generation */
-export const anthropicModel = "claude-opus-4-20250514";
+/** Default Anthropic model for release notes generation, used when the `model` action input (env `ANTHROPIC_MODEL`) is unset. */
+export const defaultAnthropicModel = "claude-sonnet-4-6";
 
 /** Maximum output tokens for the API response */
 export const maxOutputTokens = 4096;


### PR DESCRIPTION
The release action's AI release-note generation was failing because the Anthropic model id was hardcoded to the now-deprecated claude-opus-4-20250514, which the API rejects with a 404. The step is continue-on-error, so every release silently dropped its AI summary and shipped the raw changelog. This switches the built-in default to the current Sonnet and lets the model be set via a new action input, so future model migrations need no code change.

- Replace the hardcoded model constant with defaultAnthropicModel set to claude-sonnet-4-6
- Add resolveAnthropicModel, which reads ANTHROPIC_MODEL and falls back to the default when unset or blank
- Thread the resolved model through runReleaseNotes, generateWithApi, and callAnthropicApi
- Add an optional model input on the action, wired as ANTHROPIC_MODEL into both the standalone and monorepo release-notes steps

---

**Release notes:**

- Release notes are generated again using a current model (claude-sonnet-4-6) instead of failing on a deprecated one
- The release action now accepts a model input to override the model without a code change

---

**Issues:**

Closes #369