### PR TITLE
MAINTENANCE: Retry transient GitHub errors during upstream sync

### DIFF
--- a/.github/actions/agents-rules-sync/agents-rules-sync.ts
+++ b/.github/actions/agents-rules-sync/agents-rules-sync.ts
@@ -7,9 +7,9 @@
  */
 
 import * as core from '@actions/core';
-import { Octokit } from '@octokit/rest';
 import { stringify as stringifyYaml } from 'yaml';
 
+import { createOctokit } from '@code-assistants/actions-core/createOctokit';
 import { fetchRawContent } from '@code-assistants/actions-core/fetchRawContent';
 
 import { buildSyncEntries } from './src/buildSyncEntries.ts';
@@ -96,7 +96,7 @@ function readEnv(): Env {
 
 async function main(): Promise<void> {
   const env = readEnv();
-  const octokit = new Octokit({ auth: env.token });
+  const octokit = createOctokit(env.token);
 
   const raw = await fetchRawContent({
     octokit,

--- a/.github/actions/files-sync/files-sync.ts
+++ b/.github/actions/files-sync/files-sync.ts
@@ -17,7 +17,8 @@
  */
 
 import * as core from '@actions/core';
-import { Octokit } from '@octokit/rest';
+
+import { createOctokit } from '@code-assistants/actions-core/createOctokit';
 
 import { resolveBotIdentity } from './src/botIdentity.ts';
 import { computeChanges } from './src/changeDetector.ts';
@@ -144,7 +145,7 @@ async function main(): Promise<void> {
 
   core.info(`Resolved ${entries.length} sync entr${entries.length === 1 ? 'y' : 'ies'}.`);
 
-  const octokit = new Octokit({ auth: env.token });
+  const octokit = createOctokit(env.token);
   const identity = await resolveBotIdentity(octokit, process.env.INPUT_BOT_USERNAME);
 
   const changes = await computeChanges({

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
     },
     ".github/actions/code-review-action": {
       "name": "@code-assistants/code-review-action",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.202",
         "@anthropic-ai/sdk": "0.110.0",
@@ -162,12 +162,13 @@
     },
     "claude-plugins/autopilot": {
       "name": "autopilot",
-      "version": "1.8.1",
+      "version": "1.10.0",
     },
     "packages/actions-core": {
       "name": "@code-assistants/actions-core",
       "version": "0.0.0",
       "dependencies": {
+        "@octokit/plugin-retry": "8.1.0",
         "@octokit/request-error": "7.1.0",
         "@octokit/rest": "22.0.1",
       },

--- a/packages/actions-core/package.json
+++ b/packages/actions-core/package.json
@@ -10,6 +10,7 @@
     "language": "typescript"
   },
   "exports": {
+    "./createOctokit": "./src/createOctokit.ts",
     "./fetchRawContent": "./src/fetchRawContent.ts",
     "./checkStatus": "./src/checkStatus.ts",
     "./parseRepo": "./src/parseRepo.ts",
@@ -22,6 +23,7 @@
     "clean": "rm -rf node_modules .turbo"
   },
   "dependencies": {
+    "@octokit/plugin-retry": "8.1.0",
     "@octokit/request-error": "7.1.0",
     "@octokit/rest": "22.0.1"
   },

--- a/packages/actions-core/src/createOctokit.test.ts
+++ b/packages/actions-core/src/createOctokit.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+import { createOctokit } from "./createOctokit.ts";
+
+/**
+ * Drive the client through a stubbed `fetch` rather than an Octokit hook: the retry
+ * plugin listens on the request error hook, so only a failure raised by the real
+ * transport exercises the retry path we care about.
+ */
+function stubFetch(responses: Array<() => Response>): {
+  fetch: typeof globalThis.fetch;
+  calls: () => number;
+} {
+  let calls = 0;
+
+  return {
+    fetch: (() => {
+      const next = responses[Math.min(calls, responses.length - 1)]!;
+      calls += 1;
+
+      return Promise.resolve(next());
+    }) as unknown as typeof globalThis.fetch,
+    calls: () => calls,
+  };
+}
+
+const unicornPage = () =>
+  new Response("<!DOCTYPE html>\n<html>Unicorn!</html>", {
+    status: 500,
+    headers: { "content-type": "text/html" },
+  });
+
+const rawFile = () =>
+  new Response("# Rules\n", { status: 200, headers: { "content-type": "text/plain" } });
+
+const contentsRoute = "GET /repos/{owner}/{repo}/contents/{path}";
+const route = { owner: "awinogradov", repo: "code-assistants", path: "CLAUDE.md" };
+
+// plugin-retry backs off for `(retryCount + 1) ** 2` seconds on a 5xx and offers no
+// per-request knob to shorten it, so the 5xx cases allow a single retry (one ~1s wait)
+// to stay well inside the default test timeout. The 404 case must NOT set `retries`:
+// an explicit budget makes Bottleneck retry regardless of status, which would bypass
+// the very `doNotRetry` default the test is pinning.
+const singleRetry = { retries: 1 };
+
+describe("createOctokit", () => {
+  test("retries a transient 5xx and returns the eventual success", async () => {
+    const transport = stubFetch([unicornPage, rawFile]);
+    const octokit = createOctokit("token");
+
+    const response = await octokit.request(contentsRoute, {
+      ...route,
+      request: { fetch: transport.fetch, ...singleRetry },
+    });
+
+    expect(transport.calls()).toBe(2);
+    expect(response.status).toBe(200);
+    // The contents route is typed as structured JSON; `Accept: raw` hands back a plain body.
+    expect(String(response.data)).toBe("# Rules\n");
+  });
+
+  test("does not retry a 404 — a genuinely missing file fails fast", async () => {
+    const transport = stubFetch([
+      () =>
+        new Response(JSON.stringify({ message: "Not Found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        }),
+    ]);
+    const octokit = createOctokit("token");
+
+    await expect(
+      octokit.request(contentsRoute, {
+        ...route,
+        request: { fetch: transport.fetch },
+      }),
+    ).rejects.toThrow("Not Found");
+
+    expect(transport.calls()).toBe(1);
+  });
+
+  test("gives up after the retry budget and surfaces the last failure", async () => {
+    const transport = stubFetch([unicornPage]);
+    const octokit = createOctokit("token");
+
+    await expect(
+      octokit.request(contentsRoute, {
+        ...route,
+        request: { fetch: transport.fetch, ...singleRetry },
+      }),
+    ).rejects.toMatchObject({ status: 500 });
+
+    expect(transport.calls()).toBe(2);
+  });
+});

--- a/packages/actions-core/src/createOctokit.ts
+++ b/packages/actions-core/src/createOctokit.ts
@@ -1,0 +1,23 @@
+/**
+ * Build an authenticated Octokit client that retries transient GitHub failures.
+ *
+ * GitHub occasionally answers a perfectly valid API call with a 5xx (the "Unicorn"
+ * error page) or drops the connection. A single such blip is enough to fail an
+ * entire scheduled sync run, so every client that talks to the API on an
+ * unattended code path should be built here rather than with a bare `new Octokit`.
+ * The retry plugin backs off and re-issues the request; it deliberately does not
+ * retry 4xx statuses, so a genuine 404 still surfaces immediately.
+ *
+ * @example
+ *   const octokit = createOctokit(token);
+ *   await octokit.rest.repos.getCommit({ owner, repo, ref });
+ */
+
+import { retry } from "@octokit/plugin-retry";
+import { Octokit } from "@octokit/rest";
+
+const RetryingOctokit = Octokit.plugin(retry);
+
+export function createOctokit(token: string): Octokit {
+  return new RetryingOctokit({ auth: token });
+}

--- a/packages/actions-core/src/fetchRawContent.test.ts
+++ b/packages/actions-core/src/fetchRawContent.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Octokit } from "@octokit/rest";
+
+import { fetchRawContent } from "./fetchRawContent.ts";
+
+const args = {
+  owner: "awinogradov",
+  repo: "code-assistants",
+  path: "CLAUDE.md",
+  ref: "main",
+};
+
+function octokitThrowing(error: unknown): Octokit {
+  return {
+    request: () => Promise.reject(error),
+  } as unknown as Octokit;
+}
+
+function octokitReturning(data: unknown): Octokit {
+  return {
+    request: () => Promise.resolve({ data }),
+  } as unknown as Octokit;
+}
+
+async function captureFailure(octokit: Octokit): Promise<Error> {
+  try {
+    await fetchRawContent({ octokit, ...args });
+  } catch (error) {
+    return error as Error;
+  }
+
+  throw new Error("Expected fetchRawContent to reject");
+}
+
+describe("fetchRawContent", () => {
+  test("returns the raw file body", async () => {
+    const content = await fetchRawContent({ octokit: octokitReturning("# Rules\n"), ...args });
+
+    expect(content).toBe("# Rules\n");
+  });
+
+  test("returns null when the file is missing", async () => {
+    const error = Object.assign(new Error("Not Found"), { status: 404 });
+    const content = await fetchRawContent({ octokit: octokitThrowing(error), ...args });
+
+    expect(content).toBeNull();
+  });
+
+  test("summarizes a 5xx HTML error page instead of dumping it", async () => {
+    // GitHub's "Unicorn" page: Octokit lifts the whole document into `message`.
+    const htmlPage = `<!DOCTYPE html>\n<html>\n${"  <p>padding</p>\n".repeat(50)}</html>`;
+    const error = Object.assign(new Error(htmlPage), { status: 500 });
+
+    const failure = await captureFailure(octokitThrowing(error));
+
+    expect(failure.message).toStartWith(
+      "Failed to fetch awinogradov/code-assistants:CLAUDE.md@main: HTTP 500: <!DOCTYPE html>",
+    );
+    expect(failure.message).not.toInclude("padding");
+    expect(failure.message.split("\n")).toHaveLength(1);
+  });
+
+  test("truncates an over-long single-line message", async () => {
+    const error = Object.assign(new Error("x".repeat(500)), { status: 502 });
+
+    const failure = await captureFailure(octokitThrowing(error));
+
+    expect(failure.message).toInclude("HTTP 502: ");
+    expect(failure.message).toEndWith("…");
+    expect(failure.message.length).toBeLessThan(300);
+  });
+
+  test("keeps a statusless error message intact", async () => {
+    const failure = await captureFailure(octokitReturning({ notAString: true }));
+
+    expect(failure.message).toBe(
+      "Failed to fetch awinogradov/code-assistants:CLAUDE.md@main: Expected raw string content from awinogradov/code-assistants:CLAUDE.md@main, got object",
+    );
+  });
+});

--- a/packages/actions-core/src/fetchRawContent.ts
+++ b/packages/actions-core/src/fetchRawContent.ts
@@ -24,6 +24,28 @@ interface FetchRawContentArgs {
   ref?: string;
 }
 
+const maxDetailLength = 200;
+
+/**
+ * Condense an Octokit error into one short line.
+ *
+ * A GitHub 5xx answers with a full HTML error page, and Octokit lifts that whole
+ * page into `error.message` — which then floods the Actions annotation and buries
+ * the only part that matters, the status code. Lead with the status and keep just
+ * the head of the body.
+ */
+function summarizeRequestError(error: RequestError): string {
+  const firstLine = (error.message ?? '').split('\n')[0]?.trim() ?? '';
+  const detail =
+    firstLine.length > maxDetailLength ? `${firstLine.slice(0, maxDetailLength)}…` : firstLine;
+
+  if (typeof error.status !== 'number') {
+    return detail === '' ? 'request failed' : detail;
+  }
+
+  return detail === '' ? `HTTP ${error.status}` : `HTTP ${error.status}: ${detail}`;
+}
+
 export async function fetchRawContent({
   octokit,
   owner,
@@ -58,7 +80,7 @@ export async function fetchRawContent({
     }
 
     throw new Error(
-      `Failed to fetch ${owner}/${repo}:${path}${ref ? `@${ref}` : ''}: ${requestError.message}`,
+      `Failed to fetch ${owner}/${repo}:${path}${ref ? `@${ref}` : ''}: ${summarizeRequestError(requestError)}`,
     );
   }
 }


### PR DESCRIPTION
The scheduled `Upstream` sync fails outright whenever GitHub answers a perfectly valid Contents API call with a 5xx. [Run 29180945399](https://github.com/awinogradov/code-assistants/actions/runs/29180945399) died exactly this way: the fetch of `CLAUDE.md@main` came back as GitHub's "Unicorn!" HTML error page, and since nothing on the sync path retries, one blip took down the whole run. Every neighbouring hourly run succeeded, so this was never a logic bug — just an unretried transient.

[`fetchRawContent`](https://github.com/awinogradov/code-assistants/blob/main/packages/actions-core/src/fetchRawContent.ts) treats only a 404 as recoverable and rethrows everything else immediately, and both sync entrypoints built their client with a bare `new Octokit`. `@octokit/plugin-retry` was already a proven dependency in [`code-review-cost-monitor`](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/code-review-cost-monitor/src/collectRuns.ts) — it just was not wired into the sync path.

- Add a shared `createOctokit` factory in `actions-core` that wires in `@octokit/plugin-retry`, so a 5xx or dropped connection backs off and retries instead of failing the job. The plugin's `doNotRetry` defaults are left intact, so a genuine 404 still surfaces immediately and a missing source file fails as fast as before.
- Build the [`files-sync`](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/files-sync/files-sync.ts) and [`agents-rules-sync`](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/agents-rules-sync/agents-rules-sync.ts) clients through that factory. Every call they make — contents, trees, blobs, commits, PR creation — now inherits the retries, not just the fetch that happened to fail this time.
- Condense a failed request to its status plus the first 200 characters of the body. Octokit lifts the entire HTML error page into `error.message`, which is why the annotation on the failed run is an unreadable wall of markup that buries the only useful detail, the status code.

Verified with 121 tests across the three touched packages and a clean typecheck. The new tests drive a stubbed transport so they exercise the real retry path: a 5xx retries and then succeeds, a 404 does not retry, and an exhausted budget still surfaces the last failure.

---

**Release notes:**

- The upstream sync now retries transient GitHub 5xx failures instead of failing the run on a single blip.
- Sync failures now report the HTTP status and a short excerpt rather than dumping a full HTML error page into the job annotation.