### PR TITLE
Enforce the plan skill for all planning in stack rules and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Thank you for your interest in contributing! This guide will help you get starte
 - [Code of Conduct](#code-of-conduct)
 - [Quick Start](#quick-start)
 - [How to Contribute](#how-to-contribute)
+- [Planning](#planning)
 - [Git Workflow](#git-workflow)
 - [PR Guidelines](#pr-guidelines)
 - [Code Standards](#code-standards)
@@ -59,6 +60,13 @@ Use [README.md](./README.md) for development setup instructions.
 2. Make your changes following [code standards](#code-standards).
 3. Write tests for new functionality.
 4. Submit a PR following the [PR guidelines](#pr-guidelines).
+
+## Planning
+
+Before writing code, plan the change: gather context, define verifiable success criteria, and outline the implementation steps so the approach is reviewable before any code exists.
+
+> [!TIP]
+> Use the `/autopilot:plan` slash command to research, draft, and validate an implementation plan before writing code.
 
 ## Git Workflow
 

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -46,7 +46,7 @@ Before making any changes:
 - 👤 Write failing tests first, then write code to pass tests
 - 👤 Run tests after any code changes
 - 👤 Do not remove existing code/comments unless necessary
-- 👤 Write plan before changes, not report after
+- 👤 Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
 
 ## 2. Architecture
 
@@ -364,6 +364,7 @@ Choose ONE backend based on the project's needs. Do not mix.
 - 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch:create)`
 - 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 - 👤 No raw `gh issue create` — use `Skill(autopilot:issue:create)`
+- 👤 No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
@@ -386,6 +387,7 @@ Choose ONE backend based on the project's needs. Do not mix.
 - 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch:create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 - 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr:create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 - 👤 **MANDATORY**: Create issues only via `Skill(autopilot:issue:create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -44,7 +44,7 @@ Before making any changes:
 - 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - 👤 Be consistent with existing code style
 - 👤 Do not remove existing code/comments unless necessary
-- 👤 Write plan before changes, not report after
+- 👤 Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
 
 ## 2. Architecture
 
@@ -237,6 +237,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch:create)`
 - 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 - 👤 No raw `gh issue create` — use `Skill(autopilot:issue:create)`
+- 👤 No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
@@ -258,6 +259,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch:create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 - 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr:create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 - 👤 **MANDATORY**: Create issues only via `Skill(autopilot:issue:create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -46,7 +46,7 @@ Before making any changes:
 - 👤 Write failing tests first, then write code to pass tests
 - 👤 Run tests after any code changes
 - 👤 Do not remove existing code/comments unless necessary
-- 👤 Write plan before changes, not report after
+- 👤 Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
 
 ## 2. Architecture
 
@@ -355,6 +355,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch:create)`
 - 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 - 👤 No raw `gh issue create` — use `Skill(autopilot:issue:create)`
+- 👤 No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
@@ -377,6 +378,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch:create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 - 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr:create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 - 👤 **MANDATORY**: Create issues only via `Skill(autopilot:issue:create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -46,7 +46,7 @@ Before making any changes:
 - 👤 Write failing tests first, then write code to pass tests
 - 👤 Run tests after any code changes
 - 👤 Do not remove existing code/comments unless necessary
-- 👤 Write plan before changes, not report after
+- 👤 Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
 
 ## 2. Architecture
 
@@ -352,6 +352,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch:create)`
 - 👤 No raw `gh pr create` — use `Skill(autopilot:pr:create)`
 - 👤 No raw `gh issue create` — use `Skill(autopilot:issue:create)`
+- 👤 No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
@@ -374,6 +375,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch:create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 - 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr:create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 - 👤 **MANDATORY**: Create issues only via `Skill(autopilot:issue:create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- 👤 **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 


### PR DESCRIPTION
Route every planning context in the four stack rule files to the autopilot plan skill, and add a Planning section to the contributing guide so the plugin-absent fallback resolves. This closes the one workflow gap where planning was not enforced through its skill the way commit/branch/PR/issue already are.

- Add a MANDATORY §16.1 directive and a §14 anti-pattern for `Skill(autopilot:plan)` to all four `rules/*.md` files
- Rewire the §1 "Write plan before changes" core principle to route to the plan skill
- Add a Planning section to [CONTRIBUTING.md](https://github.com/awinogradov/code-assistants/blob/main/CONTRIBUTING.md) referencing the /autopilot:plan slash command, mirroring the existing branch/commit/PR tips
- Leave the byte-synced Mandatory Context and §15 Git Workflow sections untouched so the rules-sync guard stays green

---

**Issues:**

Closes #468
