### PR TITLE
PROPOSAL: Point MCP-server guidance at the repo's own .mcp.json

### DIFF
--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -387,11 +387,13 @@ Choose ONE backend based on the project's needs. Do not mix.
 
 ### 16.2 MCP Servers
 
-**context7**, **Ref**, **Exa**: Look up documentation for all technologies
+Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 
-**Playwright**: Verify UI state with browser_snapshot
-
-**Chrome DevTools**: Performance analysis, network debugging, console logging, etc.
+- 👤 **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
+- 👤 **shadcn MCP server** — search, browse, add, or audit shadcn/ui registry components; prefer it over hand-editing component source
+- 👤 **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
+- 👤 **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
+- 👤 **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -259,7 +259,10 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 16.2 MCP Servers
 
-**context7**, **Ref**, **Exa**: Look up documentation for all technologies
+Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
+
+- 👤 **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
+- 👤 **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -378,11 +378,13 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 16.2 MCP Servers
 
-**context7**, **Ref**, **Exa**: Look up documentation for all technologies
+Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 
-**Playwright**: Verify UI state with browser_snapshot
-
-**Chrome DevTools**: Performance analysis, network debugging, console logging, etc.
+- 👤 **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
+- 👤 **shadcn MCP server** — search, browse, add, or audit shadcn/ui registry components; prefer it over hand-editing component source
+- 👤 **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
+- 👤 **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
+- 👤 **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -375,11 +375,12 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 16.2 MCP Servers
 
-**context7**, **Ref**, **Exa**: Look up documentation for all technologies
+Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 
-**Playwright**: Verify UI state with browser_snapshot
-
-**Chrome DevTools**: Performance analysis, network debugging, console logging, etc.
+- 👤 **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
+- 👤 **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
+- 👤 **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
+- 👤 **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 


### PR DESCRIPTION
## What

Rewrites §16.2 "MCP Servers" across the four stack rules files so it directs assistants to the repo's **own** `.mcp.json`, README, and `docs/` for the registered-server list, with generic per-server triggers, replacing the previous thin `context7 / Ref / Exa` + Playwright + Chrome DevTools list.

Per-stack, stack-appropriate:

- **Bun** — intro + documentation servers + Repomix (unchanged UI-free scope)
- **NodeJS+React** — adds Playwright / Chrome DevTools / Repomix, omits shadcn (no Tailwind)
- **Bun+React+Tailwind**, **NodeJS+React+Tailwind** — full list including shadcn

## Why

Downstream repos register their own MCP servers in their own `.mcp.json` (and document them in their README/`docs/`). Hardcoding a fixed server list in the shared rules template drifts from what each repo actually ships. Pointing agents at the repo's own registration keeps the rule correct everywhere and lets each downstream keep its specifics (e.g. a `packages/ui-tailwind`-scoped shadcn server, a remote Prisma server) where they belong — in that repo's docs — without leaking them into the template.

## Notes

- Generic only: no project-specific server (e.g. Prisma) or path is hardcoded here.
- `PROPOSAL:` prefix — discussion on the PR, no issue filed upstream. Tracked downstream by fortune-os Linear ticket FRTNS-13, which adopts the split "generic upstream + specifics in the repo's README/docs".
- Flows to downstream repos via the `agents-rules` upstream sync.
