### PR TITLE
Fix reviewer bot never re-approving after blockers are addressed

### DIFF
--- a/.github/actions/code-review-action/action.yml
+++ b/.github/actions/code-review-action/action.yml
@@ -188,7 +188,7 @@ runs:
 
         # Skip draft PRs for issue_comment events (draft status not in payload)
         if [[ "$EVENT_NAME" == "issue_comment" && "$EVENT_IS_PR_COMMENT" == "true" ]]; then
-          if [[ "$(gh pr view "$EVENT_ISSUE_NUMBER" --json isDraft --jq '.isDraft' 2>/dev/null)" == "true" ]]; then
+          if [[ "$(gh pr view "$EVENT_ISSUE_NUMBER" -R "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null)" == "true" ]]; then
             echo "Skipping: draft PR"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -387,10 +387,13 @@ runs:
         # is CHANGES_REQUESTED. The bot is the sole approver and the author cannot
         # self-approve, so reviewDecision is a faithful, pagination-free proxy for the
         # bot's own verdict. classifyReaction uses it to arm a verdict re-evaluation
-        # when the author says a blocker is addressed. A failed query degrades to
-        # "not blocking" (today's behaviour); only a genuine gh failure warns, so a
-        # null decision (no reviews yet) stays quiet.
-        if REACT_REVIEW_DECISION=$(gh pr view "$REACT_PR_NUMBER" --json reviewDecision --jq '.reviewDecision // ""' 2>/dev/null); then
+        # when the author says a blocker is addressed. This step runs before the
+        # repo checkout, so pass -R explicitly — gh otherwise resolves the repo from
+        # the local git remote, which does not exist yet, and the query fails with
+        # "not a git repository", permanently disarming the re-verdict. A genuine
+        # query failure still degrades to "not blocking" and warns; a null decision
+        # (no reviews yet) stays quiet.
+        if REACT_REVIEW_DECISION=$(gh pr view "$REACT_PR_NUMBER" -R "$GITHUB_REPOSITORY" --json reviewDecision --jq '.reviewDecision // ""' 2>/dev/null); then
           :
         else
           REACT_REVIEW_DECISION=""
@@ -424,7 +427,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.bot_token }}
       run: |
-        echo "sha=$(gh pr view ${{ steps.ctx.outputs.pr_number }} --json headRefOid --jq '.headRefOid')" >> "$GITHUB_OUTPUT"
+        echo "sha=$(gh pr view ${{ steps.ctx.outputs.pr_number }} -R ${{ github.repository }} --json headRefOid --jq '.headRefOid')" >> "$GITHUB_OUTPUT"
 
     - name: Checkout repository
       if: steps.ctx.outputs.skip != 'true'


### PR DESCRIPTION
## Context

The reviewer bot could never lift its own `CHANGES_REQUESTED` after a PR author addressed a blocker via discussion — the react-mode verdict re-evaluation shipped in #275 never fired in production.

## Root cause

Three `gh pr view` calls in `code-review-action/action.yml` run **before** `actions/checkout`, in a workspace that has no `.git` yet. Without `-R`, `gh pr view` resolves the target repo from the local git remote, so each call fails with `fatal: not a git repository`.

Confirmed on a live react run — both pre-checkout reads failed in the same job, before checkout:

```
Run gh pr view <n> --json reviewDecision
  fatal: not a git repository (or any of the parent directories): .git
  ::warning:: treating bot as not blocking (issue #275 re-verdict will not arm)
  bot_blocking=false
Run gh pr view <n> --json headRefOid
  fatal: not a git repository ...
Checkout repository (actions/checkout@v7)   <- .git first exists here
classify: NEEDS_REVERDICT=false             <- because bot_blocking=false
pr-answer: "updatedVerdict": null           <- reply only; verdict never re-evaluated
```

Because `bot_blocking` is always `false` in react mode, `authorAcknowledgesWhileBlocking` in `classifyReaction.ts` can never arm the re-verdict, so `CHANGES_REQUESTED` is never lifted.

## What / Solution

Pass the repo explicitly to the three pre-checkout `gh pr view` calls:

- **reviewDecision** (ctx step) — the damaging one; its failure disarmed the re-verdict. Adjacent comment refreshed to explain the pre-checkout `-R` requirement.
- **headRefOid** (resolve-sha step) — was silently degrading the react checkout to the merge ref.
- **isDraft** (ctx step) — was failing open to "not draft".

Post-checkout `gh pr view` calls already have a git remote and are unchanged.

## Scope

- The fail-open direction (a genuine query failure → `bot_blocking=false`) is intentionally kept; with the repo resolved, the deterministic pre-checkout failure no longer occurs, so no retry is added.
- The `authorAcknowledgesWhileBlocking` acknowledgement vocabulary (which phrasings auto-arm) is unchanged — a separate concern. An explicit "re-review"/"PTAL" arms regardless.

## Testing

`action.yml` shell is not unit-testable (the composite action is not covered by `actionlint`, which is gated by the CI Validate Actions job). Verify on a live blocking PR: an author acknowledgement (or "PTAL") should now log `bot_blocking=true`, `NEEDS_REVERDICT: true`, and a non-null `updatedVerdict`, with no "re-verdict will not arm" warning.

Related to #275
