### PR TITLE
Post drafted review replies without asking for approval

### DIFF
--- a/claude-plugins/autopilot/skills/pr:resolve/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:resolve/SKILL.md
@@ -159,7 +159,7 @@ Tool parameters:
 - `header`: "Review"
 - `options`: [
   { label: "Address all", description: "Fix blockers, suggestions, and nitpicks; reply to questions" },
-  { label: "Review individually", description: "Approve each comment action one by one" },
+  { label: "Review individually", description: "Approve each fix one by one (replies always post)" },
   { label: "Cancel", description: "Exit without changes" }
   ]
 - `multiSelect`: false
@@ -261,17 +261,7 @@ Explained (N):
   <file>:<line> - "[reply text]"
 ```
 
-Present using AskUserQuestion:
-
-Tool parameters:
-
-- `question`: The summary text above (plain text, no markdown)
-- `header`: "Replies"
-- `options`: [
-  { label: "Post all replies", description: "Reply to all comment threads" },
-  { label: "Review individually", description: "Approve each reply one by one" }
-  ]
-- `multiSelect`: false
+Output the summary above as plain text, then post every drafted reply immediately — do not ask for approval. Before posting, resolve your login with `gh api user --jq .login` and fetch the existing comments — inline threads via `gh api repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments`, top-level via `gh api repos/<OWNER>/<REPO>/issues/<PR_NUMBER>/comments`; skip an inline thread whose latest comment (matching by `in_reply_to_id`) is already yours, and skip a top-level reply whose body you already posted — this keeps re-runs idempotent. If a post fails, continue with the remaining replies and list the failures under `Failed` in the [Phase 6](#phase-6-update-pr-and-summary) summary.
 
 Post replies using the GitHub API:
 
@@ -286,20 +276,6 @@ For top-level review comments:
 ```bash
 gh api repos/<OWNER>/<REPO>/issues/<PR_NUMBER>/comments -f body="<reply>"
 ```
-
-If "Review individually", present each reply with AskUserQuestion before posting:
-
-Tool parameters:
-
-- `question`: "<file>:<line>\n\nReviewer said: <comment text>\n\nDrafted reply: <reply text>"
-- `header`: "Reply"
-- `options`: [
-  { label: "Post reply", description: "Send this reply" },
-  { label: "Edit", description: "Let me rephrase this" }
-  ]
-- `multiSelect`: false
-
-If "Edit" selected, ask for the user's preferred reply text and use that instead.
 
 ---
 
@@ -325,6 +301,9 @@ Replied (N comments):
 Declined (N comments):
   <file>:<line> - <reply summary>
 
+Failed (N replies):
+  <file>:<line> - <post error>
+
 Commit: <commit message>
 Pushed to origin/<branch>
 PR #<N> updated: <url>
@@ -337,6 +316,9 @@ Resolve Review Complete
 
 Replied (N comments):
   <file>:<line> - <reply summary>
+
+Failed (N replies):
+  <file>:<line> - <post error>
 
 No code changes needed.
 PR #<N>: <url>

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -414,9 +414,7 @@ Call TaskUpdate to set task 9 ("Monitor PR") to `status: "in_progress"`. Invoke 
 - If changes requested: invoke pr:resolve interactively (user IS involved for review feedback)
 - Wait for approval or merge
 
-**Autopilot override for pr:resolve:** When pr:monitor invokes pr:resolve and the skill presents options via AskUserQuestion:
-- For review action (Phase 3): auto-select "Address all"
-- For replies (Phase 6): auto-select "Post all replies"
+**Autopilot override for pr:resolve:** When pr:monitor invokes pr:resolve and the skill presents the review-action gate via AskUserQuestion, auto-select "Address all". Replies post without prompting.
 
 ### Completion
 

--- a/docs/05-plan-run-skills.md
+++ b/docs/05-plan-run-skills.md
@@ -227,7 +227,7 @@ Three sub-agents isolate work from the parent's context. Each returns a single s
 
 - **Auto-Commit** — `Skill(autopilot:commits-create)` (auto-selects a single commit and confirms), then `git push`.
 - **Auto-Create PR** — `Skill(autopilot:pr-create)` (auto-selects "Create PR"), then a format check on the result.
-- **Monitor** — `Skill(autopilot:pr-monitor)` polls CI and review status; on changes-requested it runs `pr-resolve` (auto "Address all" / "Post all replies") and loops until approval.
+- **Monitor** — `Skill(autopilot:pr-monitor)` polls CI and review status; on changes-requested it runs `pr-resolve` (auto "Address all"; replies post without prompting) and loops until approval.
 - Direct `gh pr create` / `git commit` are forbidden in autopilot mode — everything routes through the sub-skills so format stays correct.
 
 ## Where to look in the code


### PR DESCRIPTION
The pr:resolve skill drafted replies to PR review threads and then stopped at an approval prompt before posting them. This change removes that gate: after printing the drafted-replies summary, replies post to the review threads immediately, in both interactive and autopilot runs.

- Removed the "Post all replies" / "Review individually" chooser and the per-reply "Post reply"/"Edit" prompt from [Phase 5 of the pr:resolve skill](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/pr%3Aresolve/SKILL.md#phase-5-reply-to-review-threads)
- Added unattended-posting safeguards: threads already answered by the current user are skipped, and a failed post no longer blocks the remaining replies — failures are listed in the Phase 6 summary
- Collapsed the [run skill](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/run/SKILL.md) autopilot override to the single remaining "Address all" auto-select and updated the monitor legend in [docs/05-plan-run-skills.md](https://github.com/awinogradov/code-assistants/blob/main/docs/05-plan-run-skills.md)

---

**Release notes:**

- pr:resolve posts drafted review replies immediately after showing the summary — no approval prompt
- Re-running pr:resolve skips threads it already answered and continues past failed reply posts

---

**Issues:**

Closes #397