### PR TITLE
Require agents to follow CONTRIBUTING.md git conventions in stack rules

### DIFF
--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -363,6 +363,13 @@ Choose ONE backend based on the project's needs. Do not mix.
 - 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 - 👤 No raw `gh issue create` — use `Skill(autopilot:issue:create)`
 
+## 15. Git Workflow
+
+- 👤 **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
+- 👤 Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
+- 👤 The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- 👤 Never bypass validation hooks with `--no-verify` — fix the violation instead
+
 ## 16. AI Assistant Workflow
 
 ### 16.1 Claude Code

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -236,6 +236,13 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 - 👤 No raw `gh issue create` — use `Skill(autopilot:issue:create)`
 
+## 15. Git Workflow
+
+- 👤 **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
+- 👤 Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
+- 👤 The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- 👤 Never bypass validation hooks with `--no-verify` — fix the violation instead
+
 ## 16. AI Assistant Workflow
 
 ### 16.1 Claude Code

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -354,6 +354,13 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 - 👤 No raw `gh issue create` — use `Skill(autopilot:issue:create)`
 
+## 15. Git Workflow
+
+- 👤 **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
+- 👤 Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
+- 👤 The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- 👤 Never bypass validation hooks with `--no-verify` — fix the violation instead
+
 ## 16. AI Assistant Workflow
 
 ### 16.1 Claude Code

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -351,6 +351,13 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 - 👤 No raw `gh issue create` — use `Skill(autopilot:issue:create)`
 
+## 15. Git Workflow
+
+- 👤 **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
+- 👤 Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
+- 👤 The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- 👤 Never bypass validation hooks with `--no-verify` — fix the violation instead
+
 ## 16. AI Assistant Workflow
 
 ### 16.1 Claude Code

--- a/scripts/validate-plugins.ts
+++ b/scripts/validate-plugins.ts
@@ -100,23 +100,49 @@ async function validateTarget(t: Target): Promise<string | null> {
   }
 }
 
+const rulesSectionHeading = "## 15. Git Workflow";
+
+/**
+ * The rules/<stack>.md files carry a duplicated Git Workflow section that ships
+ * downstream as each consumer's CLAUDE.md. Verify the section exists in every
+ * file and is byte-identical across them so the copies cannot drift.
+ */
+async function validateRulesSectionSync(): Promise<string | null> {
+  const sections = new Map<string, string>();
+  for await (const path of new Glob("rules/*.md").scan(".")) {
+    const raw = await Bun.file(path).text();
+    const start = raw.indexOf(`\n${rulesSectionHeading}\n`);
+    if (start === -1) return `missing "${rulesSectionHeading}" section in ${path}`;
+    const end = raw.indexOf("\n## ", start + 1);
+    sections.set(path, raw.slice(start + 1, end === -1 ? raw.length : end + 1));
+  }
+  if (sections.size === 0) return "no rules/*.md files found";
+  const [[firstPath, firstSection], ...rest] = [...sections.entries()];
+  const mismatch = rest.find(([, section]) => section !== firstSection);
+  if (mismatch) {
+    return `"${rulesSectionHeading}" section in ${mismatch[0]} differs from ${firstPath}`;
+  }
+  return null;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   let targets: Target[] = [];
+  let checkRules = true;
 
   const filesIdx = args.indexOf("--files");
   if (filesIdx !== -1) {
-    const paths = args.slice(filesIdx + 1);
-    for (const p of paths) {
-      const rel = p.startsWith("./") ? p.slice(2) : p;
+    const paths = args.slice(filesIdx + 1).map((p) => (p.startsWith("./") ? p.slice(2) : p));
+    for (const rel of paths) {
       const t = classify(rel);
       if (t) targets.push(t);
     }
+    checkRules = paths.some((p) => /^rules\/[^/]+\.md$/.test(p));
   } else {
     targets = await discoverAll();
   }
 
-  if (targets.length === 0) {
+  if (targets.length === 0 && !checkRules) {
     console.log("validate-plugins: no plugin files to check");
     return;
   }
@@ -132,11 +158,21 @@ async function main() {
     }
   }
 
+  if (checkRules) {
+    const err = await validateRulesSectionSync();
+    if (err) {
+      failed += 1;
+      console.error(`✖ rules/*.md\n    ${err}`);
+    } else {
+      console.log("✔ rules/*.md git workflow section in sync");
+    }
+  }
+
   if (failed > 0) {
     console.error(`\nvalidate-plugins: ${failed} file(s) failed validation`);
     process.exit(1);
   }
-  console.log(`\nvalidate-plugins: ${targets.length} file(s) OK`);
+  console.log(`\nvalidate-plugins: ${targets.length + (checkRules ? 1 : 0)} check(s) OK`);
 }
 
 main().catch((e) => {


### PR DESCRIPTION
Agents intermittently ignored [CONTRIBUTING.md](https://github.com/awinogradov/code-assistants/blob/main/CONTRIBUTING.md) conventions when creating branches, commits, and PRs whenever the autopilot skills were bypassed or unavailable. The stack rule files now bind those conventions directly in the instructions agents load as CLAUDE.md.

- Added a `## 15. Git Workflow` section to all four `rules/*.md` files, byte-identical, in the vacant slot between §14 Anti-Patterns and §16 AI Assistant Workflow — CONTRIBUTING.md is the binding standard, referenced per operation by section name with no restated rules, so CONTRIBUTING.md can evolve without the rule files going stale
- Bridged to §16.1: invoking the `Skill(autopilot:*)` commands satisfies the section
- Added a sync guard to [validate-plugins.ts](https://github.com/awinogradov/code-assistants/blob/main/scripts/validate-plugins.ts) that fails `bun run validate` when the section is missing from any rules file or differs between any two

---

**Issues:**

Closes #399