### PR TITLE
Allow alternative cn() implementations in Tailwind rules

### DIFF
--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -90,7 +90,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 ### 3.3 Tailwind CSS
 
 - 👤 Use Tailwind utility classes directly in JSX via `className`
-- 👤 Use `cn()` helper (clsx + tailwind-merge) for conditional classes
+- 👤 Use a `cn()` helper for conditional, Tailwind-aware class merging with conflict resolution (e.g. `clsx` + `tailwind-merge`, or an equivalent drop-in such as `cnfast`)
 - 👤 Extract reusable components instead of `@apply` for repeated patterns
 - 👤 Use Tailwind config for design tokens (colors, spacing, typography)
 - 👤 Use responsive prefixes (`sm:`, `md:`, `lg:`) for breakpoints

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -91,7 +91,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 ### 3.3 Tailwind CSS
 
 - 👤 Use Tailwind utility classes directly in JSX via `className`
-- 👤 Use `cn()` helper (clsx + tailwind-merge) for conditional classes
+- 👤 Use a `cn()` helper for conditional, Tailwind-aware class merging with conflict resolution (e.g. `clsx` + `tailwind-merge`, or an equivalent drop-in such as `cnfast`)
 - 👤 Extract reusable components instead of `@apply` for repeated patterns
 - 👤 Use Tailwind config for design tokens (colors, spacing, typography)
 - 👤 Use responsive prefixes (`sm:`, `md:`, `lg:`) for breakpoints


### PR DESCRIPTION
The Tailwind stack rules mandated `clsx` + `tailwind-merge` as the only acceptable `cn()` implementation. Because these rules sync into downstream repos' `CLAUDE.md` and cannot be edited locally, a downstream repo that swapped to an equivalent single-package drop-in ended up with a synced rule that misdescribed its own dependency choice. This rewords the bullet to state the requirement — Tailwind-aware conditional class merging with conflict resolution — while keeping a concrete example.

- Reworded the `cn()` bullet in both Tailwind rules files to describe the behavior rather than hard-coding one library pairing
- Kept `clsx` + `tailwind-merge` and `cnfast` as examples, not as the only permitted implementation

---

**Issues:**

Closes #433
