### PR TITLE
MAINTENANCE: Make /autopilot:run skip the plan-approval gate

### DIFF
--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -34,7 +34,7 @@ allowed-tools:
 
 Plan, implement, commit, create PR, and monitor until approved. Extended version of `/autopilot:plan` that automates post-implementation steps.
 
-**Difference from `/autopilot:plan`:** After the user confirms the plan and implementation is complete, autopilot automatically commits, creates a PR, and monitors for review approval — without asking the user for confirmation at each step.
+**Difference from `/autopilot:plan`:** invoking `/autopilot:run` authorizes the entire flow up front — there is **no plan-approval gate**. Autopilot plans, implements, commits, creates a PR, and monitors for review approval, without ever pausing for plan confirmation or per-step approval. (`/autopilot:plan`, by contrast, has two gates: it stops to get the plan approved, then asks again before creating a PR.)
 
 ## Input
 
@@ -286,7 +286,7 @@ Tool parameters:
 
 ## Phase 2: Embed Branch Creation + Autopilot Post-Implementation
 
-**BEFORE calling ExitPlanMode**, embed branch creation and autopilot post-implementation into the plan file.
+Embed branch creation and autopilot post-implementation into the plan file, then proceed directly to implementing it. **Do NOT call `ExitPlanMode`, and do NOT pause for plan approval** — invoking `/autopilot:run` is the approval. Never tell the user "after you approve I'll implement"; that is `/autopilot:plan` behavior, not run's.
 
 ### Pre-Implementation (Branch Creation)
 
@@ -418,6 +418,16 @@ Status: <approved/merged>
 ```
 
 When you write the plan file, apply the reference-formatting rules inlined at the end of this skill (the **Reference formatting & readability** block below, RFC-0001 v3) to every reference it contains — link files, docs, skills, agents, and sections, and never leave a reference as bare text.
+
+## Phase 3: Implement and Proceed
+
+Once the plan file is written (with `## Pre-Implementation` and `## Post-Implementation (Autopilot)` embedded), proceed straight through with no approval gate:
+
+1. Run the `## Pre-Implementation` branch creation.
+2. Implement every step in the plan, verifying each as you go.
+3. Execute the `## Post-Implementation (Autopilot)` chain — commit → push → PR → monitor — without prompting.
+
+The only user prompts in the entire run are the branch-type pick for plain-description inputs ([Phase 2](#phase-2-embed-branch-creation--autopilot-post-implementation)) and review-feedback handling during PR monitoring. There is no plan-approval step — do not call `ExitPlanMode` and do not ask the user to confirm the plan before implementing.
 
 <!-- ref-format:start -->
 

--- a/docs/05-plan-run-skills.md
+++ b/docs/05-plan-run-skills.md
@@ -139,7 +139,7 @@ If the stack cannot be detected, the skill asks the user via `AskUserQuestion`. 
 
 ## Phase 2 — Embed branch creation
 
-Before handing the plan to the user, the skill embeds the branch step so it runs first after approval. The exact block depends on the input type and current branch/worktree state:
+The skill embeds the branch step into the plan file so it runs first, before any code changes — in `plan` this is after the user approves the plan; in `run` it runs straight away (see [How run differs](#how-run-differs-automated-post-implementation)). The exact block depends on the input type and current branch/worktree state:
 
 - **GitHub issue** → invoke `Skill(autopilot:branch-create)` with the issue number; it produces an `issue-<number>-<slug>` branch so the PR can `Closes #<number>`.
 - **Code-scanning alert** → invoke `Skill(autopilot:branch-create)` with `--security "<slug>"`; it produces a `security-<slug>` branch (no issue number, no `Closes #`).
@@ -208,7 +208,7 @@ Three sub-agents isolate work from the parent's context. Each returns a single s
 
 ## How run differs: automated post-implementation
 
-`run` shares Phases 0–2 and the pipeline with `plan`, but **replaces** the plan's "what's next?" prompt with an automated chain that proceeds without pausing. The user has pre-authorized the recommended choices, so each sub-skill takes its default path.
+`run` shares Phases 0–2 and the pipeline with `plan`, but never stops for plan approval — invoking `/autopilot:run` is itself the authorization, so there is **no plan-approval gate**; run implements the moment the plan file is written. It then **replaces** the plan's "what's next?" prompt with an automated chain that proceeds without pausing. The user has pre-authorized the recommended choices, so each sub-skill takes its default path.
 
 ```text
  ┌────────────┐   ┌──────────────┐   ┌──────────────┐   ┌───────────────┐


### PR DESCRIPTION
Fixes vestigial planning-skill instructions that made `/autopilot:run` imply a plan-approval gate it never had. Invoking the command is now treated as the authorization, so run proceeds straight through to implementation.

- Removed the `ExitPlanMode` reference and the "user confirms the plan" line from [run/SKILL.md](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/run/SKILL.md)
- Added a Phase 3 (Implement and Proceed) step: write the plan file, then implement and run the autonomous commit -> PR -> monitor chain without prompting
- Updated [docs/05-plan-run-skills.md](https://github.com/awinogradov/code-assistants/blob/main/docs/05-plan-run-skills.md) to state run has no plan-approval gate (invoke is the authorization)

---

**Release notes:**

- `/autopilot:run` no longer pauses for plan approval — invoking the command authorizes the full plan, implement, commit, PR, and monitor flow to run without further prompts