### PR TITLE
Support multiple Linear teams in one repository

### DIFF
--- a/.github/actions/agents-rules-sync/README.md
+++ b/.github/actions/agents-rules-sync/README.md
@@ -107,6 +107,11 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 - If `package.json` is missing, malformed, or lacks `agents.rules` (or its value is
   unrecognized), the action fails with a link to `docs/02-agents-field.md` and the list of
   accepted values.
+- Also validates the optional `agents.trackers` array (see
+  [Linear tracker support](../../../docs/11-linear-tracker.md)): a `linear` entry missing
+  `team`, a key prefix that routes to more than one tracker, or a second `github` entry fails
+  the run with a docs-linked error. An absent array is treated as GitHub-only, so existing
+  consumers are unaffected.
 
 ## Flow
 

--- a/.github/actions/agents-rules-sync/agents-rules-sync.ts
+++ b/.github/actions/agents-rules-sync/agents-rules-sync.ts
@@ -14,6 +14,7 @@ import { fetchRawContent } from '@code-assistants/actions-core/fetchRawContent';
 
 import { buildSyncEntries } from './src/buildSyncEntries.ts';
 import { resolvePackageAgentsRules } from './src/resolvePackageAgentsRules.ts';
+import { resolvePackageAgentsTrackers } from './src/resolvePackageAgentsTrackers.ts';
 
 interface Env {
   token: string;
@@ -113,6 +114,7 @@ async function main(): Promise<void> {
   }
 
   const rules = resolvePackageAgentsRules(raw);
+  const trackers = resolvePackageAgentsTrackers(raw);
   const entries = buildSyncEntries({
     sourceRepo: env.sourceRepo,
     rules,
@@ -122,7 +124,12 @@ async function main(): Promise<void> {
 
   const filesYaml = stringifyYaml(entries);
 
+  const trackerSummary = trackers
+    .map((tracker) => (tracker.type === 'linear' ? `linear:${tracker.keys.join('/')}` : tracker.type))
+    .join(', ');
+
   core.info(`Resolved agents.rules=${rules}; syncing rules/${rules}.md → CLAUDE.md from ${env.sourceRepo}`);
+  core.info(`Validated agents.trackers: ${trackerSummary}`);
   if (env.agentsMd) {
     core.info('Also publishing AGENTS.md as a symlink to CLAUDE.md.');
   }

--- a/.github/actions/agents-rules-sync/src/resolvePackageAgentsTrackers.test.ts
+++ b/.github/actions/agents-rules-sync/src/resolvePackageAgentsTrackers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  resolvePackageAgentsTrackers,
+  trackersDocsUrl,
+} from './resolvePackageAgentsTrackers.ts';
+
+describe('resolvePackageAgentsTrackers', () => {
+  test('rejects empty input with docs link', () => {
+    expect(() => resolvePackageAgentsTrackers('')).toThrow(/11-linear-tracker\.md/);
+  });
+
+  test('rejects non-JSON input with docs link', () => {
+    expect(() => resolvePackageAgentsTrackers('not json')).toThrow(/not valid JSON/);
+    expect(() => resolvePackageAgentsTrackers('not json')).toThrow(trackersDocsUrl);
+  });
+
+  test('defaults to GitHub-only when `trackers` is absent', () => {
+    const raw = JSON.stringify({ name: 'demo', agents: { rules: 'Bun' } });
+    expect(resolvePackageAgentsTrackers(raw)).toEqual([{ type: 'github' }]);
+  });
+
+  test('defaults a single Linear entry `keys` to `[team]`', () => {
+    const raw = JSON.stringify({ agents: { trackers: [{ type: 'linear', team: 'FRTNS' }] } });
+    expect(resolvePackageAgentsTrackers(raw)).toEqual([
+      { type: 'linear', team: 'FRTNS', keys: ['FRTNS'] },
+    ]);
+  });
+
+  test('accepts two Linear teams side by side', () => {
+    const raw = JSON.stringify({
+      agents: {
+        trackers: [
+          { type: 'linear', team: 'FRTNS' },
+          { type: 'linear', team: 'ENG' },
+          { type: 'github' },
+        ],
+      },
+    });
+    expect(resolvePackageAgentsTrackers(raw)).toEqual([
+      { type: 'linear', team: 'FRTNS', keys: ['FRTNS'] },
+      { type: 'linear', team: 'ENG', keys: ['ENG'] },
+      { type: 'github' },
+    ]);
+  });
+
+  test('preserves explicit `keys` and routes multiple prefixes to one team', () => {
+    const raw = JSON.stringify({
+      agents: { trackers: [{ type: 'linear', team: 'ENG', keys: ['ENG', 'INF'], label: 'autopilot' }] },
+    });
+    expect(resolvePackageAgentsTrackers(raw)).toEqual([
+      { type: 'linear', team: 'ENG', keys: ['ENG', 'INF'], label: 'autopilot' },
+    ]);
+  });
+
+  test('rejects a Linear entry missing `team`, naming the path and docs link', () => {
+    const raw = JSON.stringify({ agents: { trackers: [{ type: 'linear' }] } });
+    expect(() => resolvePackageAgentsTrackers(raw)).toThrow(/agents\.trackers\.0\.team/);
+    expect(() => resolvePackageAgentsTrackers(raw)).toThrow(trackersDocsUrl);
+  });
+
+  test('rejects a key prefix that routes to two trackers, naming the key', () => {
+    const raw = JSON.stringify({
+      agents: {
+        trackers: [
+          { type: 'linear', team: 'FRTNS', keys: ['ENG', 'INF'] },
+          { type: 'linear', team: 'ENG' },
+        ],
+      },
+    });
+    expect(() => resolvePackageAgentsTrackers(raw)).toThrow(/"ENG"/);
+    expect(() => resolvePackageAgentsTrackers(raw)).toThrow(/more than one Linear tracker/);
+  });
+
+  test('rejects more than one `github` tracker', () => {
+    const raw = JSON.stringify({ agents: { trackers: [{ type: 'github' }, { type: 'github' }] } });
+    expect(() => resolvePackageAgentsTrackers(raw)).toThrow(/Only one `github` tracker/);
+  });
+
+  test('rejects an unknown tracker `type`', () => {
+    const raw = JSON.stringify({ agents: { trackers: [{ type: 'jira' }] } });
+    expect(() => resolvePackageAgentsTrackers(raw)).toThrow(/agents\.trackers/);
+  });
+
+  test('rejects a lowercase `team`', () => {
+    const raw = JSON.stringify({ agents: { trackers: [{ type: 'linear', team: 'frtns' }] } });
+    expect(() => resolvePackageAgentsTrackers(raw)).toThrow(/uppercase letters/);
+  });
+});

--- a/.github/actions/agents-rules-sync/src/resolvePackageAgentsTrackers.ts
+++ b/.github/actions/agents-rules-sync/src/resolvePackageAgentsTrackers.ts
@@ -1,0 +1,159 @@
+/**
+ * Validates a `package.json` body and extracts the normalized `agents.trackers` array.
+ *
+ * Trackers are optional: an absent array resolves to the GitHub-only default
+ * `[{ type: 'github' }]`, preserving today's behavior. A present-but-malformed
+ * array throws with a helpful, link-decorated message. Each `linear` entry is
+ * normalized so `keys` is always populated (defaulting to `[team]`), and the
+ * resolver rejects a `linear` entry missing `team`, a key prefix that would
+ * route to more than one Linear tracker, or a duplicate `github` entry.
+ *
+ * Several `linear` entries may coexist so multiple teams can share one repo,
+ * each routed to by its key prefix.
+ *
+ * @example
+ *   const trackers = resolvePackageAgentsTrackers(await readPackageJson());
+ *   // [{ type: 'linear', team: 'FRTNS', keys: ['FRTNS'] }, { type: 'github' }]
+ *
+ * @see https://github.com/awinogradov/code-assistants/blob/main/docs/11-linear-tracker.md
+ */
+
+import { z } from 'zod';
+
+export const trackersDocsUrl =
+  'https://github.com/awinogradov/code-assistants/blob/main/docs/11-linear-tracker.md';
+
+/** A Linear team key (and key prefix) — the `FRTNS` in `FRTNS-123`. */
+const teamKeyPattern = /^[A-Z]+$/;
+
+const linearTrackerSchema = z
+  .object({
+    type: z.literal('linear'),
+    team: z
+      .string()
+      .regex(teamKeyPattern, 'Linear `team` must be uppercase letters (e.g. "FRTNS").'),
+    keys: z
+      .array(
+        z
+          .string()
+          .regex(teamKeyPattern, 'Each Linear `keys` entry must be uppercase letters (e.g. "FRTNS").'),
+      )
+      .optional(),
+    label: z.string().optional(),
+  })
+  .passthrough();
+
+const githubTrackerSchema = z
+  .object({
+    type: z.literal('github'),
+  })
+  .passthrough();
+
+const trackerSchema = z.discriminatedUnion('type', [
+  linearTrackerSchema,
+  githubTrackerSchema,
+]);
+
+const trackersSchema = z
+  .array(trackerSchema)
+  .superRefine((trackers, ctx) => {
+    const keyOwners = new Map<string, number>();
+    let githubCount = 0;
+
+    for (const [index, tracker] of trackers.entries()) {
+      if (tracker.type === 'github') {
+        githubCount += 1;
+        if (githubCount > 1) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [index, 'type'],
+            message: 'Only one `github` tracker is allowed.',
+          });
+        }
+        continue;
+      }
+
+      const keys = tracker.keys ?? [tracker.team];
+      for (const key of keys) {
+        if (keyOwners.has(key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [index, 'keys'],
+            message: `Key prefix "${key}" routes to more than one Linear tracker; each key may belong to only one team.`,
+          });
+        } else {
+          keyOwners.set(key, index);
+        }
+      }
+    }
+  })
+  .transform((trackers) =>
+    trackers.map((tracker) =>
+      tracker.type === 'linear'
+        ? { ...tracker, keys: tracker.keys ?? [tracker.team] }
+        : tracker,
+    ),
+  );
+
+const packageJsonSchema = z
+  .object({
+    agents: z
+      .object({ trackers: z.unknown().optional() })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+/** A consuming repo's normalized `agents.trackers`: every `linear` entry has its `keys` populated (defaulting to `[team]`). */
+export type AgentsTrackers = z.infer<typeof trackersSchema>;
+
+/**
+ * Parse, validate, and normalize the `agents.trackers` array from a raw
+ * `package.json` string. Absent trackers resolve to `[{ type: 'github' }]`.
+ */
+export function resolvePackageAgentsTrackers(raw: string): AgentsTrackers {
+  const parsed = parseJsonOrThrow(raw);
+  const result = packageJsonSchema.safeParse(parsed);
+
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    throw new Error(`Invalid package.json at ${path}: ${issue.message}. ${addInstructions()}`);
+  }
+
+  const trackers = result.data.agents?.trackers;
+
+  if (trackers === undefined) {
+    return [{ type: 'github' }];
+  }
+
+  const trackersResult = trackersSchema.safeParse(trackers);
+
+  if (!trackersResult.success) {
+    const issue = trackersResult.error.issues[0];
+    const path =
+      issue.path.length > 0 ? `agents.trackers.${issue.path.join('.')}` : 'agents.trackers';
+    throw new Error(`Invalid ${path}: ${issue.message}. ${addInstructions()}`);
+  }
+
+  return trackersResult.data;
+}
+
+function parseJsonOrThrow(raw: string): unknown {
+  const trimmed = raw.trim();
+
+  if (trimmed === '') {
+    throw new Error(`package.json is empty. ${addInstructions()}`);
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`package.json is not valid JSON: ${message}. ${addInstructions()}`);
+  }
+}
+
+function addInstructions(): string {
+  return `Configure \`agents.trackers\` as an array of { type: "linear" | "github", ... } entries — a \`linear\` entry needs a \`team\`, and each key prefix may belong to only one team. See ${trackersDocsUrl}`;
+}

--- a/claude-plugins/autopilot/skills/issue:run/SKILL.md
+++ b/claude-plugins/autopilot/skills/issue:run/SKILL.md
@@ -81,13 +81,13 @@ Resolve the repository once and store it as `<repo>` (format `owner/name`):
 gh repo view --json nameWithOwner --jq .nameWithOwner
 ```
 
-Determine the provider: read `agents.trackers` from `package.json` (via the Read tool). When a `linear` tracker is configured, the provider is **Linear** (note its `team`); otherwise **GitHub** (the default).
+Determine the provider: read `agents.trackers` from `package.json` (via the Read tool). When at least one `linear` tracker is configured, the provider is **Linear** (note **every** configured `team`); otherwise **GitHub** (the default).
 
 If `$ARGUMENTS` already supplies an issue identifier (a GitHub number or a Linear id), skip directly to [Phase 3](#phase-3-hand-off-to-autopilot).
 
 ## Phase 1: Fetch Recent Open Issues
 
-**If the provider is Linear:** list the team's recent open issues via `mcp__plugin_autopilot_linear__list_issues` (open only, ordered by most-recently-updated; without `--all`, prefer unassigned when the tool exposes an assignee filter). Then mirror the GitHub empty-state handling:
+**If the provider is Linear:** first pick the team to browse. With exactly one `linear` tracker, use its `team` (no prompt). With two or more, ask via AskUserQuestion (single-select) — one option per team, `{ label: "<team>", description: "<comma-joined keys, or 'no keys'>" }` — and use the chosen `team`. Then list that team's recent open issues via `mcp__plugin_autopilot_linear__list_issues` (open only, ordered by most-recently-updated; without `--all`, prefer unassigned when the tool exposes an assignee filter). Then mirror the GitHub empty-state handling:
 
 - Non-empty — map each to a picker option `{ label: "<identifier> <title>", description: "<labels or 'no labels'>" }` and continue at [Phase 2](#phase-2-select-an-issue).
 - Empty with `--all` — there are genuinely no open issues to pick from; tell the user and stop (they can re-invoke as `/issue:run <id>`).

--- a/claude-plugins/autopilot/skills/linear:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/linear:create/SKILL.md
@@ -38,8 +38,8 @@ Expected form:
 ## Input resolution
 
 - **Title hint** — `$ARGUMENTS` → if empty, prompt once via AskUserQuestion: "What is this issue about?" with a free-form slot. Do not abort silently.
-- **Linear team** — read the `linear` entry of `agents.trackers` in the repo-root `package.json` (via the Read tool); use its `team`. REQUIRED. If no `linear` tracker is configured, stop and tell the user to file a GitHub issue with `/autopilot:issue-create` instead.
-- **Repo label** — the `linear` entry's optional `label`, pre-selected in [Phase 4](#phase-4-select-labels).
+- **Linear team** — collect every `linear` entry of `agents.trackers` in the repo-root `package.json` (via the Read tool) and resolve a single target `team` in [Phase 0](#phase-0-resolve-team-and-hint). REQUIRED. If no `linear` tracker is configured, stop and tell the user to file a GitHub issue with `/autopilot:issue-create` instead.
+- **Repo label** — the chosen `linear` entry's optional `label`, pre-selected in [Phase 4](#phase-4-select-labels).
 
 ## Completion Requirement
 
@@ -48,7 +48,10 @@ This workflow is not complete until [Phase 7](#phase-7-create-issue) calls `mcp_
 ## Phase 0: Resolve Team and Hint
 
 1. Parse `$ARGUMENTS` as an optional title hint; if empty, prompt once via AskUserQuestion.
-2. Read `package.json` and extract the `linear` entry from `agents.trackers`. If absent, stop: `This project is not Linear-tracked. Use /autopilot:issue-create for a GitHub issue.`
+2. Read `package.json` and collect **all** `linear` entries from `agents.trackers`, then resolve a single target `team`:
+   - **None** ⇒ stop: `This project is not Linear-tracked. Use /autopilot:issue-create for a GitHub issue.`
+   - **Exactly one** ⇒ use its `team` (and `label`) — no prompt.
+   - **Two or more** ⇒ ask the user which team to file on via AskUserQuestion (single-select): one option per `linear` entry, `{ label: "<team>", description: "<comma-joined keys, or 'no keys'>" }`. Bind the chosen entry's `team` and optional `label` for the rest of the wizard.
 
 ## Phase 1: Gather Context
 

--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -104,7 +104,7 @@ Detect the input type from the arguments. Match **top-to-bottom and stop at the 
 
 A **bare number stays a GitHub issue** — alerts require the alert URL or the explicit `alert#{n}` / `alert {n}` token, so there is zero collision with the issue-number rows.
 
-The detection rows are gated on the project's configured trackers — `agents.trackers` in `package.json`, an array of `{ type, ... }` entries (absent ⇒ a single `github` tracker, today's behavior). **Linear rows fire only when a `linear` tracker is configured**; the Linear ID is the uppercase `KEY-N` form (`^[A-Z]+-[0-9]+$`), and when that entry's `keys` are set, `KEY` must be one of them. **GitHub rows fire when a `github` tracker is configured** (the default). A project may configure both — e.g. `linear` for internal issues and `github` for external user feedback — and each argument routes by shape: `ENG-123` → Linear, `#42` / `123` / a `github.com` URL → GitHub. A Linear-shaped argument with no matching `linear` tracker matches none of the GitHub numeric rows and falls through to **Plain description**, so existing GitHub repos are unaffected.
+The detection rows are gated on the project's configured trackers — `agents.trackers` in `package.json`, an array of `{ type, ... }` entries (absent ⇒ a single `github` tracker, today's behavior). **Linear rows fire only when at least one `linear` tracker is configured**; the Linear ID is the uppercase `KEY-N` form (`^[A-Z]+-[0-9]+$`), and its `KEY` must match the **union of every** `linear` tracker's effective keys (each entry's `keys`, defaulting to `[team]`). Several `linear` teams may coexist — `FRTNS-3` routes to the `FRTNS` tracker and `ENG-12` to `ENG` — and the matched entry supplies the `team` passed to `resolve-issue-context`. **GitHub rows fire when a `github` tracker is configured** (the default). A project may configure both — e.g. `linear` for internal issues and `github` for external user feedback — and each argument routes by shape: `ENG-123` → Linear, `#42` / `123` / a `github.com` URL → GitHub. A Linear-shaped argument with no matching `linear` tracker matches none of the GitHub numeric rows and falls through to **Plain description**, so existing GitHub repos are unaffected.
 
 Launch context-gathering calls **in parallel**. The number of parallel calls depends on input type:
 
@@ -158,7 +158,7 @@ Agent 2 (search-codebase-todos):
 Agent 1 (resolve-issue-context):
   Use the Agent tool with:
   - `subagent_type`: "autopilot:resolve-issue-context"
-  - `prompt`: "Fetch issue context. Input type: linear-issue. Linear ID: [ENG-123]. Linear team: [from the matching linear entry in package.json agents.trackers]. Auto-assign current user: false."
+  - `prompt`: "Fetch issue context. Input type: linear-issue. Linear ID: [ENG-123]. Linear team: [the `team` of the `linear` entry in package.json agents.trackers whose keys matched the ID's KEY]. Auto-assign current user: false."
   - `description`: "Resolve issue context"
 ```
 

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -114,7 +114,7 @@ Detect the input type from the arguments. Match **top-to-bottom and stop at the 
 
 A **bare number stays a GitHub issue** — alerts require the alert URL or the explicit `alert#{n}` / `alert {n}` token, so there is zero collision with the issue-number rows.
 
-The detection rows are gated on the project's configured trackers — `agents.trackers` in `package.json`, an array of `{ type, ... }` entries (absent ⇒ a single `github` tracker, today's behavior). **Linear rows fire only when a `linear` tracker is configured**; the Linear ID is the uppercase `KEY-N` form (`^[A-Z]+-[0-9]+$`), and when that entry's `keys` are set, `KEY` must be one of them. **GitHub rows fire when a `github` tracker is configured** (the default). A project may configure both — e.g. `linear` for internal issues and `github` for external user feedback — and each argument routes by shape: `ENG-123` → Linear, `#42` / `123` / a `github.com` URL → GitHub. A Linear-shaped argument with no matching `linear` tracker matches none of the GitHub numeric rows and falls through to **Plain description**, so existing GitHub repos are unaffected.
+The detection rows are gated on the project's configured trackers — `agents.trackers` in `package.json`, an array of `{ type, ... }` entries (absent ⇒ a single `github` tracker, today's behavior). **Linear rows fire only when at least one `linear` tracker is configured**; the Linear ID is the uppercase `KEY-N` form (`^[A-Z]+-[0-9]+$`), and its `KEY` must match the **union of every** `linear` tracker's effective keys (each entry's `keys`, defaulting to `[team]`). Several `linear` teams may coexist — `FRTNS-3` routes to the `FRTNS` tracker and `ENG-12` to `ENG` — and the matched entry supplies the `team` passed to `resolve-issue-context`. **GitHub rows fire when a `github` tracker is configured** (the default). A project may configure both — e.g. `linear` for internal issues and `github` for external user feedback — and each argument routes by shape: `ENG-123` → Linear, `#42` / `123` / a `github.com` URL → GitHub. A Linear-shaped argument with no matching `linear` tracker matches none of the GitHub numeric rows and falls through to **Plain description**, so existing GitHub repos are unaffected.
 
 Launch context-gathering calls **in parallel**. The number of parallel calls depends on input type:
 
@@ -168,7 +168,7 @@ Agent 2 (search-codebase-todos):
 Agent 1 (resolve-issue-context):
   Use the Agent tool with:
   - `subagent_type`: "autopilot:resolve-issue-context"
-  - `prompt`: "Fetch issue context. Input type: linear-issue. Linear ID: [ENG-123]. Linear team: [from the matching linear entry in package.json agents.trackers]. Auto-assign current user: false."
+  - `prompt`: "Fetch issue context. Input type: linear-issue. Linear ID: [ENG-123]. Linear team: [the `team` of the `linear` entry in package.json agents.trackers whose keys matched the ID's KEY]. Auto-assign current user: false."
   - `description`: "Resolve issue context"
 ```
 

--- a/claude-plugins/autopilot/skills/todo-cleanup/SKILL.md
+++ b/claude-plugins/autopilot/skills/todo-cleanup/SKILL.md
@@ -34,7 +34,7 @@ No arguments are expected. Any supplied arguments are ignored.
 1. Read `package.json` from the repository root
 2. Extract `agents.language` field — determines file globs and comment syntax
 3. Extract `agents.rules` field — determines verification commands
-4. Extract `agents.trackers` — when a `linear` tracker is configured the provider is **Linear** (note its `team`); otherwise **GitHub**
+4. Extract `agents.trackers` — when at least one `linear` tracker is configured the provider is **Linear** (note **every** configured `team` and its `keys`); otherwise **GitHub**. Existing `TEAM-123` TODO ids resolve to their team automatically by key prefix, so checking their state needs no team prompt
 5. Determine the repository in `owner/repo` form from `gh repo view --json nameWithOwner --jq .nameWithOwner` (or `git remote get-url origin`)
 
 **Language-to-pattern mapping:**
@@ -131,11 +131,13 @@ For each stale TODO:
 
 ### 4b. Create GitHub issues for unlinked TODOs
 
-1. **Group related TODOs** when possible:
+1. **Resolve the destination team for new Linear tickets** (Linear provider only): with exactly one `linear` tracker, use its `team` (no prompt); with two or more, ask once via AskUserQuestion (single-select) which team new tickets go on — one option per team, `{ label: "<team>", description: "<comma-joined keys>" }` — and reuse the chosen `team` for every unlinked TODO below.
+
+2. **Group related TODOs** when possible:
    - TODOs in the same file within 10 lines of each other
    - Present grouping to user for confirmation if "Review individually" was selected
 
-2. **For each TODO or group of TODOs:**
+3. **For each TODO or group of TODOs:**
 
    a. Generate an issue title from the TODO description:
    - Single TODO: use the description directly, cleaned up and capitalized
@@ -148,7 +150,7 @@ For each stale TODO:
 
    c. Create the issue:
    - **GitHub:** `gh issue create --title "<title>" --body "<body>"`
-   - **Linear:** `mcp__plugin_autopilot_linear__save_issue` with `{ "title": "<title>", "team": "<team>", "description": "<body>" }` (the `team` from [Phase 1](#phase-1-read-repository-context))
+   - **Linear:** `mcp__plugin_autopilot_linear__save_issue` with `{ "title": "<title>", "team": "<team>", "description": "<body>" }` (the `team` resolved in step 1 above)
 
    d. Capture the created issue's URL (GitHub prints it on the last line; for Linear use the returned ticket URL).
 

--- a/docs/02-agents-field.md
+++ b/docs/02-agents-field.md
@@ -24,7 +24,7 @@ An object under the top-level key `agents` in a `package.json`:
 
 The field coexists with normal npm metadata. It is not consumed by npm, Bun, or any package manager — only by Autopilot skills.
 
-An optional `trackers` array (entries `{ type: "linear" | "github", ... }`; absent ⇒ a single `github` tracker) opts the project into one or more issue trackers — for example Linear for internal issues and GitHub for external feedback; see [Linear tracker support](./11-linear-tracker.md).
+An optional `trackers` array (entries `{ type: "linear" | "github", ... }`; absent ⇒ a single `github` tracker) opts the project into one or more issue trackers — for example Linear for internal issues and GitHub for external feedback, or several `linear` teams sharing one repo; see [Linear tracker support](./11-linear-tracker.md).
 
 ### Workspaces
 
@@ -75,14 +75,16 @@ Only consumed by `/todo-cleanup` today.
 
 ## Consumers
 
-The matrix below lists every skill that reads `agents`, the key(s) it reads, and what it does with the value. Line numbers point at the canonical detection block in each skill.
+The matrix below lists every skill that reads `agents`, the key(s) it reads, and what it does with the value. Line numbers point at the canonical detection block in each skill. `/plan` and `/run` additionally read `agents.trackers` to route a Linear `KEY-N` id to its team by key prefix — see [Linear tracker support](./11-linear-tracker.md#how-a-skill-resolves-the-provider). The `agents.trackers` array is validated by the [`agents-rules-sync`](../.github/actions/agents-rules-sync/README.md) action.
 
-| Skill           | Reads                              | Behavior                                                                                   | Source                                                                                     |
-| --------------- | ---------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| `/plan`         | `agents.rules`                     | Delegates to `Skill(autopilot:plan-bun)` or `Skill(autopilot:plan-nodejs-react)`           | `claude-plugins/autopilot/skills/plan/SKILL.md` (Phase 1: Detect Stack and Delegate)       |
-| `/run`          | `agents.rules`                     | Same delegation as `/plan`, plus embedded post-implementation autopilot                    | `claude-plugins/autopilot/skills/run/SKILL.md` (Phase 1: Detect Stack and Delegate)        |
-| `/pr:review`    | `agents.rules`                     | Tags the review with the stack identifier; falls back to `unknown` if missing              | `claude-plugins/autopilot/skills/pr:review/SKILL.md` (Phase 2.1: Detect Stack)             |
-| `/todo-cleanup` | `agents.language` + `agents.rules` | Picks file globs + comment syntax from `language`, picks verification command from `rules` | `claude-plugins/autopilot/skills/todo-cleanup/SKILL.md` (Phase 1: Read Repository Context) |
+| Skill            | Reads                                                  | Behavior                                                                                                                                       | Source                                                                                          |
+| ---------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `/plan`          | `agents.rules`                                         | Delegates to `Skill(autopilot:plan-bun)` or `Skill(autopilot:plan-nodejs-react)`                                                               | `claude-plugins/autopilot/skills/plan/SKILL.md` (Phase 1: Detect Stack and Delegate)            |
+| `/run`           | `agents.rules`                                         | Same delegation as `/plan`, plus embedded post-implementation autopilot                                                                        | `claude-plugins/autopilot/skills/run/SKILL.md` (Phase 1: Detect Stack and Delegate)             |
+| `/pr:review`     | `agents.rules`                                         | Tags the review with the stack identifier; falls back to `unknown` if missing                                                                  | `claude-plugins/autopilot/skills/pr:review/SKILL.md` (Phase 2.1: Detect Stack)                  |
+| `/todo-cleanup`  | `agents.language` + `agents.rules` + `agents.trackers` | Picks file globs + comment syntax from `language`, verification command from `rules`; routes new-TODO issues to GitHub or a chosen Linear team | `claude-plugins/autopilot/skills/todo-cleanup/SKILL.md` (Phase 1: Read Repository Context)      |
+| `/linear:create` | `agents.trackers`                                      | Files a Linear issue on the configured `team`; prompts to choose when 2+ `linear` trackers exist                                               | `claude-plugins/autopilot/skills/linear:create/SKILL.md` (Phase 0: Resolve Team and Hint)       |
+| `/issue:run`     | `agents.trackers`                                      | Resolves the provider and Linear team; prompts to choose the team when 2+ `linear` trackers exist                                              | `claude-plugins/autopilot/skills/issue:run/SKILL.md` (Phase 0: Resolve Repository and Provider) |
 
 ### Stack → planning skill (used by `/plan` and `/run`)
 

--- a/docs/11-linear-tracker.md
+++ b/docs/11-linear-tracker.md
@@ -32,11 +32,49 @@ When `trackers` is absent, autopilot behaves as if it were `[{ "type": "github" 
 | `keys`  | no                | ID prefixes that route to that Linear tracker; defaults to `[team]` |
 | `label` | no                | Label applied to issues autopilot creates on that Linear tracker    |
 
+Several `linear` entries may be listed so multiple teams can share one repo. Each issue id routes to its team by key prefix:
+
+```json
+{
+  "agents": {
+    "trackers": [
+      { "type": "linear", "team": "FRTNS", "keys": ["FRTNS"] },
+      { "type": "linear", "team": "ENG", "keys": ["ENG"] },
+      { "type": "github" }
+    ]
+  }
+}
+```
+
+The array is validated when the [`agents-rules-sync`](../.github/actions/agents-rules-sync/README.md) action syncs a repository: a `linear` entry missing `team`, a key prefix that routes to more than one tracker, or a second `github` entry fails the sync with a docs-linked error. Absent or single-tracker configs are unaffected.
+
 ## How a skill resolves the provider
 
 A skill reads `agents.trackers` from `package.json` (via the Read tool — no extra tooling) and routes each argument to the tracker whose shape it matches, so several trackers coexist.
 
 The [`plan`](../claude-plugins/autopilot/skills/plan/SKILL.md) and `run` skills add two input-detection rows — a `linear.app` URL and the uppercase `^[A-Z]+-[0-9]+$` ID (e.g. `ENG-123`) — placed after the code-scanning-alert row and before the bare-number row. The Linear rows are active only when a `linear` tracker is configured (and, when that entry's `keys` are set, only for those prefixes); the GitHub rows are active when a `github` tracker is configured (the default). With both configured, `ENG-123` routes to Linear while `#42`, a bare `123`, or a `github.com` URL routes to GitHub — internal and external trackers side by side. A Linear-shaped argument with no matching `linear` tracker collides with no GitHub numeric row and falls through to a plain task description, so existing GitHub repos are unaffected.
+
+When several `linear` trackers are configured, an incoming `KEY-N` id is matched against the **union of every** `linear` tracker's effective keys (an entry's `keys`, or `[team]` when `keys` is omitted), and the matched entry supplies the `team`. With `FRTNS` and `ENG` side by side, `FRTNS-12` routes to the FRTNS team and `ENG-3` to ENG, while a bare number or `github.com` URL still routes to GitHub:
+
+```text
+  FRTNS-12  ──▶ key FRTNS ──▶ linear FRTNS ─┐
+  ENG-3     ──▶ key ENG   ──▶ linear ENG   ─┼──▶ resolve-issue-context
+  #42 / 123 ──▶ number    ──▶ github       ─┘    → provider-agnostic JSON
+  add-cache ──▶ no match  ──▶ plain description (planned directly)
+```
+
+**Flow Legend:**
+
+- `FRTNS-12` — its `FRTNS` key matches the FRTNS tracker; resolved on team FRTNS.
+- `ENG-3` — its `ENG` key matches the ENG tracker; resolved on team ENG.
+- `#42` / a bare `123` / a `github.com` URL — numeric shape; resolved on GitHub.
+- `add-cache` (or a `KEY` matching no configured tracker) — falls through to a plain task description and is planned directly, with no issue lookup.
+
+The three tracker branches converge on the single [`resolve-issue-context`](#the-single-resolution-seam) seam, so everything downstream stays provider-agnostic regardless of which team an id belonged to.
+
+### Choosing a team on the write path
+
+Reading an issue never prompts — the id's key prefix already names the team. Creating or listing does, because the team is not given by an id: when two or more `linear` trackers are configured, [`linear:create`](../claude-plugins/autopilot/skills/linear:create/SKILL.md), [`issue:run`](../claude-plugins/autopilot/skills/issue:run/SKILL.md), and [`todo-cleanup`](../claude-plugins/autopilot/skills/todo-cleanup/SKILL.md) ask once via `AskUserQuestion` which team to file on or browse, then proceed against the chosen team. A single `linear` tracker auto-selects with no prompt, so existing one-team repos are unchanged.
 
 ## Access paths: MCP first, GraphQL fallback
 


### PR DESCRIPTION
Lets several Linear teams share one repository under `agents.trackers`: each issue routes to its team by key prefix, the write and list skills prompt to pick a team when more than one Linear tracker is configured, and the array is now validated.

- Add a `resolvePackageAgentsTrackers` Zod schema that normalizes each linear entry's keys to `[team]`, defaults an absent array to GitHub-only, and rejects a missing `team`, colliding key prefixes, or a duplicate `github` entry — wired into the `agents-rules-sync` action
- `linear:create`, `issue:run`, and `todo-cleanup` prompt for the team when 2+ linear trackers exist; a single team auto-selects
- `plan` and `run` match a `KEY-N` id against the union of every linear tracker's keys
- Document the multi-team config, key-union routing, and write-path team-pick in the trackers and agents-field docs

---

**Release notes:**

- `agents.trackers` now supports multiple Linear teams in one repo; issues route to their team by key prefix
- Creating or listing Linear issues prompts to pick the team when more than one Linear tracker is configured
- The `agents.trackers` array is validated, rejecting a missing team, colliding key prefixes, or a duplicate GitHub entry

---

**Issues:**

Closes #377