### PR TITLE
HOTFIX: Skip dependabot PRs in shared PR-validation actions

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -105,7 +105,12 @@ runs:
   steps:
     # ── Validation ──
 
+    # Skip for dependabot PRs: their runs use the Dependabot secrets store, so
+    # anthropic_api_key/bot_token are empty and this gate would hard-exit before
+    # "Detect context" reaches its existing dependabot skip. Gating here lets that
+    # skip run (it needs only bot_token) and set skip=true, so the job stays GREEN.
     - name: Validate tokens
+      if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
       shell: bash
       env:
         BOT_TOKEN: ${{ inputs.bot_token }}

--- a/.github/actions/contributing-check/README.md
+++ b/.github/actions/contributing-check/README.md
@@ -63,6 +63,8 @@ The action never writes to the repository or to the PR, so writes are not reques
 
 The action runs four steps sequentially. The first failure short-circuits the job — later steps do not run.
 
+Dependabot-authored PRs (author `dependabot[bot]`) skip every step — their machine-generated `dependabot/...` branches and update titles do not follow the human conventions. Each step is gated on the PR author, so the "Validate PR" job still reports success (green) rather than a stuck or failed required check.
+
 1. **Branch name** — [`deepakputhraya/action-branch-name@v1.0.0`](https://github.com/deepakputhraya/action-branch-name) enforces the regex `^(issue-\d+-[a-z0-9]+(-[a-z0-9]+)*|[a-z][a-z0-9]*-\d+-[a-z0-9]+(-[a-z0-9]+)*|(hotfix|trivial|maintenance|proposal|security)-[a-z0-9]+(-[a-z0-9]+)*|release-([a-z0-9]+(-[a-z0-9]+)*-)?\d+\.\d+\.\d+)$` — the GitHub `issue-<n>-<slug>` form, the Linear `<team>-<n>-<slug>` form, the special prefixes, and release branches — with `min_length: 5`, `max_length: 100`, and `ignore: main,master`. This matches the CONTRIBUTING.md `Branches` section.
 2. **Checkout** — `actions/checkout@v4` with `fetch-depth: 0` so commitlint can resolve the full PR commit range.
 3. **Commit messages** — [`wagoid/commitlint-github-action@v6`](https://github.com/wagoid/commitlint-github-action) runs against `./commitlint.config.mjs` with `failOnWarnings: false`. Level-1 (warning) rules — `body-max-line-length` and `footer-max-line-length` — are surfaced as warnings but do not block merge. Level-2 (error) rules — including the custom `body-required-for-types`, `no-issue-id-in-subject`, and `no-ai-coauthored-by` — block merge.

--- a/.github/actions/contributing-check/action.yml
+++ b/.github/actions/contributing-check/action.yml
@@ -4,7 +4,15 @@ description: Validate branch name, commit messages, and PR title against the con
 runs:
   using: composite
   steps:
+    # Dependabot PRs deviate from the branch-name and PR-title conventions (e.g.
+    # `dependabot/github_actions/...` branches), so every step below is gated to
+    # skip them. Keying on the PR author (not github.actor) survives synchronize
+    # events and is not spoofable — only GitHub can author under `dependabot[bot]`.
+    # Gating each step (not the job) keeps the required "Validate PR" check GREEN.
+    # Every step MUST carry this identical guard; a new step without it re-blocks
+    # dependabot. Actions do not support YAML anchors, so it is repeated verbatim.
     - name: Validate branch name
+      if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
       uses: deepakputhraya/action-branch-name@v1.0.0
       with:
         regex: '^(issue-\d+-[a-z0-9]+(-[a-z0-9]+)*|[a-z][a-z0-9]*-\d+-[a-z0-9]+(-[a-z0-9]+)*|(hotfix|trivial|maintenance|proposal|security)-[a-z0-9]+(-[a-z0-9]+)*|release-([a-z0-9]+(-[a-z0-9]+)*-)?\d+\.\d+\.\d+)$'
@@ -13,17 +21,20 @@ runs:
         ignore: main,master
 
     - name: Checkout
+      if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Validate commit messages
+      if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
       uses: wagoid/commitlint-github-action@v6
       with:
         configFile: ./commitlint.config.mjs
         failOnWarnings: false
 
     - name: Validate PR title (semantic)
+      if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
       uses: amannn/action-semantic-pull-request@v6
       env:
         GITHUB_TOKEN: ${{ github.token }}
@@ -44,6 +55,7 @@ runs:
           PR title must not end with a period. See CONTRIBUTING.md §pr-title.
 
     - name: Validate PR title length
+      if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
       shell: bash
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Dependabot pull requests fail two shared composite actions that downstream repos consume at `@main`. This skips dependabot-authored PRs in both so their checks pass (green) without weakening validation for human PRs. Because consumers reference the actions at `@main`, the fix is live for downstream repos (e.g. [fortune-os](https://github.com/wefortis/fortune-os), symbiot) the instant it merges — with no per-repo sync PR.

- Gate all 5 [`contributing-check`](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/contributing-check/action.yml) steps on the PR author, so `dependabot/...` branches no longer fail the branch-name regex — its `ignore` input is exact-match only and cannot match them
- Gate the [`code-review-action`](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/code-review-action/action.yml) "Validate tokens" step so its existing dependabot skip runs before the token check — dependabot runs use the separate Dependabot secrets store where the Anthropic key is empty, so validation hard-exited before the skip was reached
- Keys on `github.event.pull_request.user.login` (not `github.actor`): survives synchronize events and is not spoofable, since only GitHub can author under `dependabot[bot]`
- Step-level gating (not job-level) keeps the required "Validate PR" and "ai-review" checks green rather than stuck-pending
- Rollback: revert this commit on `main` to instantly restore prior behavior for every `@main` consumer — there is no sync-PR buffer

---

**Release notes:**

- Dependabot PRs now pass the Contributing (branch name, commit messages, PR title) and AI Code Review checks automatically instead of failing
