### PR TITLE
Remove issue-body size caps and sharpen sections to exclude duplication

### DIFF
--- a/claude-plugins/autopilot/skills/issue:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/issue:create/SKILL.md
@@ -170,9 +170,12 @@ For each open item returned by [Phase 3](#phase-3-find-related-issues-and-prs), 
 
 Heading format MUST be exact: `## Context` (single space, no trailing colon, no bold `**Heading:**`). Reordering sections is a format violation.
 
+**Single-responsibility rule:** each section answers exactly one question and MUST NOT repeat what another section already covers — cross-reference a sibling section instead of restating it. Length follows the content: include as much context as a reader needs to act on the issue, and never cap a section at a fixed paragraph count. Do not pad — every sentence must add information.
+
 **Section 1: Context**
 
-- 1-2 paragraphs describing the situation, what work area this touches, why we're noticing it now
+- The situation and background only: the current state of the world, what work area this touches, and what surfaced it now. Do NOT state user impact or motivation (that is Why), and do NOT propose a fix (that is Solution)
+- As many paragraphs as the background genuinely needs
 - Single continuous line per paragraph (no hard-wrapping — GitHub renders single newlines as visible line breaks)
 - If [Phase 3](#phase-3-find-related-issues-and-prs) returned related items, end the section with a single `Related:` line:
   ```
@@ -182,28 +185,29 @@ Heading format MUST be exact: `## Context` (single space, no trailing colon, no 
 
 **Section 2: What**
 
-- 1 paragraph or short bullet list
-- The deliverable in plain terms — what changes when this is done
+- The deliverable: the observable end state once this is done, in plain terms. Describe WHAT changes, not HOW to achieve it (the approach is Solution)
+- A paragraph or bullet list, as long as needed to enumerate the deliverables
 - Single continuous line per item
 
 **Section 3: Why**
 
-- 1 paragraph
-- User impact / business motivation / what problem this solves
-- A reader on day one should understand
+- User impact and business motivation only: what problem this solves and the cost of leaving it unsolved
+- Assume the reader has already read Context — do NOT restate the situation
+- A reader on day one should understand the stakes
 
 **Section 4: Scope**
 
 - Bullet list with two sub-headings: `**In scope:**` and `**Out of scope:**`
+- Bound the work by referencing the What deliverables — do NOT re-describe them in full here
 - If there are no out-of-scope items, write `_None — this is the entire change._` under "Out of scope"
 - Never invent out-of-scope items just to fill the section
 
 **Section 5: Solution**
 
-- Paragraph(s) describing the high-level approach
-- **Diagram trigger rule:** invoke `Skill(autopilot:ascii-schemas)` when the Solution describes a flow between ≥ 2 components, an architectural relationship, a sequence, or a UI layout
+- The high-level approach: HOW the What gets delivered. Do NOT restate the deliverable itself (that is What)
+- As detailed as the approach warrants
+- **Diagram trigger rule:** invoke `Skill(autopilot:ascii-schemas)` whenever a diagram would aid understanding — a flow or sequence between components, an architecture or data schema, a UI layout, a comparison, or a logical relationship worth seeing at a glance. Default to including one whenever it makes the approach clearer; skip it only when prose alone is unambiguous
 - Embed the schema output verbatim in a fenced ` ```text ` block
-- Skip the diagram for pure logic/refactor issues
 
 **Linkability pass (after drafting all five sections):**
 

--- a/claude-plugins/autopilot/skills/linear:create/SKILL.md
+++ b/claude-plugins/autopilot/skills/linear:create/SKILL.md
@@ -71,13 +71,13 @@ Mirror `issue:create` so the body reflects real code, not hallucinated structure
 
 **Title:** capitalized, ≤ 80 characters, no trailing period, business-focused, NOT Conventional Commits, no prefix.
 
-**Body — section ordering is MANDATORY** (exact `## ` headings, no trailing colon, no bold). The five-section spec is canonical in [issue:create Phase 5](../issue:create/SKILL.md#phase-5-generate-body) — keep this list in sync with it:
+**Body — section ordering is MANDATORY** (exact `## ` headings, no trailing colon, no bold). The five-section spec is canonical in [issue:create Phase 5](../issue:create/SKILL.md#phase-5-generate-body) — keep this list in sync with it. Each section has one non-overlapping job and must not repeat what another covers; length follows the content, with no fixed paragraph cap:
 
-1. `## Context` — 1-2 paragraphs on the situation and why it matters now.
-2. `## What` — the deliverable in plain terms.
-3. `## Why` — user impact / business motivation.
-4. `## Scope` — a bullet list with `**In scope:**` and `**Out of scope:**` sub-headings.
-5. `## Solution` — the high-level approach. Invoke `Skill(autopilot:ascii-schemas)` for a diagram when the Solution describes a flow between ≥ 2 components; embed it verbatim in a fenced ` ```text ` block.
+1. `## Context` — the situation and background only: state of the world and what surfaced it now (not impact — that's Why; not the fix — that's Solution).
+2. `## What` — the deliverable / observable end state (not the how).
+3. `## Why` — user impact and motivation only; assumes Context, never restates it.
+4. `## Scope` — a bullet list with `**In scope:**` and `**Out of scope:**` sub-headings that reference What rather than re-describe it.
+5. `## Solution` — the high-level approach (how), not a restatement of the deliverable. Invoke `Skill(autopilot:ascii-schemas)` for a diagram whenever one would aid understanding — a flow, sequence, architecture, data schema, UI layout, comparison, or logical relationship; embed it verbatim in a fenced ` ```text ` block.
 
 After drafting, run the linkability pass from [issue:create Phase 5](../issue:create/SKILL.md#phase-5-generate-body) — every prose mention of a file or path that exists in the repo becomes an absolute `<repo-blob-url>` link, and every cited external source whose URL is in context becomes an inline `[title](url)` link; never invent a URL for an unlinkable mention.
 


### PR DESCRIPTION
The autopilot issue-generation skills capped every issue-body section at a fixed paragraph count and gave Context/Why and What/Solution overlapping jobs, so callers with rich background had to truncate it and generated bodies restated the same motivation and fix twice. This sharpens each section to a single, non-overlapping responsibility, removes the size caps so length follows the content, and broadens when a diagram should accompany the Solution.

- Removed the per-section paragraph caps in [issue:create Phase 5](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/issue:create/SKILL.md#phase-5-generate-body) and [linear:create Phase 2](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/linear:create/SKILL.md#phase-2-generate-title-and-body)
- Added a single-responsibility rule so each section covers one topic and cross-references siblings instead of repeating them
- Broadened the Solution diagram trigger so a diagram is included whenever it aids understanding — flows, sequences, architecture, data schemas, UI layouts, comparisons, or logical relationships — instead of only multi-component flows
- Redefined Context, What, Why, Scope, and Solution with explicit hand-offs; kept the five headings, their order, and the 80-character title cap unchanged

---

**Release notes:**

- Generated GitHub and Linear issues now carry as much context as the work needs — the per-section paragraph caps are gone
- Issue sections no longer duplicate each other: Context, What, Why, Scope, and Solution each have one clearly-scoped job
- Solution diagrams are now suggested for any change a diagram would clarify, not just multi-component flows

---

**Issues:**

Closes #438