### PR TITLE
Keep Auto label green when GitHub returns a transient 502

### DIFF
--- a/.github/actions/auto-label/src/autoLabel.ts
+++ b/.github/actions/auto-label/src/autoLabel.ts
@@ -6,8 +6,8 @@
  * All inputs/payloads are validated before any label is mutated.
  */
 import * as core from "@actions/core";
-import { Octokit } from "@octokit/rest";
 
+import { createOctokit } from "@code-assistants/actions-core/createOctokit";
 import { parseRepo } from "@code-assistants/actions-core/parseRepo";
 
 import { deriveLabelPrefix } from "./enumerateWorkspaces.ts";
@@ -76,7 +76,7 @@ async function run(): Promise<void> {
   const { owner, repo } = parseRepo(requireEnv("GITHUB_REPOSITORY"));
   const prefixOverride = (process.env.LABEL_PREFIX ?? "").trim();
 
-  const api = createGitHubApi(new Octokit({ auth: token }), owner, repo);
+  const api = createGitHubApi(createOctokit(token), owner, repo);
 
   if (eventName === "pull_request") {
     await runPullRequest(api, prefixOverride);

--- a/.github/actions/auto-label/src/githubApi.ts
+++ b/.github/actions/auto-label/src/githubApi.ts
@@ -5,7 +5,7 @@
  * `null` on 404) to read `package.json` at a ref — no checkout or `git` required.
  *
  * @example
- *   const api = createGitHubApi(new Octokit({ auth: token }), owner, repo);
+ *   const api = createGitHubApi(createOctokit(token), owner, repo);
  *   const pkg = await api.readPackageJson(".github/actions/files-sync", headSha);
  */
 import { Octokit } from "@octokit/rest";

--- a/.github/actions/code-review-action/src/github/githubReview.ts
+++ b/.github/actions/code-review-action/src/github/githubReview.ts
@@ -5,7 +5,8 @@
  * @example
  * import { fetchReviewThreads, resolveThread, parseRepoEnv } from "./github/githubReview.ts";
  */
-import { Octokit } from "@octokit/rest";
+import { createOctokit } from "@code-assistants/actions-core/createOctokit";
+import type { Octokit } from "@octokit/rest";
 
 import { stripReviewTips } from "../reviewTip.ts";
 import { stripLegacyUsageHint, stripRunSummaryFooter } from "../runSummaryFooter.ts";
@@ -165,7 +166,7 @@ export function parseRepoEnv(): RepoEnv {
   }
 
   return {
-    octokit: new Octokit({ auth: token }),
+    octokit: createOctokit(token),
     owner,
     repoName,
     pullNumber: Number(prNumber),

--- a/.github/actions/release-automerge/src/automerge.ts
+++ b/.github/actions/release-automerge/src/automerge.ts
@@ -15,10 +15,11 @@
  * GH_TOKEN=xxx REPO=owner/repo HEAD_SHA=abc JOB_NAME=automerge bun run src/automerge.ts
  */
 import { fetchCheckStatuses, pollCheckStatuses } from "@code-assistants/actions-core/checkStatus";
+import { createOctokit } from "@code-assistants/actions-core/createOctokit";
 import { fetchRawContent } from "@code-assistants/actions-core/fetchRawContent";
 import { parseRepo } from "@code-assistants/actions-core/parseRepo";
 import { readRootRelease } from "@code-assistants/actions-core/releaseField";
-import { Octokit } from "@octokit/rest";
+import type { Octokit } from "@octokit/rest";
 
 /** Minimal PR shape needed to pick the release PR for a commit. */
 export interface PrRef {
@@ -44,6 +45,10 @@ const rootPackageJsonPath = "package.json";
 const releaseNotesFile = /(?:^|\/)\.release_notes\/[^/]+\.md$/;
 // GitHub merge-API responses that mean "nothing to do" rather than a real error:
 // 405 not mergeable / already merged, 409 head SHA moved (sha mismatch), 422 unprocessable.
+// The retrying client (createOctokit) does not fast-fail 405/409 — only 422 is in
+// plugin-retry's doNotRetry list — so those two surface here after ~14s of backoff.
+// That is intended: GitHub computes mergeability asynchronously, so a 405 often clears
+// on retry, and the skip below stays correct either way.
 const idempotentMergeStatuses = new Set([405, 409, 422]);
 // An approval usually triggers this action while CI is still running, and GitHub
 // does not redeliver `check_suite` events for `GITHUB_TOKEN` check suites — so no
@@ -75,7 +80,7 @@ function parseEnv(): AutomergeConfig {
 
   const { owner, repo } = parseRepo(repository);
 
-  return { octokit: new Octokit({ auth: token }), owner, repo, headSha, jobName };
+  return { octokit: createOctokit(token), owner, repo, headSha, jobName };
 }
 
 /** Pick the open release PR (head ref `^release-`) from commit-associated PRs. */

--- a/packages/actions-core/src/octokitConstruction.test.ts
+++ b/packages/actions-core/src/octokitConstruction.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Guards the rule that `createOctokit` exists to enforce: every action client is built
+ * through it, never with a bare `new Octokit`. A bare client carries no retry policy, so
+ * a single transient GitHub 5xx fails the whole job with no recovery path — auto-label
+ * red-checked a PR four times over that, surviving three reruns and a dependabot recreate
+ * (issue #450). The retry plugin lives in `createOctokit`, so bypassing it silently opts
+ * an action out of the fix.
+ *
+ * The check covers doc comments too, not just code: the auto-label bug propagated through
+ * a stale `@example` in `githubApi.ts` that showed the bare form for a contributor to copy.
+ */
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+const repoRoot = join(import.meta.dirname, "..", "..", "..");
+const actionsDir = join(repoRoot, ".github/actions");
+
+// Each action installs its own node_modules, and the vendored Octokit sources are full of
+// `new Octokit(` — walking into them would fail this test against our own dependencies.
+const prunedDirs = new Set(["node_modules", "dist"]);
+
+const bareOctokit = /new\s+Octokit\s*\(/;
+
+async function collectSources(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (!prunedDirs.has(entry.name)) {
+        files.push(...(await collectSources(path)));
+      }
+      continue;
+    }
+    // Tests may legitimately construct a client; only shipped action code is bound by the rule.
+    if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      files.push(path);
+    }
+  }
+
+  return files;
+}
+
+describe("octokit construction", () => {
+  test("no action builds a bare Octokit — all clients go through createOctokit", async () => {
+    const sources = await collectSources(actionsDir);
+    expect(sources.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const path of sources) {
+      const content = await readFile(path, "utf8");
+      if (bareOctokit.test(content)) {
+        offenders.push(path.slice(repoRoot.length + 1));
+      }
+    }
+
+    expect(
+      offenders,
+      `Build the client with createOctokit(token) from @code-assistants/actions-core/createOctokit — a bare "new Octokit" has no retry policy and dies on a transient GitHub 5xx:\n${offenders.map((file) => `  - ${file}`).join("\n")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
A transient GitHub 502 permanently failed the Auto label check on wefortis/fortune-os#172: it survived three job reruns and a full `@dependabot recreate`, each time on a different file, so the PR had to be merged with a red check. The cause is that `auto-label` built a bare `new Octokit`, bypassing the retry-wrapped client this repo already ships.

- [autoLabel.ts](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/auto-label/src/autoLabel.ts), [automerge.ts](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/release-automerge/src/automerge.ts) and [githubReview.ts](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/code-review-action/src/github/githubReview.ts) now build their client with [createOctokit](https://github.com/awinogradov/code-assistants/blob/main/packages/actions-core/src/createOctokit.ts), removing the last bare clients left behind by [63e8289](https://github.com/awinogradov/code-assistants/commit/63e8289), which added the helper and moved `files-sync` and `agents-rules-sync` onto it. One duplicate remains — `code-review-cost-monitor` reimplements the helper locally as `createRetryingOctokit` rather than importing it; that is tracked in 454 and is out of scope here.
- Note for the reviewer: issue 450 proposed a retry loop inside [fetchRawContent.ts](https://github.com/awinogradov/code-assistants/blob/main/packages/actions-core/src/fetchRawContent.ts). That premise predates [63e8289](https://github.com/awinogradov/code-assistants/commit/63e8289). A second loop would duplicate the plugin, compound retries in the two sync actions that already retry at the transport layer, and still leave auto-label's non-contents calls unprotected — so this reuses `createOctokit` instead and `fetchRawContent` is unchanged. Its 404 → `null` contract is preserved because 404 sits in the plugin's `doNotRetry` list.
- A new `octokitConstruction.test.ts` guard in `actions-core` fails, naming the file, if any action reintroduces a bare `new Octokit` — including in a JSDoc `@example`, which is how the anti-pattern propagated into [githubApi.ts](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/auto-label/src/githubApi.ts).
- Behavior change worth knowing: `plugin-retry` does not fast-fail 405/409, and `release-automerge` treats those as idempotent merge no-ops. They now surface after ~14s of backoff instead of immediately. The outcome is identical, it is far inside the action's existing 480s poll budget, and a 405 is often transient anyway since GitHub computes mergeability asynchronously.

No dependency changes: all three actions already depend on `@code-assistants/actions-core`, which already ships `@octokit/plugin-retry`.

---

**Release notes:**

- Auto label, release-automerge and code review no longer fail a job when GitHub returns a transient 5xx or 429 — the request is retried with backoff instead.

---

**Issues:**

Closes #450
