### PR TITLE
Switch autopilot plan skills to the harness plan mode

### DIFF
--- a/claude-plugins/autopilot/skills/plan/SKILL.md
+++ b/claude-plugins/autopilot/skills/plan/SKILL.md
@@ -17,6 +17,8 @@ allowed-tools:
   - MCP(perplexity:*)
   - MCP(repomix:*)
   - AskUserQuestion
+  - EnterPlanMode
+  - ExitPlanMode
   - Skill(autopilot:preflight-check)
   - Skill(autopilot:plan-bun)
   - Skill(autopilot:plan-nodejs-react)
@@ -242,6 +244,19 @@ The skill receives `mode: plan` and the [Phase 0](#phase-0-input-resolution) con
 
 If the skill outputs "Planning cancelled", stop execution immediately — do not proceed to [Phase 1](#phase-1-detect-stack-and-delegate).
 
+## Enter Plan Mode
+
+Once the preflight passes, switch the session into the harness plan mode **before** any codebase exploration or plan-file write:
+
+```
+EnterPlanMode
+```
+
+This makes the rest of planning read-only (the stack pipeline's [Context Gathering](#phase-1-context-gathering) explores without mutating the tree) and gives the harness-provided plan-file path — the single file the pipeline's [Finalize Output](#phase-6-finalize-output) writes to and the [Phase 2](#phase-2-embed-branch-creation-in-plan-file) `ExitPlanMode` step then reads back for approval. Do not compute a separate plan-file path; the plan file **is** the plan-mode file.
+
+- **Idempotency** — if the session is already in plan mode (the user invoked `/autopilot:plan` from plan mode), skip this call; a second `EnterPlanMode` is unnecessary.
+- **`/autopilot:plan` only** — this step and its paired `ExitPlanMode` ([Phase 2](#phase-2-embed-branch-creation-in-plan-file)) live in the orchestrator, outside the shared [**Stack Pipeline (Phases 1–6)**](#stack-pipeline-phases-16). `/autopilot:run` reuses only that pipeline and authorizes the whole flow up front, so it never enters plan mode and never gates on approval — keep both mode calls out of the pipeline section so `run` cannot reach them.
+
 ## Common Instructions
 
 The following apply to ALL stacks throughout planning — both the orchestrator phases below and the shared [**Stack Pipeline (Phases 1–6)**](#stack-pipeline-phases-16) the stack skills execute, which points back here rather than restating them:
@@ -377,7 +392,7 @@ Tool parameters:
 
 ## Phase 2: Embed Branch Creation in Plan File
 
-**BEFORE calling ExitPlanMode**, embed branch creation into the plan file so it executes as the first post-approval step.
+**BEFORE calling `ExitPlanMode`** (the [Request Approval](#request-approval) step below), embed branch creation into the plan file so it executes as the first post-approval step.
 
 ### Check conditions
 
@@ -450,6 +465,18 @@ Then invoke `/autopilot:branch-create --<chosen-prefix> "<description>"` using t
 ### Otherwise (not on `main` AND (`isWorktree` is false OR `worktreeNeedsBranch` is false))
 
 Do NOT add `## Pre-Implementation` — already on a feature branch with active work.
+
+### Request Approval
+
+Once the shared [**Stack Pipeline (Phases 1–6)**](#stack-pipeline-phases-16) has written the finalized plan file (its [Finalize Output](#phase-6-finalize-output)) and the branch block above is embedded, request the user's approval of the plan:
+
+```
+ExitPlanMode
+```
+
+`ExitPlanMode` reads the plan back from the plan-mode file that [Enter Plan Mode](#enter-plan-mode) established and asks the user to approve it. On approval the session leaves plan mode and implementation begins with the embedded `## Pre-Implementation` branch step, then the plan's `## Implementation Steps`.
+
+This step is `/autopilot:plan` only. `/autopilot:run` replaces it: invoking `/autopilot:run` is itself the authorization, so run never enters plan mode and never calls `ExitPlanMode` — it proceeds straight from the written plan into implementation (see [`run/SKILL.md`](../run/SKILL.md)). Keeping this call in the orchestrator, outside the Stack Pipeline section below, is what lets `run` reuse the pipeline without inheriting the gate.
 
 ## Stack Pipeline (Phases 1–6)
 

--- a/docs/05-plan-run-skills.md
+++ b/docs/05-plan-run-skills.md
@@ -116,6 +116,12 @@ The skill then emits, for the user's review (all derived from the resolved issue
 
 `Skill(autopilot:preflight-check)` (mode `plan`) validates git state: current branch, stale/merged branches, issue-ID mismatches, and whether `main` is up to date. If it cancels, planning stops immediately.
 
+## Plan mode
+
+Once preflight passes, `plan` switches the session into the harness plan mode via `EnterPlanMode` before any codebase exploration or plan-file write. Plan mode makes the rest of planning read-only and supplies the plan-file path — the single file the pipeline's Finalize Output writes to and that `ExitPlanMode` later reads back for approval, so `plan` no longer depends on the user having already been in plan mode. The call is idempotent (skipped when the session is already in plan mode). After the plan file is finalized and the branch block embedded, `plan` calls `ExitPlanMode` to request approval; on approval the session leaves plan mode and implementation begins.
+
+Both mode calls live in the orchestrator, deliberately **outside** the shared Stack Pipeline. `run` reuses only that pipeline and authorizes the whole flow up front, so it never enters plan mode and never calls `ExitPlanMode` — keeping the two calls out of the pipeline is what lets `run` share it without inheriting the approval gate (see [How run differs](#how-run-differs-automated-post-implementation)).
+
 ## Common Instructions
 
 Declared once and applied throughout — both the orchestrator phases and the shared pipeline reference them rather than restating them:


### PR DESCRIPTION
The `/autopilot:plan` skill now switches the session into the harness plan mode explicitly instead of assuming it was already in plan mode. It calls `EnterPlanMode` before delegating to the stack pipeline — so exploration is read-only and the harness supplies the plan-file path the pipeline writes and `ExitPlanMode` reads back — then calls `ExitPlanMode` at finalize to request approval. `/autopilot:run` is unchanged: it keeps its zero-gate contract and never enters plan mode.

- Add `EnterPlanMode` and `ExitPlanMode` to [plan/SKILL.md](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/plan/SKILL.md) `allowed-tools`
- Add an Enter Plan Mode orchestrator section that calls `EnterPlanMode` after preflight and before stack delegation (idempotent — skipped when already in plan mode)
- Make the `ExitPlanMode` approval call explicit in the Phase 2 Request Approval step
- Keep both mode calls outside the shared Stack Pipeline so `/autopilot:run` reuses the pipeline without inheriting the approval gate
- Document the plan-mode entry and exit in [docs/05-plan-run-skills.md](https://github.com/awinogradov/code-assistants/blob/main/docs/05-plan-run-skills.md)

---

**Release notes:**

- `/autopilot:plan` now enters the harness plan mode automatically and requests approval on exit, so it works without first toggling plan mode manually
- `/autopilot:run` behavior is unchanged — it still runs without a plan-approval gate

---

**Issues:**

Closes #436