### PR TITLE
Enforce repository rfc/ and docs/ standards in AI code review

### DIFF
--- a/.github/actions/code-review-action/README.md
+++ b/.github/actions/code-review-action/README.md
@@ -101,6 +101,12 @@ The `pr:review` skill carries the full review rubric (all `CHECK-*` rules) inlin
 
 To run a different repo's skills instead — e.g. a consumer's own `pr:review` — point `review_prompt` / `react_prompt` at them and install the plugin that provides them (see below).
 
+## Repository standards (rfc/ and docs/)
+
+When the reviewed repository carries an `rfc/` folder (versioned standards with `status` frontmatter) or a `docs/` folder, the review enforces those standards on the diff — no input or config needed; the folders are the opt-in. Severity follows source stability: an Accepted RFC violation blocks (`CHECK-RFC-001`), a Draft RFC conflict and a `docs/` convention contradiction are non-blocking suggestions (`CHECK-RFC-002`, `CHECK-DOC-005`), and two hygiene checks protect the `rfc/` contract itself (`CHECK-RFC-003/004`).
+
+See [Code review repository standards](../../../docs/12-code-review-repository-standards.md) for the discovery, selection, and citation contract.
+
 ## Installing plugins
 
 `marketplaces` and `plugins` install Claude Code plugins before the run, so `review_prompt` / `react_prompt` can target a skill the bundled `autopilot` plugin doesn't provide. Each `marketplaces` line is `name=source` and each `plugins` line is `plugin@marketplace`; the action registers the marketplaces (`extraKnownMarketplaces`) and installs the plugins (`enabledPlugins`), then Claude Code's headless install resolves their slash commands.

--- a/README.md
+++ b/README.md
@@ -22,19 +22,20 @@ See the [plugin README](./claude-plugins/autopilot/README.md#installation) for s
 
 The `docs/` guides are numbered chapters in reading order — start at chapter 1 and read on, or jump to the chapter you need.
 
-| #   | Document                                                                        | What it covers                                                                                      |
-| --- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| 1   | [Workspace structure](./docs/01-workspace-structure.md)                         | where new actions, packages, and apps go, and how they wire into Turbo                              |
-| 2   | [`agents` field spec](./docs/02-agents-field.md)                                | how skills detect a repository's tech stack from `package.json`                                     |
-| 3   | [Review run-summary footer](./docs/03-code-review-run-summary.md)               | how `code-review-action` surfaces per-run metrics in a footer, plus the rare rotating review tip    |
-| 4   | [Inline suggestions and AI-agent prompts](./docs/04-code-review-suggestions.md) | one-click GitHub suggestion blocks and a "Prompt for AI agents" block on each inline finding        |
-| 5   | [Plan and run skills](./docs/05-plan-run-skills.md)                             | how the `plan` and `run` skills go from task to reviewed plan to merged PR, with ASCII diagrams     |
-| 6   | [`release` field spec](./docs/06-release-field.md)                              | how `release-action` picks the right artifacts for npm packages, GitHub Actions, and plugins        |
-| 7   | [Release auto-merge flow](./docs/07-release-automerge.md)                       | the event-driven action that merges approved, all-green release PRs and propagates downstream       |
-| 8   | [Upstream sync](./docs/08-upstream-sync.md)                                     | the one-action `upstream-sync` aggregator and the thin `upstream.yml` consumers run, per-kind       |
-| 9   | [Committed Repomix pack](./docs/09-repomix-pack.md)                             | the `.repomix/pack.xml` snapshot, its merge-triggered refresh, and the snapshot-first contract      |
-| 10  | [The `pdf:create` skill](./docs/10-pdf-create-skill.md)                         | the portable `@react-pdf/renderer` pipeline that renders a themed PDF, decoupled from the workspace |
-| 11  | [Linear tracker support](./docs/11-linear-tracker.md)                           | how `agents.trackers` opts a project into Linear and other issue trackers behind one JSON contract  |
+| #   | Document                                                                          | What it covers                                                                                      |
+| --- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| 1   | [Workspace structure](./docs/01-workspace-structure.md)                           | where new actions, packages, and apps go, and how they wire into Turbo                              |
+| 2   | [`agents` field spec](./docs/02-agents-field.md)                                  | how skills detect a repository's tech stack from `package.json`                                     |
+| 3   | [Review run-summary footer](./docs/03-code-review-run-summary.md)                 | how `code-review-action` surfaces per-run metrics in a footer, plus the rare rotating review tip    |
+| 4   | [Inline suggestions and AI-agent prompts](./docs/04-code-review-suggestions.md)   | one-click GitHub suggestion blocks and a "Prompt for AI agents" block on each inline finding        |
+| 5   | [Plan and run skills](./docs/05-plan-run-skills.md)                               | how the `plan` and `run` skills go from task to reviewed plan to merged PR, with ASCII diagrams     |
+| 6   | [`release` field spec](./docs/06-release-field.md)                                | how `release-action` picks the right artifacts for npm packages, GitHub Actions, and plugins        |
+| 7   | [Release auto-merge flow](./docs/07-release-automerge.md)                         | the event-driven action that merges approved, all-green release PRs and propagates downstream       |
+| 8   | [Upstream sync](./docs/08-upstream-sync.md)                                       | the one-action `upstream-sync` aggregator and the thin `upstream.yml` consumers run, per-kind       |
+| 9   | [Committed Repomix pack](./docs/09-repomix-pack.md)                               | the `.repomix/pack.xml` snapshot, its merge-triggered refresh, and the snapshot-first contract      |
+| 10  | [The `pdf:create` skill](./docs/10-pdf-create-skill.md)                           | the portable `@react-pdf/renderer` pipeline that renders a themed PDF, decoupled from the workspace |
+| 11  | [Linear tracker support](./docs/11-linear-tracker.md)                             | how `agents.trackers` opts a project into Linear and other issue trackers behind one JSON contract  |
+| 12  | [Code review repository standards](./docs/12-code-review-repository-standards.md) | how the review enforces a consumer repo's `rfc/` and `docs/` standards with status-based severity   |
 
 **Standards.**
 

--- a/claude-plugins/autopilot/skills/pr:review/SKILL.md
+++ b/claude-plugins/autopilot/skills/pr:review/SKILL.md
@@ -50,7 +50,7 @@ You review the whole PR yourself in a single pass: load context, evaluate the di
 Fetch PR metadata and the diff:
 
 ```bash
-gh pr view <PR_NUMBER> -R <REPO> --json title,body,files,commits,reviews,latestReviews,comments,reviewDecision
+gh pr view <PR_NUMBER> -R <REPO> --json title,body,files,commits,reviews,latestReviews,comments,reviewDecision,headRefOid,baseRefOid
 gh pr diff <PR_NUMBER> -R <REPO>
 ```
 
@@ -145,7 +145,11 @@ Do NOT produce the structured JSON output.
 Read the project's own conventions before judging the diff — you enforce them, so you must load them first (mirrors the [`plan` skill's Phase 1](../plan/SKILL.md#phase-1-context-gathering)):
 
 - **CLAUDE.md (stack rules)** — read the repository-root `CLAUDE.md`; map each changed line to the rule it must satisfy.
-- **README + `docs/*` (project conventions)** — read the root `README.md` and the docs it links; treat `docs/` as the source of truth for project-specific conventions.
+- **README + `docs/*` (project conventions)** — read the root `README.md` and the docs it links; treat `docs/` as the source of truth for project-specific conventions. When the root README carries no docs index, fall back to `docs/README.md`, then to the Glob `docs/*.md` file names.
+- **`rfc/` (versioned standards)** — if `rfc/` exists at the repository root, build a standards inventory and read the diff-relevant standards; the [Repository Standards checks](#repository-standards-rfcs) enforce them:
+  - **Inventory** — read the `rfc/README.md` index table into `{id, title, status, path}`; when it is absent, Glob `rfc/[0-9]*.md` and read each file's frontmatter block. Derive a missing id/title from the `NNNN-slug` filename (or the first H1). A missing or unparseable `status` counts as Draft — record it as defaulted. `Superseded` entries are never enforcement sources.
+  - **Selection** — match each entry's title+slug tokens against the changed file paths and the diff's visible domains (log calls → a logging standard, HTTP routes → an API standard, new files → a file-structure standard). When in doubt whether a standard applies, load it — capped at 3 standards per review, ranked by match strength; record dropped candidates in the Context Map (no silent truncation).
+  - **Reads** — use the Read tool on matched standards (do not rely on the pack; a fallback pack may omit nested markdown); for a standard longer than ~300 lines, read only the matched sections. An RFC the diff itself modifies is enforced at its **base-branch version** — fetch it via `gh api repos/<REPO>/contents/<path>?ref=<baseRefOid>` (from [§1.1](#11-pr-context)) — so a PR cannot legalize its own diff by editing the standard; the hygiene checks still apply to the modified version.
 - **context7 / Ref / Exa** — MANDATORY for any unfamiliar library or API the diff touches; never guess an API's behavior.
 - **Perplexity** — web search for general or architectural questions.
 
@@ -158,6 +162,7 @@ Read the project's own conventions before judging the diff — you enforce them,
 - **Related work** — TODOs and `#<issue>` references in the codebase from `search-codebase-todos` ([§1.2](#12-load-context-via-sub-agents)): flag whether the diff resolves or conflicts with a related TODO, leaves a referenced issue half-addressed, or duplicates work tracked elsewhere; "none" when no issue is linked or none found.
 - **Prior-review findings** — unresolved findings from prior review bodies ([§1.1](#11-pr-context)) and inline threads from `fetch-pr-reviews` ([§1.2](#12-load-context-via-sub-agents)); empty on first review.
 - **Project conventions** — the CLAUDE.md / README / `docs/*` points that bear on the diff ([§1.4](#14-project-context-read-before-reviewing)).
+- **Applicable standards** — the standards selected in [§1.4](#14-project-context-read-before-reviewing): each as id + status (marked "defaulted" when the status was inferred) with a one-line why, plus any dropped candidates; "none" when nothing matched or the folders are absent. This map is the audit log of what was loaded and why.
 - **Codebase pointers** — only the targeted pack-`grep` hits pulled for cross-file checks; "none" when the diff is self-contained.
 - **Stack** — `agents.rules` value (drives [§2](#phase-2-review-the-diff) thresholds), or `unknown`.
 
@@ -732,6 +737,50 @@ The root `README.md` Documentation section is the single index — every `.md` u
 
 A `docs/*.md` file exceeds ~5000 characters or documents more than one area. Split it; keep code examples minimal (link to source, explain the "why" in prose).
 
+<a id="CHECK-DOC-005"></a>
+**CHECK-DOC-005: Diff contradicts a documented project convention** — Severity: suggestion
+
+A change violates a convention documented in the repository's `docs/*` or README — the [§1.5](#15-context-map) Applicable standards map lists the conventions in play. Docs are unversioned prose, so this is capped at suggestion; a convention that must block belongs in an Accepted RFC. Quote the contradicted sentence verbatim (≤2 lines) in the finding detail and cite the doc section as a link built from the [§1.1](#11-pr-context) `headRefOid`.
+
+- Example: a `docs/*.md` API chapter prescribes cursor pagination and the diff adds an offset-paginated endpoint.
+- Skip: the doc describes current behavior the diff intentionally changes AND the same PR updates that doc.
+
+#### Repository Standards (RFCs)
+
+Applies to repositories carrying an `rfc/` folder ([§1.4](#14-project-context-read-before-reviewing) builds the inventory). Skip CHECK-RFC-001/002 when the [§1.5](#15-context-map) Applicable standards map is "none"; CHECK-RFC-003/004 apply whenever the diff touches `rfc/` files. When a violation also matches a generic check above, report that check once and cite the RFC in its detail — do not double-report. Every CHECK-RFC-001/002 finding must quote the violated clause verbatim (≤2 lines) from the standard in its detail — a finding that only paraphrases the rule is not reportable — and cite the standard by its stable ID as a link built from the [§1.1](#11-pr-context) `headRefOid` (e.g. `[RFC-0003](https://github.com/<REPO>/blob/<headRefOid>/rfc/0003-service-logging-standard.md)`).
+
+<a id="CHECK-RFC-001"></a>
+**CHECK-RFC-001: Diff violates an Accepted repository RFC** — Severity: blocker
+
+A change contradicts a clause of an RFC whose `status` is Accepted — the repository's ratified standard, immutable except through a version bump.
+
+- Example: an Accepted logging RFC mandates structured JSON logs and the diff adds a plain `console.log` to a service.
+- Skip: the RFC's own text names an exception that applies; a defaulted status is Draft, not Accepted — route it to CHECK-RFC-002.
+
+<a id="CHECK-RFC-002"></a>
+**CHECK-RFC-002: Diff conflicts with a Draft repository RFC** — Severity: suggestion
+
+A change contradicts a clause of a Draft RFC (including standards whose status was defaulted to Draft). Draft standards are proposals — advisory only, never a blocker; name the Draft status in the finding.
+
+- Example: a Draft API-versioning RFC prescribes `/v1/` route prefixes and the diff adds an unversioned route.
+- Skip: the Draft's own text scopes itself to future or new code and the diff only extends an existing pattern.
+
+<a id="CHECK-RFC-003"></a>
+**CHECK-RFC-003: Accepted RFC edited without a version bump** — Severity: blocker
+
+The diff changes the content of an Accepted RFC without incrementing its `version` frontmatter and adding a Changelog entry (and updating `updated` when the format carries it). An Accepted RFC is immutable except through an explicit, recorded version bump.
+
+- Example: rewording a mandate inside an Accepted RFC while `version:` stays unchanged.
+- Skip: pure typo or formatting fixes that change no normative content — mention them in prose instead; a status transition (e.g. Draft → Accepted) recorded with a version bump.
+
+<a id="CHECK-RFC-004"></a>
+**CHECK-RFC-004: RFC file hygiene** — Severity: suggestion
+
+A new or renamed RFC is missing from the `rfc/README.md` index, its filename does not follow `NNNN-short-slug.md`, or its frontmatter is missing or malformed (no parseable `status`).
+
+- Example: adding an `rfc/0008-*.md` standard without an index row; an RFC whose frontmatter lacks `status`.
+- Skip: repositories with no `rfc/README.md` index at all — the Glob fallback is the index there; flag only frontmatter problems.
+
 #### Service Standards
 
 Applies when the diff adds or changes a backend service's API, entrypoint, or runtime config. Skip libraries, frontend-only changes, and diffs that touch none of these. Secrets in code are CHECK-SEC-001 and missing tests are CHECK-TEST-008 — do not double-report them here.
@@ -789,7 +838,7 @@ Map `severity` to its emoji when rendering in [Phase 3](#phase-3-submit-review):
 
 ### Issue Severity
 
-- **🚧 Blocking** - Must fix before merge (bugs, security, missing tests, RFC violations)
+- **🚧 Blocking** - Must fix before merge (bugs, security, missing tests, Accepted-RFC violations)
 - **🙋‍♂️ Suggestions** - Should fix, can discuss (architecture, patterns)
 - **💡 Nitpicks** - Optional improvement (style, naming)
 

--- a/docs/12-code-review-repository-standards.md
+++ b/docs/12-code-review-repository-standards.md
@@ -1,0 +1,40 @@
+# Code review repository standards
+
+> Chapter 12 of the [repository docs](../README.md#repository-docs).
+
+`code-review-action` reviews every PR against the repo's `CLAUDE.md` and the generic `CHECK-*` catalog in the [pr:review skill](../claude-plugins/autopilot/skills/pr:review/SKILL.md). This chapter defines the additional, convention-based contract: when a consumer repository carries `rfc/` or `docs/`, the review enforces those standards too. There is no workflow input or config key — the folders are the opt-in, and repositories without them see no change and pay no cost.
+
+## Discovery
+
+- **`rfc/` (versioned standards)** — the review builds an inventory `{id, title, status, path}` from the `rfc/README.md` index table; when no index exists it globs `rfc/[0-9]*.md` and reads each file's frontmatter. A missing id or title is derived from the `NNNN-slug` filename (or the first H1); a missing or unparseable `status` counts as Draft and is recorded as defaulted — visible in the review, never a silent downgrade.
+- **`docs/` (project conventions)** — indexed via the root `README.md` docs table, else `docs/README.md`, else the `docs/*.md` file names.
+
+## Selection
+
+The review reads only diff-relevant standards, chosen mechanically: each inventory entry's title+slug tokens are matched against the changed file paths and the diff's visible domains (log calls → a logging standard, HTTP routes → an API standard, new files → a file-structure standard). When in doubt whether a standard applies, it is loaded — capped at 3 standards per review, ranked by match strength; dropped candidates are recorded in the review's context map, never silently truncated. A standard longer than ~300 lines is read section-by-section, not in full.
+
+## Severity ladder
+
+Severity follows source stability:
+
+| Source                 | Status               | Finding                               |
+| ---------------------- | -------------------- | ------------------------------------- |
+| RFC                    | Accepted             | CHECK-RFC-001 — blocker               |
+| RFC                    | Draft (or defaulted) | CHECK-RFC-002 — suggestion (advisory) |
+| RFC                    | Superseded           | never enforced                        |
+| docs/README convention | —                    | CHECK-DOC-005 — suggestion            |
+
+Ratifying an RFC (status Accepted) is what makes a standard blocking — a docs convention can advise but never block. Every finding quotes the violated clause verbatim (≤2 lines) and cites the standard as a link at the PR head commit, so citations stay grounded and resolvable. A violation that also matches a generic `CHECK-*` rule is reported once under the generic code, with the RFC cited in its detail.
+
+## RFC hygiene
+
+Two checks protect the `rfc/` contract itself and apply whenever a diff touches `rfc/` files:
+
+- **CHECK-RFC-003** (blocker) — an Accepted RFC edited in place without a `version` bump and Changelog entry.
+- **CHECK-RFC-004** (suggestion) — a new or renamed RFC missing from the index, a filename not matching `NNNN-short-slug.md`, or missing/malformed frontmatter.
+
+An RFC modified by the diff is enforced at its base-branch version, so a single PR cannot weaken a standard and ship code that violated the old version at the same time.
+
+## Cost behavior
+
+Discovery is index-first: one small read builds the inventory, and only matched standards (at most 3) are read further, section-targeted for large files. The rule catalog grows by five codes total; per-review cost stays within the normal band for repositories with standards and is unchanged for repositories without them.


### PR DESCRIPTION
The AI review now enforces a consumer repository's own standards, not just CLAUDE.md and the generic CHECK catalog: pr:review discovers `rfc/` (versioned, status-tracked standards) and `docs/` (project conventions), loads only diff-relevant standards index-first, and reports violations with new CHECK codes that cite the violated standard. Because the action serves the skill from its @main checkout, the checks activate for every consumer on merge; rollback is a one-commit revert on main.

- New checks: CHECK-RFC-001 (blocker, Accepted RFC violated), CHECK-RFC-002 (suggestion, Draft RFC conflict), CHECK-RFC-003 (blocker, Accepted RFC edited without a version bump), CHECK-RFC-004 (suggestion, RFC file hygiene), CHECK-DOC-005 (suggestion, documented convention contradicted)
- Mechanical selection rule capped at 3 standards per review; severity follows source stability (Accepted → blocker-capable, Draft/docs → suggestion, Superseded → ignored, unparseable status → Draft, recorded as defaulted)
- Findings must quote the violated clause verbatim and cite the standard at the PR head SHA per [RFC-0001](https://github.com/awinogradov/code-assistants/blob/main/rfc/0001-reference-formatting.md); §1.1 now fetches headRefOid/baseRefOid
- An RFC modified by the diff is enforced at its base-branch version, so a PR cannot legalize its own diff by editing the standard
- New chapter `docs/12-code-review-repository-standards.md` defines the consumer contract; the action README gains a consumer-facing section
- No action.yml, output-schema, or TS changes; verified by the action test suite (774 pass) and a manual dry run of the new selection logic against PR #333

---

**Release notes:**

- The AI review now enforces a repository's own `rfc/` and `docs/` standards: Accepted-RFC violations block, Draft-RFC conflicts and docs-convention contradictions surface as suggestions
- New RFC hygiene checks flag an Accepted RFC edited without a version bump and RFCs missing from the `rfc/README.md` index
- Repositories without `rfc/` or `docs/` folders see no change in review behavior or cost

---

**Issues:**

Closes #403
