### PR TITLE
HOTFIX: Fix garbled line breaks in AI review comments

### DIFF
--- a/.github/actions/code-review-action/src/reactToComment.ts
+++ b/.github/actions/code-review-action/src/reactToComment.ts
@@ -6,7 +6,7 @@
  * GH_TOKEN=xxx REPO=owner/repo PR_NUMBER=123 COMMENT_ID=456 STRUCTURED_OUTPUT='{"reply":"..."}' bun run scripts/reactToComment.ts
  */
 import type { ReviewEvent } from "./github/githubReview.ts";
-import { parseReactionOutput } from "./reviewOutput/reviewOutput.ts";
+import { parseReactionOutput, repairOverEscapedWhitespace } from "./reviewOutput/reviewOutput.ts";
 import {
   deletePendingReviews,
   fetchReviewThreads,
@@ -134,7 +134,7 @@ if (!output || !output.reply) {
   }
   console.log("Structured output missing, falling back to execution result as reply");
   output = {
-    reply: resultText,
+    reply: repairOverEscapedWhitespace(resultText),
     resolveComments: [],
     updatedVerdict: null,
     updatedReviewComment: null,

--- a/.github/actions/code-review-action/src/reviewOutput/reviewOutput.test.ts
+++ b/.github/actions/code-review-action/src/reviewOutput/reviewOutput.test.ts
@@ -10,7 +10,29 @@ import {
   isAlreadyMentioned,
   parseReactionOutput,
   parseStructuredOutput,
+  repairOverEscapedWhitespace,
 } from "./reviewOutput.ts";
+
+describe("repairOverEscapedWhitespace", () => {
+  test("converts over-escaped whitespace in a single-line body", () => {
+    expect(repairOverEscapedWhitespace("a\\nb")).toBe("a\nb");
+    expect(repairOverEscapedWhitespace("a\\tb")).toBe("a\tb");
+  });
+
+  test("collapses a literal \\r\\n to a single newline in one pass", () => {
+    expect(repairOverEscapedWhitespace("a\\r\\nb")).toBe("a\nb");
+  });
+
+  test("leaves a body that already has a real newline untouched (guard)", () => {
+    const healthy = "real\nbreak with a `\\n` code span";
+    expect(repairOverEscapedWhitespace(healthy)).toBe(healthy);
+  });
+
+  test("is a no-op on empty or escape-free text", () => {
+    expect(repairOverEscapedWhitespace("")).toBe("");
+    expect(repairOverEscapedWhitespace("plain text")).toBe("plain text");
+  });
+});
 
 describe("parseStructuredOutput", () => {
   test("returns null for empty or literal-null input", () => {
@@ -59,6 +81,19 @@ describe("parseStructuredOutput", () => {
       inlineComments: [],
     });
   });
+
+  test("repairs over-escaped reviewComment and inline body, but not suggestion", () => {
+    const raw = JSON.stringify({
+      verdict: "comment",
+      reviewComment: "a\\nb",
+      inlineComments: [{ path: "x.ts", line: 1, body: "c\\nd", suggestion: "e\\nf" }],
+    });
+    const out = parseStructuredOutput(raw);
+    expect(out?.reviewComment).toBe("a\nb");
+    expect(out?.inlineComments[0]?.body).toBe("c\nd");
+    // A suggestion is committed verbatim, so its escapes are left untouched.
+    expect(out?.inlineComments[0]?.suggestion).toBe("e\\nf");
+  });
 });
 
 describe("parseReactionOutput", () => {
@@ -87,6 +122,18 @@ describe("parseReactionOutput", () => {
       updatedVerdict: "approve",
       updatedReviewComment: "done",
     });
+  });
+
+  test("repairs over-escaped reply and updatedReviewComment, keeps null", () => {
+    const withUpdate = parseReactionOutput(
+      JSON.stringify({ reply: "a\\nb", updatedVerdict: "comment", updatedReviewComment: "c\\nd" })
+    );
+    expect(withUpdate?.reply).toBe("a\nb");
+    expect(withUpdate?.updatedReviewComment).toBe("c\nd");
+
+    const noUpdate = parseReactionOutput(JSON.stringify({ reply: "x\\ny" }));
+    expect(noUpdate?.reply).toBe("x\ny");
+    expect(noUpdate?.updatedReviewComment).toBeNull();
   });
 });
 

--- a/.github/actions/code-review-action/src/reviewOutput/reviewOutput.ts
+++ b/.github/actions/code-review-action/src/reviewOutput/reviewOutput.ts
@@ -71,14 +71,66 @@ function parseJsonWithSchema<T>(rawOutput: string, schema: z.ZodType<T>): T | nu
   return result.success ? result.data : null;
 }
 
-/** Parse and validate structured review output from Claude (null on any failure). */
-export function parseStructuredOutput(rawOutput: string): StructuredOutput | null {
-  return parseJsonWithSchema(rawOutput, structuredOutputSchema);
+/**
+ * Repair whitespace escape sequences the review model over-escaped.
+ *
+ * Under strict `json_schema` output the model sometimes serializes a line break
+ * as a literal backslash-n (`\\n`) instead of a control newline, so after
+ * `JSON.parse` the string carries the two characters `\` + `n` and GitHub renders
+ * the body as one wall of text with visible `\n` (the defect this fixes). This
+ * restores the real characters in a single pass — `\r\n`/`\r`/`\n` become a
+ * newline, `\t` a tab — so an emitted newline can never be re-matched.
+ *
+ * Whole-field guard: when the text already holds a real newline the model
+ * produced structure, so it is returned untouched. That protects a healthy
+ * multi-paragraph body legitimately quoting `` `\n` `` inside a code span from
+ * being rewritten. The confirmed defect is uniform — one JSON string value is
+ * either wholly over-escaped or not — so the guard misses nothing real.
+ *
+ * Residual ambiguity: after `JSON.parse` an intentionally-literal `\n`/`\t` (or a
+ * backslash path such as `C:\newfolder`) in a single-line field is byte-identical
+ * to an over-escaped newline and is converted. This is rare, applies only to
+ * prose fields (callers leave committed `suggestion` code untouched), and beats
+ * leaving every multi-line body broken.
+ */
+export function repairOverEscapedWhitespace(text: string): string {
+  if (text.includes("\n")) return text;
+  return text.replaceAll(/\\r\\n|\\r|\\n|\\t/g, (match) => (match === "\\t" ? "\t" : "\n"));
 }
 
-/** Parse and validate structured reaction output from Claude (null on any failure). */
+/**
+ * Parse and validate structured review output from Claude (null on any failure).
+ * Repairs over-escaped whitespace in the prose fields (`reviewComment`, inline
+ * `body`); an inline `suggestion` is committed verbatim, so it is left untouched.
+ */
+export function parseStructuredOutput(rawOutput: string): StructuredOutput | null {
+  const parsed = parseJsonWithSchema(rawOutput, structuredOutputSchema);
+  if (!parsed) return null;
+  return {
+    ...parsed,
+    reviewComment: repairOverEscapedWhitespace(parsed.reviewComment),
+    inlineComments: parsed.inlineComments.map((comment) => ({
+      ...comment,
+      body: repairOverEscapedWhitespace(comment.body),
+    })),
+  };
+}
+
+/**
+ * Parse and validate structured reaction output from Claude (null on any failure).
+ * Repairs over-escaped whitespace in the prose fields (`reply`, `updatedReviewComment`).
+ */
 export function parseReactionOutput(rawOutput: string): ReactionOutput | null {
-  return parseJsonWithSchema(rawOutput, reactionOutputSchema);
+  const parsed = parseJsonWithSchema(rawOutput, reactionOutputSchema);
+  if (!parsed) return null;
+  return {
+    ...parsed,
+    reply: repairOverEscapedWhitespace(parsed.reply),
+    updatedReviewComment:
+      parsed.updatedReviewComment === null
+        ? null
+        : repairOverEscapedWhitespace(parsed.updatedReviewComment),
+  };
 }
 
 /** Expand a single unified-diff hunk header match into its added-line locations. */

--- a/.github/actions/code-review-action/src/submitReview.ts
+++ b/.github/actions/code-review-action/src/submitReview.ts
@@ -14,6 +14,7 @@ import {
   formatInvalidComments,
   isAlreadyMentioned,
   parseStructuredOutput,
+  repairOverEscapedWhitespace,
   type InlineComment,
   type ValidLine,
 } from "./reviewOutput/reviewOutput.ts";
@@ -115,7 +116,7 @@ if (!output) {
   console.log("Structured output missing, falling back to execution result as COMMENT review");
   output = {
     verdict: "comment",
-    reviewComment: resultText,
+    reviewComment: repairOverEscapedWhitespace(resultText),
     inlineComments: [],
   };
 }


### PR DESCRIPTION
AI code-review comments rendered the model-authored portion as a wall of text with visible `\n` escape sequences instead of line breaks (see the review on https://github.com/awinogradov/code-assistants/pull/408#pullrequestreview-4620940087). Under strict `json_schema` output the model over-escapes newlines, so the parsed `reviewComment`/`reply` carried a literal backslash-n while the code-appended footer used real newlines, producing the mixed body. The fix repairs the over-escaping at the pure parse boundary in [reviewOutput.ts](https://github.com/awinogradov/code-assistants/blob/e7a4584/.github/actions/code-review-action/src/reviewOutput/reviewOutput.ts), which feeds both the review and reaction submission paths.

- Added `repairOverEscapedWhitespace` that unescapes literal `\n`/`\r`/`\t` in a single pass, guarded to skip any field already holding a real newline so a healthy multi-paragraph body quoting a `\n` code span is left untouched
- Applied it to the prose fields (`reviewComment`, inline comment `body`, reaction `reply`, `updatedReviewComment`); an inline `suggestion` is left verbatim because it is committed as code
- Routed the structured-output-missing fallbacks in [submitReview.ts](https://github.com/awinogradov/code-assistants/blob/e7a4584/.github/actions/code-review-action/src/submitReview.ts) and [reactToComment.ts](https://github.com/awinogradov/code-assistants/blob/e7a4584/.github/actions/code-review-action/src/reactToComment.ts) through the same helper so no model-authored text bypasses the repair
- Rollout: the action runs from `@main`, so it is live on merge (rollback is a plain revert); the first review on an already-open PR differs from its previously-posted broken body, so the duplicate-suppression guard re-posts it once with correct formatting

---

**Release notes:**

- Fixed AI code-review comments showing literal `\n` escape sequences instead of line breaks
