### PR TITLE
MAINTENANCE: Enable weekly Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot version updates for the github-actions ecosystem.
+# Options reference:
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # `/` scans .github/workflows/*.yml (and a root action.yml, if any).
+    # `/.github/actions/*` reaches every composite action.yml one level deep.
+    # Required because `directory: "/"` does NOT recurse into .github/actions/*/,
+    # where the third-party actions pinned inside composites (oven-sh/setup-bun,
+    # etc.) live. If a nested composite dir is ever added
+    # (.github/actions/<group>/<name>/action.yml), add another entry here.
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      # Weekly, Sunday 20:00 Asia/Dubai (UTC+4, no DST). timezone applies only
+      # when `time` is set; the default check time is 06:00 otherwise.
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"
+      timezone: "Asia/Dubai"
+    # One consolidated group across all directories -> a single weekly PR, so
+    # turbo runs test/typecheck once instead of once per touched directory.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # Rebase-merge replays each commit onto main and release-action classifies
+    # releases by conventional type; `ci(deps): bump ...` keeps history
+    # conventional and non-releasing.
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
Adds `.github/dependabot.yml` enabling weekly Dependabot version updates for the `github-actions` ecosystem. This monorepo pins third-party actions in two places — `.github/workflows/*.yml` and 17 composite `.github/actions/*/action.yml` files — and a plain `directory: "/"` config scans only the workflows, silently missing the actions pinned inside composites (e.g. `oven-sh/setup-bun`, used in 10 of them).

- Scan both roots via `directories: ["/", "/.github/actions/*"]` — the glob reaches every composite action.yml, since `directory: "/"` does not recurse ([dependabot-core#6345](https://github.com/dependabot/dependabot-core/issues/6345))
- Bundle all bumps into one weekly grouped PR (`groups.github-actions.patterns: ["*"]`) so turbo runs test/typecheck once, not per directory
- Schedule weekly on Sunday 20:00 Asia/Dubai
- Set `commit-message: {prefix: ci, include: scope}` → `ci(deps): bump ...`, keeping rebase-replayed commits conventional and non-releasing
- First-party `...@main` refs are branch refs, so Dependabot leaves them untouched by design