### PR TITLE
Add an explore skill that primes a durable context brief

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ node_modules/
 dist/
 coverage/
 
+# Local context brief written by the explore skill — machine-generated, and
+# specific to one worktree's branch and working state. Narrow on purpose:
+# .claude/settings.json and .claude/agents/ are tracked.
+.claude/context/
+
 # Editor / OS
 .DS_Store
 .idea/

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,7 @@ coverage/
 # Bundled, self-contained Node sub-project for the pdf:create skill — decoupled
 # from the Bun workspace and the root Prettier (.{md,json}) glob on purpose.
 claude-plugins/autopilot/skills/pdf:create/renderer/
+
+# Local context brief written by the explore skill — machine-generated and
+# git-ignored, so the root Prettier (.{md,json}) glob must not check it.
+.claude/context/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The `docs/` guides are numbered chapters in reading order — start at chapter 1
 | 11  | [Linear tracker support](./docs/11-linear-tracker.md)                             | how `agents.trackers` opts a project into Linear and other issue trackers behind one JSON contract  |
 | 12  | [Code review repository standards](./docs/12-code-review-repository-standards.md) | how the review enforces a consumer repo's `rfc/`, `docs/`, and `principles/` with status severity   |
 | 13  | [The `shared-rules` skill](./docs/13-shared-rules-skill.md)                       | the single home for instruction blocks several skills need, and how a consumer reads one at runtime |
+| 14  | [The `explore` skill](./docs/14-explore-skill.md)                                 | the third on-ramp: prime a durable context brief, then take surgical fixes one at a time            |
 
 **Standards.**
 

--- a/claude-plugins/autopilot/README.md
+++ b/claude-plugins/autopilot/README.md
@@ -86,6 +86,7 @@ code-assistants/
             ├── commits:create/
             ├── commits:restructure/
             ├── dependabot:resolve/
+            ├── explore/
             ├── gather-context/
             ├── issue:create/
             ├── issue:run/
@@ -110,7 +111,7 @@ All user-invocable entries are skills. Skills natively accept `$ARGUMENTS` and s
 
 ### Codebase context snapshot
 
-The skills that need whole-codebase context — `/autopilot:plan`, `/autopilot:run`, `/autopilot:issue-create`, `/autopilot:pr-review`, `/autopilot:pr-answer`, `/autopilot:pr-resolve` — read the committed `.repomix/pack.xml` snapshot first (via `attach_packed_output`) and fall back to a live `pack_codebase` when it is absent. The snapshot is refreshed by CI on every merge to `main`; see the consumer host repo's [Committed Repomix pack](../../docs/09-repomix-pack.md) doc for details.
+The skills that need whole-codebase context — `/autopilot:plan`, `/autopilot:run`, `/autopilot:explore`, `/autopilot:issue-create`, `/autopilot:pr-review`, `/autopilot:pr-answer`, `/autopilot:pr-resolve` — read the committed `.repomix/pack.xml` snapshot first (via `attach_packed_output`) and fall back to a live `pack_codebase` when it is absent. The snapshot is refreshed by CI on every merge to `main`; see the consumer host repo's [Committed Repomix pack](../../docs/09-repomix-pack.md) doc for details.
 
 ### `/autopilot:branch-create`
 
@@ -210,6 +211,18 @@ Plan, implement, commit, create PR, and monitor until approved. Same as `/autopi
 /autopilot:run "add user authentication"                                # From description
 /autopilot:run #42 I think we should start with the auth module         # Issue + additional context
 ```
+
+### `/autopilot:explore`
+
+Map the repository broadly, write a durable context brief to `.claude/context/brief.md`, then take surgical fixes one at a time. Uses the [codebase context snapshot](#codebase-context-snapshot). See [the explore skill](../../docs/14-explore-skill.md) for the full flow.
+
+Reach for it when you have an _area_ rather than a target and the changes that follow are small and located. Unlike `/autopilot:plan` and `/autopilot:run` it never branches, never opens a PR, and never asks for approval — invoking it commits you to nothing.
+
+```bash
+/autopilot:explore                                                      # Takes no arguments; the map is broad by design
+```
+
+Re-invoking it refreshes the brief, replaying the full fan-out only when something other than derived files moved upstream. Deleting the brief is the supported reset.
 
 ### `/autopilot:todo-cleanup`
 
@@ -359,9 +372,11 @@ Validate git working state before branching, committing, or opening a PR. Mode-a
 
 ### `gather-context`
 
-Acquire all planning context in one parallel fan-out and emit a Context Map. Invoked automatically by `/autopilot:plan` and `/autopilot:run` after they detect the input type.
+Acquire all planning context in one parallel fan-out and emit a Context Map. Invoked automatically by `/autopilot:plan` and `/autopilot:run` after they detect the input type, and by `/autopilot:explore`.
 
-The fan-out issues every context call in a single message — the repo-standards and branch-diff digest agents, issue or alert resolution, the TODO search, the codebase snapshot, stack detection, and git state — then runs one task-scoped snapshot pass and returns the Context Map. Sub-agents return bounded JSON, so the full text of a README, the selected RFCs, and an unbounded `git diff` never reaches the calling skill's context.
+The fan-out issues every context call in a single message — the repo-standards and branch-diff digest agents, issue or alert resolution, the TODO search, the codebase snapshot, stack detection, and git state — then runs one snapshot pass and returns the Context Map. Sub-agents return bounded JSON, so the full text of a README, the selected RFCs, and an unbounded `git diff` never reaches the calling skill's context.
+
+An optional `Scope` input selects how that pass reads the snapshot: `task` (the default, used by `plan` and `run`) narrows to what the change touches, while `broad` maps the repository breadth-first for `/autopilot:explore`. The emitted Context Map has the same sections either way.
 
 Planning is stack-agnostic apart from three values (example libraries, expert table, verify examples), which both skills resolve from `plan/references/stack-deltas.md` keyed by `agents.rules`. There are no per-stack planning skills.
 

--- a/claude-plugins/autopilot/skills/explore/SKILL.md
+++ b/claude-plugins/autopilot/skills/explore/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: explore
+description: Map this repository broadly, write a durable context brief to .claude/context/brief.md, then take surgical fixes one at a time with no plan, branch, or PR machinery. Use when you have an area rather than a task — "help me understand this repo", "explore the refactoring flow" — and want the codebase understood before deciding what to change.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Agent
+  - MCP(repomix:*)
+  - Bash(git *)
+  - Bash(bun run *)
+  - Bash(bun test *)
+  - Bash(bunx *)
+  - Bash(npm run *)
+  - Skill(autopilot:gather-context)
+  - Skill(autopilot:ascii-schemas)
+  - Skill(autopilot:commits-create)
+  - Skill(autopilot:pr-create)
+---
+
+Prime the session with a broad picture of this repository, write it to disk so it survives compaction, then hand control back and take fixes one at a time.
+
+This is the third on-ramp into a repository, and it exists because the other two do not fit a common shape of work. [`plan`](../plan/SKILL.md) and [`run`](../run/SKILL.md) both require a target and then carry the session through draft, expert panel, scoring, a plan file, a branch, and a pull request. Arriving with an _area_ rather than a task — and following it with a few surgical edits — means inventing a target for `plan` and discarding everything it drags along. `explore` is the same context quality with none of that machinery.
+
+## When to Use
+
+- When you want the codebase understood before deciding what to change
+- When the work is a series of small, located fixes rather than one planned change
+- When a long session risks compacting away the context it depends on
+
+Reach for [`plan`](../plan/SKILL.md) instead when you have a target and want the approach reviewed and approved, and for [`run`](../run/SKILL.md) when you have a target and want it carried through to a merged pull request.
+
+## Input
+
+This skill takes **no arguments**. The map is deliberately broad — there is no subject matter to narrow to, so there is nothing to pass.
+
+## Phase 0: Classify the run
+
+1. Resolve the repository root with `git rev-parse --show-toplevel`. The brief lives at `<root>/.claude/context/brief.md`, one per worktree.
+
+2. If no brief exists, this is a **full prime** — go to [Phase 1](#phase-1-acquire-context-full-prime-only).
+
+3. Otherwise read the brief and take its `Base:` SHA, then ask whether anything **semantically** moved upstream since:
+
+   ```bash
+   git fetch origin main
+   git diff --name-only <base>..origin/main -- . \
+     ':(exclude).repomix/' ':(exclude)**/CHANGELOG.md' \
+     ':(exclude)**/.release_notes/' ':(exclude)LICENSES.md'
+   ```
+
+   Empty output ⇒ **delta refresh**: skip [Phase 1](#phase-1-acquire-context-full-prime-only) and [Phase 2](#phase-2-diagrams-full-prime-only) entirely, resume at [Phase 3](#phase-3-recompute-the-volatile-sections), and rewrite only the volatile sections. Any other output ⇒ full prime. A `<base>` that no longer resolves in this clone also means full prime — never diff against a SHA you cannot name.
+
+**The exclusions are the load-bearing part, and an include-list cannot replace them.** A committed codebase snapshot is refreshed by automation on nearly every merge, so watching it makes the diff non-empty almost always and the delta path becomes dead code. Watching only prose roots has the opposite failure: the architecture, key-types, and test sections describe code, so they would go stale under a fresh `Base:` vouching for them. Excluding what is derived and watching everything else is the only formulation that means what those sections claim.
+
+The diff is remote-to-remote, so locally-uncommitted edits never force a full prime. That is deliberate — local edits are exactly what an explore session produces, and they surface in the volatile sections, which are rewritten every time.
+
+## Phase 1: Acquire context (full prime only)
+
+Invoke:
+
+```
+Skill(autopilot:gather-context)
+```
+
+Pass input type `plain-description`, **`Scope: broad`**, the repository and repository root, and a task summary of `broad architecture map`. There is no issue id.
+
+Two consequences of that input are worth knowing rather than rediscovering. `Scope: broad` is what makes the codebase pass read the snapshot breadth-first instead of hunting for what a change touches. And `plain-description` gates off the issue and TODO resolvers, so no sub-agent runs whose output this brief would discard.
+
+Do not re-implement the fan-out here. It has one owner; a hand-mirrored copy would rot the first time an agent is added to one side and not the other.
+
+## Phase 2: Diagrams (full prime only)
+
+Invoke `Skill(autopilot:ascii-schemas)` for two diagrams — module boundaries, and the primary data or control flow between them. Embed each verbatim in the section it explains. Never hand-draw one.
+
+This sits beside [Phase 1](#phase-1-acquire-context-full-prime-only) rather than after the volatile-recompute pass so that everything a delta refresh skips is contiguous: the two full-prime-only phases run back to back, and the delta path rejoins at [Phase 3](#phase-3-recompute-the-volatile-sections).
+
+## Phase 3: Recompute the volatile sections
+
+Runs on **both** paths, and is the sole source of all three volatile sections. Issue these in a single message:
+
+```bash
+# Local session state
+git status --porcelain
+git stash list
+git worktree list
+git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads/
+
+# In-flight changes
+git log --oneline origin/main..HEAD
+git diff --stat origin/main..HEAD
+
+# Git state
+git branch --show-current
+git rev-parse --git-dir && git rev-parse --git-common-dir   # differ inside a worktree
+git cherry origin/main HEAD                                 # every line "-" ⇒ isStaleMerged
+git rev-list --count HEAD..origin/main                      # baseAhead
+```
+
+**This phase owns the volatile sections outright — do not source them from the Context Map.** [Phase 1](#phase-1-acquire-context-full-prime-only) also reports in-flight changes and git state, but it does not run on a delta refresh, so anything sourced from it cannot honor the "rewritten on every invocation" contract. A brief primed once and refreshed thereafter would keep showing the branch as it stood at the first prime — and since an explore session's whole purpose is producing commits, that is the common case, not an edge case. On a full prime these commands simply recompute what the map already said; the duplicate cost is a few `git` calls, and it buys a volatile half that is genuinely volatile on both paths.
+
+Read `isStaleMerged` from `git cherry` rather than from a commit count: a branch whose commits already landed upstream under rebase-rewritten SHAs still shows a non-empty `git log origin/main..HEAD`, and testing only for emptiness reads a finished branch as active work.
+
+Local session state is what makes a "surgical" fix land in the wrong place: an edit staged for another purpose, a stash holding the version you meant to change, a sibling worktree already on the branch you were about to create, or a branch with unpushed commits you assumed were gone.
+
+## Phase 4: Write the brief
+
+Create `<root>/.claude/context/` if absent and write `brief.md`. Section order is fixed, so two briefs of the same repository are comparable and a delta refresh can rewrite a subset in place.
+
+```text
+# Context brief — <repo> @ <branch>
+
+Base: <origin/main SHA>
+
+## Architecture map          <- stable
+## Data flow                 <- stable
+## Conventions and standards <- stable
+## Key types                 <- stable
+## Test and verify           <- stable
+## In-flight changes         <- volatile
+## Local session state       <- volatile
+## Git state                 <- volatile
+## Snapshot                  <- stable
+```
+
+`Base:` is the only metadata, because it is the only field a decision reads. No timestamp — nothing keys off one, and an unused field is a field that goes stale. The current branch belongs in the volatile `## Git state`, so switching branches cannot leave a stale name in a stable region.
+
+**On a delta refresh, rewrite `Base:` and the three volatile sections only.** The stable sections must come through byte-identical; that is the property the whole classification exists to buy.
+
+Every **stable** section is written from the Context Map, and the transformation is fixed here rather than improvised per run:
+
+| Context Map section  | Brief section                                    |
+| -------------------- | ------------------------------------------------ |
+| Relevant files       | `## Architecture map`                            |
+| Patterns to mirror   | `## Architecture map`                            |
+| Stack                | `## Architecture map`                            |
+| Applicable standards | `## Conventions and standards`                   |
+| Key types            | `## Key types`                                   |
+| Test conventions     | `## Test and verify`                             |
+| Snapshot             | `## Snapshot`                                    |
+| In-flight changes    | unused — the brief recomputes it in Phase 3      |
+| Git state            | unused — the brief recomputes it in Phase 3      |
+| Related TODOs        | dropped — never populated for this skill's input |
+| Issue / alert        | dropped — always `none` for this skill's input   |
+
+The last four rows are the load-bearing ones. In-flight changes and git state are the map's only volatile output, and the map exists solely on a full prime, so reading them from it would make two "volatile" sections silently freeze after the first prime — [Phase 3](#phase-3-recompute-the-volatile-sections) recomputes both instead. Related TODOs and Issue / alert are never populated at all, because this skill passes `plain-description` and both of those resolvers are gated on issue inputs.
+
+`## Data flow` carries the [Phase 2](#phase-2-diagrams-full-prime-only) diagram and has no Context Map source. `## Test and verify` must name the **exact commands** to run, because every later fix is verified with one of them.
+
+An empty section is written `none`, never dropped — the same rule the Context Map itself carries.
+
+## Phase 5: State the session contract, then stop
+
+Report where the brief was written, whether this was a full prime or a delta refresh, and anything in `## Git state` the user should know before editing — being on `main`, or on a branch whose work already landed upstream. **Report it; do not prompt on it.** This skill does not branch.
+
+Then state the contract for the rest of the session and stop. Do not start work; the next instruction is the user's.
+
+## The fix loop
+
+Once the brief is written, every instruction that follows is handled the same way: locate it through the brief, edit, run the verify check named in `## Test and verify`, and report the result.
+
+**No plan file, no expert panel, no scoring, no branch prompt, no PR chain.** Never call `EnterPlanMode` or `ExitPlanMode`, and never invoke `preflight-check` — those belong to the flows this skill exists to avoid. Suppressing them is half the value here; a fix that costs one edit should not cost a planning pipeline.
+
+When the user asks to commit or open a pull request, hand off — invoke `Skill(autopilot:commits-create)` or `Skill(autopilot:pr-create)`, which own those conventions. Do not improvise either with raw `git` or `gh`.
+
+Re-invoking `/autopilot:explore` refreshes the brief. Deleting `.claude/context/brief.md` is the supported reset: the next invocation is a full prime.
+
+## Reference formatting
+
+Before writing any output that mentions a file, standard, section, commit, or issue, read [`reference-formatting.md`](../shared-rules/references/reference-formatting.md) (RFC-0001) and apply it verbatim — link files, docs, skills, agents, and sections, and never leave a reference as bare text.
+
+**Reference self-check (MANDATORY):** after composing the output, re-read it against [`reference-formatting.md`](../shared-rules/references/reference-formatting.md). A bare commit SHA, a bare tracker id outside a magic-word line, or an unlinked mention of a file that exists in the repo is a violation — fix it before emitting.

--- a/claude-plugins/autopilot/skills/gather-context/SKILL.md
+++ b/claude-plugins/autopilot/skills/gather-context/SKILL.md
@@ -27,6 +27,7 @@ The invoking skill provides in the prompt:
 - **Repository** (e.g., `awinogradov/code-assistants`) and **repository root** (absolute path).
 - **Linear team** — for `linear-issue` only, the matched tracker's team.
 - **Task summary** — the raw task text, used to rank standards and scope the codebase pass.
+- **Scope** — `task` (the default) or `broad`, selecting how [Phase 2](#phase-2-scope-the-codebase-pass) reads the snapshot. Optional: `plan` and `run` omit it and get `task`.
 
 ## Phase 1: Fan out
 
@@ -55,6 +56,8 @@ Issue **every** call below in a **single message** so they run concurrently. Do 
 Only now is the task's subject matter known, so this pass runs after the fan-out returns.
 
 Search the snapshot with `mcp__repomix__grep_repomix_output` for the implementations, patterns, and tests the change touches, reading specific ranges via `mcp__repomix__read_repomix_output`. The snapshot reflects the base at its last refresh, so reach for live Grep/Glob/Read **only** for working-tree code the snapshot cannot show — `digest-branch-diff` already reports what is in flight. Do not crawl the tree for anything the snapshot answers.
+
+**At `broad` scope there is no change to narrow to**, so read the snapshot breadth-first instead: the principal modules and their boundaries, the entry points, and the conventions that govern them. Fill `Relevant files` and `Patterns to mirror` at that altitude — the modules a newcomer must know and the conventions they must copy, rather than the handful a specific edit would touch. Every other section keeps its meaning, and the emitted section list is identical either way, so a caller that omits `Scope` sees exactly today's behavior.
 
 ## Phase 3: Emit the Context Map
 

--- a/docs/05-plan-run-skills.md
+++ b/docs/05-plan-run-skills.md
@@ -121,6 +121,8 @@ The snapshot prefers the committed `.repomix/pack.xml` via `attach_packed_output
 
 A resolver returning `unresolved` with a non-null `resolveError` is fatal: the skill surfaces the error and stops rather than proceeding against a misfetched target. A _digest_ failure is not fatal — it is recorded and planning continues, because a plan without a standards digest is degraded, not wrong.
 
+The fan-out takes an optional `Scope` input — `task` or `broad`. Both skills here omit it and get `task`, the change-scoped pass described above; `broad` reads the snapshot breadth-first instead and is used only by [the `explore` skill](./14-explore-skill.md), a third on-ramp for work that starts from an area rather than a target. The emitted Context Map has the same sections either way.
+
 ## Phase 2 — Intent, assumptions, and the human gate
 
 After the Context Map, deliberately. The skill emits a one-line **steelmanned intent** (the request restated in its strongest form — the stable target for expert reviewers, copied verbatim into the plan's `## Summary`), then **Assumptions** and **Open Questions**. Any load-bearing open question is raised via `AskUserQuestion` before drafting.
@@ -278,7 +280,7 @@ Sub-agents isolate work from the parent's context. Each returns a single schema-
 | `claude-plugins/autopilot/skills/plan/references/pipeline.md`        | Draft template, review and scoring, finalize                 |
 | `claude-plugins/autopilot/skills/plan/references/stack-deltas.md`    | Per-stack example libraries, expert tables, verify examples  |
 | `claude-plugins/autopilot/skills/plan/references/branch-blocks.md`   | `## Pre-Implementation` bodies and their mechanics           |
-| `claude-plugins/autopilot/skills/gather-context/SKILL.md`            | The one context fan-out and the Context Map contract         |
+| `claude-plugins/autopilot/skills/gather-context/SKILL.md`            | The one context fan-out, its `Scope` input, and the map      |
 | `claude-plugins/autopilot/skills/run/SKILL.md`                       | `plan` plus the automated post-implementation chain          |
 | `claude-plugins/autopilot/agents/digest-repo-standards.md`           | README / `docs/` / `rfc/` / `principles/` digest (JSON)      |
 | `claude-plugins/autopilot/agents/digest-branch-diff.md`              | Branch commits, diff, and stale-merge detection (JSON)       |

--- a/docs/14-explore-skill.md
+++ b/docs/14-explore-skill.md
@@ -1,0 +1,180 @@
+# The `explore` skill
+
+> Chapter 14 of the [repository docs](../README.md#repository-docs).
+
+How `/autopilot:explore` primes a session with a broad, durable picture of a repository, and then gets out of the way so fixes can be issued one at a time.
+
+> Source of truth: `claude-plugins/autopilot/skills/explore/SKILL.md` (the skill), `…/skills/gather-context/SKILL.md` (the context fan-out it reuses, and the `Scope` input this chapter adds), and the sub-agents under `…/agents/`.
+
+## Why a third on-ramp
+
+Autopilot had exactly two entry points, and both start from a target. [`plan`](../claude-plugins/autopilot/skills/plan/SKILL.md) and [`run`](../claude-plugins/autopilot/skills/run/SKILL.md) each take a GitHub issue, a Linear ticket, a code-scanning alert, or a description concrete enough to plan against — then carry the session through draft, expert panel, scoring, a plan file, a branch, and a pull request. See [Plan and run skills](./05-plan-run-skills.md).
+
+Work does not always arrive that way. Sometimes it arrives as an _area_ — "the refactoring flow", "the review pipeline" — and the changes that follow are surgical: a few lines in a file you first have to find. Getting autopilot's context quality for that mode meant inventing a target for `plan` and then discarding everything the plan pipeline dragged along.
+
+The context acquisition was already the right shape. [`gather-context`](../claude-plugins/autopilot/skills/gather-context/SKILL.md) runs one parallel fan-out and returns a bounded Context Map. It just was not reachable: it is marked `user-invocable: false`, and its codebase pass was written around "the implementations, patterns, and tests **the change touches**" — an instruction with no referent when there is no change yet.
+
+Two further properties made the map unsuitable for a steer-as-you-go session. It lives only in the conversation, so it is lost on compaction — and a session of successive small fixes is exactly the session most likely to compact. And it says nothing about the local workspace: uncommitted changes, stashes, sibling worktrees, unpushed commits on other branches.
+
+## When to use which
+
+| Skill                | You have                   | You get                                                   |
+| -------------------- | -------------------------- | --------------------------------------------------------- |
+| `/autopilot:explore` | an area, no target         | a durable brief, then edit-and-verify on your instruction |
+| `/autopilot:plan`    | a target you want reviewed | a scored plan file, an approval gate, then implementation |
+| `/autopilot:run`     | a target you want carried  | the same plan, implemented and driven to a merged PR      |
+
+`explore` is the only one of the three that never branches, never opens a pull request, and never asks for approval — invoking it is not a commitment to change anything.
+
+## At a glance
+
+```text
+                ┌───────────────────────┐
+                │  /autopilot:explore   │
+                └───────────┬───────────┘
+                            │ ①
+                            ▼
+                ┌───────────────────────┐
+                │  Phase 0              │
+                │  Classify the run     │
+                └───────────┬───────────┘
+                            │
+                  ┌─────────┴─────────┐
+                  │ ②                 │ ③
+                  ▼                   │
+        ┌───────────────────┐         │
+        │  Phase 1          │         │
+        │  gather-context   │         │
+        │  Scope: broad     │         │
+        └─────────┬─────────┘         │
+                  │                   │
+                  ▼                   │
+        ┌───────────────────┐         │
+        │  Phase 2          │         │
+        │  ascii-schemas    │         │
+        └─────────┬─────────┘         │
+                  │                   │
+                  └─────────┬─────────┘
+                            ▼
+                ┌───────────────────────┐
+                │  Phase 3              │
+                │  Recompute volatile   │
+                └───────────┬───────────┘
+                            │ ④
+                            ▼
+                ┌───────────────────────┐
+                │  Phase 4              │
+                │  Write the brief      │
+                └───────────┬───────────┘
+                            │ ⑤
+                            ▼
+                ┌───────────────────────┐
+                │  Phase 5              │
+                │  Session contract     │
+                └───────────┬───────────┘
+                            │ ⑥
+                            ▼
+                ┌───────────────────────┐
+                │  You steer: edit,     │
+                │  verify, repeat       │
+                └───────────────────────┘
+```
+
+**Flow Legend:**
+
+- ① The skill takes no arguments. The map is broad by design, so there is nothing to scope.
+- ② No brief, an unresolvable recorded base, or non-derived upstream changes — a full prime.
+- ③ Nothing but derived files moved upstream — skip both full-prime phases and delta-refresh instead.
+- ④ Runs on both paths and owns every volatile section: branch diff, git state, dirty files, stashes, sibling worktrees, unpushed branches.
+- ⑤ A full prime writes every section; a delta refresh rewrites only the volatile ones.
+- ⑥ No plan file, no expert panel, no scoring, no branch prompt, no PR chain.
+
+## Reuse, not a second fan-out
+
+`explore` invokes `gather-context` rather than re-implementing it. These are prompt files with no import mechanism, so a "mirrored" roster is a hand-copy — and it would rot the first time a sub-agent is added to one side and not the other, with no guard relating the two skills.
+
+The only change on that shared path is one optional input:
+
+| `Scope`          | Codebase pass                                                            |
+| ---------------- | ------------------------------------------------------------------------ |
+| `task` (default) | the implementations, patterns, and tests the change touches              |
+| `broad`          | principal modules and boundaries, entry points, the conventions in force |
+
+The Context Map's section shape is identical either way. `plan` and `run` omit `Scope` and get `task`, so the addition is additive and default-preserving — the blast radius is confined to callers that pass `broad`.
+
+`explore` also passes input type `plain-description`, which gates off `resolve-issue-context` and `search-codebase-todos`. No sub-agent runs whose output the brief would discard.
+
+Local workspace state deliberately stays in `explore` rather than joining the Context Map: it is four bounded `git` calls, not a digest, and `plan`/`run` did not ask for it.
+
+## The brief
+
+One brief per worktree, at `.claude/context/brief.md`. It is ignored by both git and Prettier, so it never reaches a commit or a format check — the entry is the narrow `.claude/context/`, because `.claude/settings.json` and `.claude/agents/` are tracked.
+
+```text
+┌────────────────────────────────────────────────────────────┐
+│  .claude/context/brief.md    Base: <origin/main SHA>       │
+├────────────────────────────────────────────────────────────┤
+│  Stable — rewritten only on a full prime                   │
+├────────────────────────────────────────────────────────────┤
+│  Architecture map            module boundaries + diagram   │
+│  Data flow                   diagram                       │
+│  Conventions and standards   rfc / docs / principles       │
+│  Key types                   interfaces, schemas           │
+│  Test and verify             the exact commands to run     │
+│  Snapshot                    repomix outputId              │
+├────────────────────────────────────────────────────────────┤
+│  Volatile — rewritten on every invocation                  │
+├────────────────────────────────────────────────────────────┤
+│  In-flight changes           branch diff                   │
+│  Local session state         dirty, stash, worktrees       │
+│  Git state                   branch, worktree, staleness   │
+└────────────────────────────────────────────────────────────┘
+```
+
+`Base:` is the only metadata, because it is the only field a decision reads. There is no timestamp: nothing keys off one, and an unused field is a field that goes stale. The current branch belongs to the volatile `## Git state`, so switching branches cannot leave a stale branch name sitting in a stable region.
+
+The skill fixes the Context-Map-to-brief transformation rather than improvising it per run — otherwise no two briefs are structurally comparable and the stable/volatile split is aspirational. `Relevant files`, `Patterns to mirror`, and `Stack` collapse into `## Architecture map`; `Related TODOs` and `Issue / alert` are never populated for this input and are dropped. An empty section is written `none`, never omitted.
+
+Crucially, the map feeds the **stable** sections only. The map's own `In-flight changes` and `Git state` are deliberately unused, because the map exists solely on a full prime: sourcing a "rewritten on every invocation" section from it would freeze that section after the first prime. Phase 3 recomputes both from `git` instead, on both paths.
+
+## Delta refresh
+
+Re-invoking the skill does not repeat the fan-out unless something upstream actually invalidates it:
+
+```bash
+git fetch origin main
+git diff --name-only <base>..origin/main -- . \
+  ':(exclude).repomix/' ':(exclude)**/CHANGELOG.md' \
+  ':(exclude)**/.release_notes/' ':(exclude)LICENSES.md'
+```
+
+Empty means delta refresh — rewrite `Base:` and the three volatile sections, leave the six stable ones byte-identical. Anything else, a missing brief, or a `<base>` that no longer resolves means a full prime.
+
+**The exclusions carry the design, and an include-list cannot replace them.** The [committed Repomix pack](./09-repomix-pack.md) is refreshed by a merge-triggered CI job on essentially every merge, so watching it makes the diff non-empty almost always and the delta path becomes dead code — the exact outcome the rule exists to avoid. Watching only prose roots (`docs/`, `rfc/`, `README.md`) fails in the other direction: `## Architecture map`, `## Key types`, and `## Test and verify` describe code, so they would go stale while a fresh `Base:` vouched for them. Excluding what is derived and watching everything else is the only formulation that means what those sections claim.
+
+The diff is remote-to-remote, so locally-uncommitted work never forces a full prime. That is deliberate: local edits are what an explore session produces, and they already surface in the volatile sections.
+
+## Brief lifecycle
+
+- **Who reads it** — both the agent and the human. It is written as prose with diagrams, not as a machine format.
+- **Who does not** — `plan`, `run`, and `commits-create` do not consume it. It is not an input to any other skill; nothing silently depends on it being current.
+- **Hand-editing** — safe, and it survives every delta refresh. A full prime overwrites the stable sections, so notes worth keeping belong somewhere else.
+- **Staleness beyond the refresh rule** — the rule watches `origin/main` only, so long-lived local work that never lands upstream will not trigger a full prime. That is safe because the three volatile sections are recomputed from `git` in Phase 3 on both paths, never read from the Context Map; the stable sections describe the upstream base, which such work has not moved.
+- **Reset** — delete the file. The next invocation is a full prime.
+
+## The session contract
+
+After writing the brief the skill reports what it did, notes anything in `## Git state` worth knowing before editing — being on `main`, or on a branch whose work already landed upstream — and stops. It **reports** that state rather than prompting on it, because this skill does not branch.
+
+Every instruction after that is handled the same way: locate through the brief, edit, run the verify check `## Test and verify` names, report. No plan file, no expert panel, no scoring, no branch prompt, no PR chain. `EnterPlanMode`, `ExitPlanMode`, and `preflight-check` are never called — they belong to the flows this skill exists to avoid.
+
+Suppressing that machinery is half the value. A fix that costs one edit should not cost a planning pipeline. Committing or opening a pull request hands off to [`commits:create`](../claude-plugins/autopilot/skills/commits:create/SKILL.md) or [`pr:create`](../claude-plugins/autopilot/skills/pr:create/SKILL.md), which own those conventions.
+
+## Where to look in the code
+
+| File                                                      | Role                                                     |
+| --------------------------------------------------------- | -------------------------------------------------------- |
+| `claude-plugins/autopilot/skills/explore/SKILL.md`        | The skill: classify, prime, persist, contract            |
+| `claude-plugins/autopilot/skills/gather-context/SKILL.md` | The fan-out it reuses, and the `Scope` input             |
+| `claude-plugins/autopilot/skills/ascii-schemas/SKILL.md`  | Generates the module and data-flow diagrams              |
+| `.gitignore` / `.prettierignore`                          | Keep `.claude/context/` out of commits and format checks |


### PR DESCRIPTION
Adds `/autopilot:explore`, a third on-ramp for work that starts from an area rather than a target: it maps the repository broadly, writes a durable context brief to `.claude/context/brief.md`, then stops so fixes can be issued one at a time. Unlike [`plan`](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/plan/SKILL.md) and [`run`](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/run/SKILL.md) it never branches, never opens a PR, and never asks for approval.

- Reuses [`gather-context`](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/gather-context/SKILL.md) rather than duplicating its fan-out, so the sub-agent roster keeps one owner — these are prompt files with no import mechanism, and a hand-mirrored roster would rot the first time an agent is added to one side only.
- Adds one optional `Scope` input to that skill (`task`, the default, or `broad`). The Context Map's section shape is unchanged, so `plan` and `run` omit it and behave exactly as before; the blast radius is confined to callers passing `broad`.
- The brief splits into six stable sections and three volatile ones. Re-invoking delta-refreshes the volatile half instead of replaying the fan-out.
- The refresh rule diffs against `origin/main` **excluding derived paths** (`.repomix/`, CHANGELOG files, `.release_notes/`, `LICENSES.md`) rather than watching an include-list. The committed pack is auto-refreshed on nearly every merge, so watching it would make the delta path dead code; watching only prose roots would let the code-describing sections go stale under a fresh base. Verified against real history: a `chore(repomix)`-only merge classifies as a delta refresh, a `feat` merge as a full prime, and an unresolvable base fails loudly rather than silently reading as "no change".
- The brief is ignored by git and Prettier via the narrow `.claude/context/` entry — `.claude/settings.json` and `.claude/agents/` stay tracked.

Both commits were verified green independently by checkout, since rebase-merge replays each one and the chapter-14 links only resolve once that file exists.

---

**Release notes:**

- Added `/autopilot:explore`, a new slash skill that maps a repository broadly, saves a reusable context brief, and then takes surgical fixes one at a time with no plan, branch, or PR steps
- Added an optional `Scope` setting to context gathering; existing planning flows are unaffected

---

**Issues:**

Closes #487
