### PR TITLE
HOTFIX: Keep file-sync PR descriptions accurate across runs

### DIFF
--- a/.github/actions/files-sync/README.md
+++ b/.github/actions/files-sync/README.md
@@ -106,6 +106,7 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 - A single PR with all changed files is created (or reused if `branch` already has an open PR).
 - The PR link is surfaced on the run page as a `::notice` annotation (titled with the PR title) in addition to the step-summary link, so a scheduled sync run leads straight to its PR.
 - The head `branch` is force-updated on every run.
+- A reused PR's title and body are refreshed on every run, so the `**Updated files:**` list always reflects the current diff — not just the files that differed when the PR was first opened.
 - If no files differ between source and destination, no PR is created and the action exits cleanly.
 - A missing source path fails the run with `Source not found at <repo>:<path>`.
 - The destination path may not exist yet — it will be created in the PR.

--- a/.github/actions/files-sync/src/createSyncPullRequest.test.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.test.ts
@@ -9,6 +9,13 @@ import { createSyncPullRequest } from './createSyncPullRequest.ts';
 interface MockOverrides {
   listOpenPrs?: () => Promise<{ data: Array<{ number: number; html_url: string }> }>;
   createPr?: () => Promise<{ data: { number: number; html_url: string } }>;
+  updatePr?: (args: {
+    owner: string;
+    repo: string;
+    pull_number: number;
+    title: string;
+    body: string;
+  }) => Promise<{ data: unknown }>;
   createCommit?: (args: {
     author: BotIdentity;
     committer: BotIdentity;
@@ -21,6 +28,7 @@ function makeOctokit(overrides: MockOverrides = {}): Octokit {
     overrides.createPr ??
     (async () => ({ data: { number: 42, html_url: 'https://github.com/owner/repo/pull/42' } }));
   const createCommit = overrides.createCommit ?? (async () => ({ data: { sha: 'new-commit-sha' } }));
+  const updatePr = overrides.updatePr ?? (async () => ({ data: {} }));
 
   return {
     rest: {
@@ -36,6 +44,7 @@ function makeOctokit(overrides: MockOverrides = {}): Octokit {
       pulls: {
         list: listOpenPrs,
         create: createPr,
+        update: updatePr,
       },
     },
   } as unknown as Octokit;
@@ -62,6 +71,33 @@ describe('createSyncPullRequest', () => {
     const pr = await createSyncPullRequest({ octokit, ...baseArgs });
 
     expect(pr).toEqual({ number: 42, htmlUrl: 'https://github.com/owner/repo/pull/42' });
+  });
+
+  test('updates the existing PR title and body when an open PR is reused', async () => {
+    let captured: unknown;
+    const octokit = makeOctokit({
+      listOpenPrs: async () => ({
+        data: [{ number: 7, html_url: 'https://github.com/owner/repo/pull/7' }],
+      }),
+      updatePr: async (args) => {
+        captured = args;
+        return { data: {} };
+      },
+      createPr: async () => {
+        throw new Error('must not create a PR when reusing an open one');
+      },
+    });
+
+    const pr = await createSyncPullRequest({ octokit, ...baseArgs });
+
+    expect(pr).toEqual({ number: 7, htmlUrl: 'https://github.com/owner/repo/pull/7' });
+    expect(captured).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+      pull_number: 7,
+      title: 'Sync',
+      body: 'body',
+    });
   });
 
   test('authors and commits as the resolved bot identity', async () => {

--- a/.github/actions/files-sync/src/createSyncPullRequest.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.ts
@@ -173,6 +173,16 @@ async function upsertPullRequest({
   const open = existing.data[0];
 
   if (open !== undefined) {
+    // The branch is force-updated every run, but a reused PR keeps its original
+    // title/body — refresh them so the `Updated files` list matches the current diff.
+    await octokit.rest.pulls.update({
+      owner,
+      repo,
+      pull_number: open.number,
+      title,
+      body,
+    });
+
     return { number: open.number, htmlUrl: open.html_url };
   }
 


### PR DESCRIPTION
The `files-sync` action reuses one open PR across runs but never refreshed its title or body, so the `Updated files` list went stale whenever a later run changed a different set of files than the run that first opened the PR. The reused PR's title and body are now updated on every run to match the current diff.

- Call `pulls.update` with the freshly composed title and body whenever an open PR is reused, before returning it
- Keeps the PR metadata consistent with the branch, which is already force-updated every run
- Add a reuse-path test and document the behavior in the `files-sync` README

Found while analyzing repeatedly-failing upstream-sync PRs in a consumer repo; the unrelated BDD flake that actually red-failed those runs is tracked separately in awinogradov/symbiot#236.

---

**Release notes:**

- Reused file-sync pull requests now refresh their title and `Updated files` list on every run, so the description always matches the current diff
