### PR TITLE
Dedupe the retrying Octokit client in code-review-cost-monitor

### DIFF
--- a/.github/actions/code-review-cost-monitor/package.json
+++ b/.github/actions/code-review-cost-monitor/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@actions/core": "3.0.1",
     "@code-assistants/actions-core": "workspace:*",
-    "@octokit/plugin-retry": "8.1.0",
     "@octokit/rest": "22.0.1",
     "zod": "4.4.3"
   },

--- a/.github/actions/code-review-cost-monitor/src/collectRuns.ts
+++ b/.github/actions/code-review-cost-monitor/src/collectRuns.ts
@@ -4,23 +4,22 @@
  *
  * Walks pull requests by `updated` descending and stops paginating once a page
  * falls fully outside the lookback window, then parses every review body via
- * `parseFooterMetrics`. The Octokit instance is injected so tests mock it;
- * `createRetryingOctokit` wires `@octokit/plugin-retry` so a transient 5xx or
- * secondary rate limit doesn't redden a scheduled run. Failure semantics are
- * deliberate: an API error (after retries) throws, and so does a scan where at
- * least `minRuns` reviews carry a run-summary data comment yet none parse —
- * genuine format drift. A window with too few footers to judge degrades to an
- * empty result instead, mirroring the `minRuns` gate, so a newly-adopting or
+ * `parseFooterMetrics`. The Octokit instance is injected so tests mock it; build
+ * it with actions-core's `createOctokit`, which wires `@octokit/plugin-retry` so
+ * a transient 5xx or secondary rate limit doesn't redden a scheduled run. Failure
+ * semantics are deliberate: an API error (after retries) throws, and so does a
+ * scan where at least `minRuns` reviews carry a run-summary data comment yet none
+ * parse — genuine format drift. A window with too few footers to judge degrades to
+ * an empty result instead, mirroring the `minRuns` gate, so a newly-adopting or
  * quiet repo never reddens its scheduled run.
  *
  * @example
- * const octokit = createRetryingOctokit(token);
+ * const octokit = createOctokit(token);
  * const { runs, scannedReviews } = await collectRuns(octokit, {
  *   owner, repo, lookbackDays: 30, now: new Date(), minRuns: 8,
  * });
  */
-import { retry } from "@octokit/plugin-retry";
-import { Octokit } from "@octokit/rest";
+import type { Octokit } from "@octokit/rest";
 
 import type { RunMetrics } from "./footerMetrics.ts";
 import { hasRunSummaryData, parseFooterMetrics } from "./footerMetrics.ts";
@@ -71,12 +70,6 @@ export class FooterDriftError extends Error {
     );
     this.name = "FooterDriftError";
   }
-}
-
-/** Build an authenticated Octokit with transient-failure retries wired in. */
-export function createRetryingOctokit(token: string): Octokit {
-  const RetryingOctokit = Octokit.plugin(retry);
-  return new RetryingOctokit({ auth: token });
 }
 
 /**

--- a/.github/actions/code-review-cost-monitor/src/costMonitor.ts
+++ b/.github/actions/code-review-cost-monitor/src/costMonitor.ts
@@ -15,11 +15,12 @@
 import { mkdir } from "node:fs/promises";
 
 import { setOutput } from "@actions/core";
+import { createOctokit } from "@code-assistants/actions-core/createOctokit";
 import { parseRepo } from "@code-assistants/actions-core/parseRepo";
 import { z } from "zod";
 
 import { buildAttributionPrompt, buildReport } from "./buildReport.ts";
-import { collectRuns, createRetryingOctokit } from "./collectRuns.ts";
+import { collectRuns } from "./collectRuns.ts";
 import type { ThresholdConfig } from "./evaluateThresholds.ts";
 import { evaluateThresholds } from "./evaluateThresholds.ts";
 
@@ -84,7 +85,7 @@ export function parseMonitorConfig(env: Record<string, string | undefined>): Mon
 
 async function run(): Promise<void> {
   const config = parseMonitorConfig(process.env);
-  const octokit = createRetryingOctokit(config.token);
+  const octokit = createOctokit(config.token);
   const now = new Date();
 
   const collected = await collectRuns(octokit, {

--- a/.github/actions/code-review-cost-monitor/src/reportIssue.ts
+++ b/.github/actions/code-review-cost-monitor/src/reportIssue.ts
@@ -15,10 +15,9 @@
  */
 import { notice, setOutput, summary } from "@actions/core";
 import type { Octokit } from "@octokit/rest";
+import { createOctokit } from "@code-assistants/actions-core/createOctokit";
 import { parseRepo } from "@code-assistants/actions-core/parseRepo";
 import { z } from "zod";
-
-import { createRetryingOctokit } from "./collectRuns.ts";
 
 /** HTML marker identifying cost-report issues and comments for dedup. */
 export const reportMarker = "<!-- code-review-cost-report -->";
@@ -176,7 +175,7 @@ async function run(): Promise<void> {
   const report = await Bun.file(env.REPORT_FILE).text();
   const attribution = parseAttribution(env.ATTRIBUTION_REQUESTED === "true", env.ATTRIBUTION_JSON);
 
-  const result = await postReport(createRetryingOctokit(env.GH_TOKEN), {
+  const result = await postReport(createOctokit(env.GH_TOKEN), {
     owner,
     repo,
     issueLabel: env.ISSUE_LABEL,

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     ".github/actions/agents-rules-sync": {
       "name": "@code-assistants/agents-rules-sync-action",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@actions/core": "3.0.1",
         "@code-assistants/actions-core": "workspace:*",
@@ -51,7 +51,7 @@
     },
     ".github/actions/code-review-action": {
       "name": "@code-assistants/code-review-action",
-      "version": "1.6.3",
+      "version": "1.7.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.202",
         "@anthropic-ai/sdk": "0.110.0",
@@ -72,7 +72,6 @@
       "dependencies": {
         "@actions/core": "3.0.1",
         "@code-assistants/actions-core": "workspace:*",
-        "@octokit/plugin-retry": "8.1.0",
         "@octokit/rest": "22.0.1",
         "zod": "4.4.3",
       },
@@ -83,7 +82,7 @@
     },
     ".github/actions/files-sync": {
       "name": "@code-assistants/files-sync-action",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@actions/core": "3.0.1",
         "@code-assistants/actions-core": "workspace:*",

--- a/packages/actions-core/src/octokitConstruction.test.ts
+++ b/packages/actions-core/src/octokitConstruction.test.ts
@@ -8,6 +8,12 @@
  *
  * The check covers doc comments too, not just code: the auto-label bug propagated through
  * a stale `@example` in `githubApi.ts` that showed the bare form for a contributor to copy.
+ *
+ * It also rejects `Octokit.plugin(` — an action that plugs the retry plugin itself ends up
+ * constructing `new RetryingOctokit(`, which the bare-client pattern never matches. That is
+ * how code-review-cost-monitor's private `createRetryingOctokit` copy escaped both the guard
+ * and the grep that was meant to find it (issue #454). The one legitimate `Octokit.plugin`
+ * call lives in `createOctokit`, inside actions-core — outside the walked tree.
  */
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
@@ -21,7 +27,15 @@ const actionsDir = join(repoRoot, ".github/actions");
 // `new Octokit(` — walking into them would fail this test against our own dependencies.
 const prunedDirs = new Set(["node_modules", "dist"]);
 
-const bareOctokit = /new\s+Octokit\s*\(/;
+// Two ways to end up with a client actions-core does not own: construct it bare, or plug the
+// retry plugin locally and construct the resulting class under any name.
+const forbiddenConstruction: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /new\s+Octokit\s*\(/, reason: 'a bare "new Octokit" has no retry policy' },
+  {
+    pattern: /Octokit\.plugin\s*\(/,
+    reason: 'a local "Octokit.plugin" duplicates the shared retry policy',
+  },
+];
 
 async function collectSources(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -46,21 +60,23 @@ async function collectSources(dir: string): Promise<string[]> {
 }
 
 describe("octokit construction", () => {
-  test("no action builds a bare Octokit — all clients go through createOctokit", async () => {
+  test("no action builds its own Octokit — all clients go through createOctokit", async () => {
     const sources = await collectSources(actionsDir);
     expect(sources.length).toBeGreaterThan(0);
 
     const offenders: string[] = [];
     for (const path of sources) {
       const content = await readFile(path, "utf8");
-      if (bareOctokit.test(content)) {
-        offenders.push(path.slice(repoRoot.length + 1));
+      for (const { pattern, reason } of forbiddenConstruction) {
+        if (pattern.test(content)) {
+          offenders.push(`${path.slice(repoRoot.length + 1)} — ${reason}`);
+        }
       }
     }
 
     expect(
       offenders,
-      `Build the client with createOctokit(token) from @code-assistants/actions-core/createOctokit — a bare "new Octokit" has no retry policy and dies on a transient GitHub 5xx:\n${offenders.map((file) => `  - ${file}`).join("\n")}`,
+      `Build the client with createOctokit(token) from @code-assistants/actions-core/createOctokit, which owns the one retry policy:\n${offenders.map((offender) => `  - ${offender}`).join("\n")}`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
[collectRuns.ts](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/code-review-cost-monitor/src/collectRuns.ts) shipped its own `createRetryingOctokit` — a byte-equivalent copy of [createOctokit](https://github.com/awinogradov/code-assistants/blob/main/packages/actions-core/src/createOctokit.ts) in an action that already depends on `actions-core`. Two copies of one retry policy drift apart, and the second copy is invisible to anyone grepping for `createOctokit` or `new Octokit`. Surfaced in review of PR #453.

- `collectRuns`, `costMonitor` and `reportIssue` now build the client with the shared `createOctokit`; the local factory is deleted and the direct `@octokit/plugin-retry` dependency it existed to feed is dropped from the action's `package.json`.
- The construction guard in `actions-core` now also rejects `Octokit.plugin(`, not just `new Octokit(`. This is the fix that matters most: an action that plugs the retry plugin itself constructs `new RetryingOctokit(`, which the bare-client pattern never matched — that is precisely how this duplicate escaped both the guard added in PR #453 and the grep that was meant to find it. `actions-core` keeps the one legitimate `Octokit.plugin` call and sits outside the walked tree.
- No behavior change. The local copy already retried correctly; it is the same plugin with the same defaults. This removes the duplication, not a defect.

Verified by reintroducing a probe file containing `Octokit.plugin(retry)` — the widened guard fails on it by name, so the blind spot is provably closed rather than assumed closed. Cost-monitor tests (50) and actions-core tests (65) pass; typecheck clean.

The two prettier warnings on `costMonitor.ts` and `reportIssue.ts` are pre-existing drift on `main` (confirmed by stashing), and `.ts` is not format-enforced here — left untouched to avoid whole-file reformat noise.

---

**Release notes:**

- code-review-cost-monitor now uses the shared retrying GitHub client instead of its own copy, so the retry policy is defined in exactly one place.

---

**Issues:**

Closes #454
