### PR TITLE
MAINTENANCE: Revert workflow_run trigger for AI review

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -177,38 +177,8 @@ runs:
         EVENT_REVIEW_AUTHOR: ${{ github.event.review.user.login }}
         REVIEW_BODY_RAW: ${{ github.event.review.body }}
         EVENT_SENDER: ${{ github.event.sender.login }}
-        # workflow_run (review): the PR gate finished. The payload carries the head SHA
-        # and the associated PR array (empty for fork PRs — resolved via gh below).
-        EVENT_WR_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-        EVENT_WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         GH_TOKEN: ${{ inputs.bot_token }}
       run: |
-        # Normalize a workflow_run (PR gate completed) into the pull_request review
-        # path: resolve the PR's fields once via gh, then rewrite EVENT_NAME so every
-        # downstream branch (draft-skip, release-branch, bot-author, dependabot, the
-        # review-mode detection) works unchanged. github.event.pull_request is absent
-        # under workflow_run, so these must come from gh, not the payload.
-        if [[ "$EVENT_NAME" == "workflow_run" ]]; then
-          WR_PR="$EVENT_WR_PR_NUMBER"
-          if [[ -z "$WR_PR" ]]; then
-            # Fork PRs omit pull_requests[]; resolve from the head SHA.
-            WR_PR=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${EVENT_WR_HEAD_SHA}/pulls" \
-              --jq '.[0].number // ""' 2>/dev/null || echo "")
-          fi
-          if [[ -z "$WR_PR" ]]; then
-            echo "Skipping: workflow_run has no associated PR"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          WR_JSON=$(gh pr view "$WR_PR" --json isDraft,headRefName,headRefOid,author 2>/dev/null || echo '{}')
-          EVENT_PR_NUMBER="$WR_PR"
-          EVENT_PR_HEAD_SHA="${EVENT_WR_HEAD_SHA:-$(jq -r '.headRefOid // ""' <<<"$WR_JSON")}"
-          EVENT_PR_DRAFT=$(jq -r '.isDraft // false' <<<"$WR_JSON")
-          EVENT_PR_HEAD_REF=$(jq -r '.headRefName // ""' <<<"$WR_JSON")
-          EVENT_PR_AUTHOR=$(jq -r '.author.login // ""' <<<"$WR_JSON")
-          EVENT_NAME="pull_request"
-        fi
-
         # Skip draft PRs (covers pull_request and pull_request_review_comment events)
         if [[ "$EVENT_PR_DRAFT" == "true" ]]; then
           echo "Skipping: draft PR"

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -3,11 +3,6 @@
 # Edits made downstream are overwritten on the next run.
 # To change it, open a pull request against the source file above.
 #
-# Repository requirements:
-#   - The repo's PR quality-gate workflow MUST be named `PR` (`name: PR`). Review runs
-#     event-driven off its completion via `on: workflow_run`, and GitHub does not allow
-#     an expression in `on.workflow_run.workflows`, so the name is hardcoded below.
-#
 # Repository variables consumed by this workflow:
 #   - `BOT_USERNAME` (required): GitHub login of the AI reviewer bot. Without this the
 #     `ai-review` job is skipped entirely.
@@ -19,15 +14,8 @@
 name: AI Code Review
 
 on:
-  # Review runs AFTER the PR gate completes, not on every push — the review no longer
-  # polls sibling checks (the old `pull_request` trigger + a 600s preflight budget that
-  # raced the gate's wall clock and flapped red on timeout). `workflows: [PR]` keys off
-  # the repo's quality-gate workflow; the job `if:` requires it to have concluded
-  # `success` for a same-repo `pull_request` head, so review runs only on a green PR.
-  workflow_run:
-    workflows: [PR]
-    types: [completed]
-  # React flows are NOT gated on CI and keep their immediate triggers.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -35,38 +23,27 @@ on:
 
 concurrency:
   # comment.id gives each comment its own group so bursty replies aren't cancelled;
-  # it's empty for the review event, which stays grouped per-PR (event_name + number).
-  group: code-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.event.issue.number }}-${{ github.event.comment.id }}
-  # Cancel superseded runs so only the latest gate-completion/comment is reviewed. The
-  # action no longer edits the PR body, so no bot self-edit can abort an in-flight review.
+  # it's empty for pull_request events, which stay grouped per-PR (event_name + number).
+  group: code-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event.comment.id }}
+  # Cancel superseded runs so only the latest push/comment is reviewed. The action
+  # no longer edits the PR body, so no bot self-edit can abort an in-flight review.
   cancel-in-progress: true
 
 jobs:
   ai-review:
-    # Three arms, one per event:
-    #   - workflow_run (review): the gate finished. Run only when it ran for a
-    #     `pull_request` and concluded `success`, and the head branch lives in this
-    #     repo — `actions/checkout` refuses a fork head under `workflow_run`, so a fork
-    #     PR would fail rather than review; skip it cleanly instead. The sender is NOT
-    #     checked here on purpose: an unrelated bot push (e.g. a license-regen chore
-    #     landing on top of the PR) must not suppress the review. The bot reviewing its
-    #     OWN authored PR is still skipped, by the action's PR-author guard.
-    #   - issue_comment / pull_request_review_comment (react): the bot's own comment and
-    #     review events are skipped here (sender == BOT_USERNAME) so they don't spawn a
-    #     no-op react run — cheaper than letting a runner spin up first.
+    # The bot's own events (its review and inline comments) are skipped here so they
+    # don't spawn a no-op react run — the in-action guard would skip them only after a
+    # runner spins up, so filtering at the job `if:` is cheaper.
+    #
+    # The last clause re-runs review when a user edits a PR title/body, so a
+    # description fix clears a stale CHANGES_REQUESTED verdict without the prior
+    # close/reopen workaround (introduced de-facto by #233's alignment checks).
+    # Base retargets (changes.base) are skipped — a later push re-covers them.
     if: >-
-      vars.BOT_USERNAME != ''
-      && (
-        (github.event_name == 'workflow_run'
-          && github.event.workflow_run.event == 'pull_request'
-          && github.event.workflow_run.conclusion == 'success'
-          && github.event.workflow_run.head_repository.full_name == github.event.repository.full_name)
-        || (github.event_name == 'issue_comment'
-          && github.event.issue.pull_request
-          && github.event.sender.login != vars.BOT_USERNAME)
-        || (github.event_name == 'pull_request_review_comment'
-          && github.event.sender.login != vars.BOT_USERNAME)
-      )
+      (github.event_name != 'issue_comment' || github.event.issue.pull_request)
+      && vars.BOT_USERNAME != ''
+      && github.event.sender.login != vars.BOT_USERNAME
+      && (github.event.action != 'edited' || github.event.changes.title || github.event.changes.body)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -78,7 +55,3 @@ jobs:
           bot_token: ${{ secrets.BOT_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_CODE_REVIEW }}
           release_pr_authors: ${{ vars.RELEASE_PR_AUTHORS }}
-          # The gate already concluded `success` (job `if:`), so there is nothing left
-          # to wait for — skip the preflight poll on the workflow_run path. (React
-          # events never use preflight; this expression is simply false for them too.)
-          preflight_checks: ${{ github.event_name != 'workflow_run' }}


### PR DESCRIPTION
Reverts #471 (the `on: workflow_run` migration of AI code review).

**Why revert:** under `workflow_run`, a job's status attaches to the **default-branch commit**, not the PR head SHA — so the visible `ai-review` **check disappears from the PR** and it can't be a required status check without extra Checks-API work. `workflow_run` also fires on **every** completion of the gate workflow repo-wide (every PR, every push-to-main, every schedule), spinning up many review runs that mostly skip. The review verdict itself still posts (as a `pulls.createReview`), so nothing was strictly *broken*, but losing the on-PR check and the run proliferation are regressions.

Restoring the `pull_request` trigger brings back the visible `ai-review` check. The original motivation for #471 — the preflight poll racing a repo's CI wall clock and flapping red on a 600s timeout — is better addressed by the consuming repo reducing its gate wall clock (already done downstream), so `pull_request` + preflight comfortably fits the budget again.

This also reverts the sender-skip scoping from #471 (a bot chore commit could suppress review). A cleaner redo — running code-review as a **project-level PR-gate job** ordered via `needs:` (review after CI, as a normal `pull_request`-context check, no polling and no `workflow_run` proliferation) — is tracked separately and will restore that fix properly.

Exactly restores the pre-#471 `code-review.yml` and `action.yml` (verified: empty diff vs the commit before #471).