### PR TITLE
Keep generated plans minimal and their implementation steps concrete

### DIFF
--- a/claude-plugins/autopilot/skills/plan/references/pipeline.md
+++ b/claude-plugins/autopilot/skills/plan/references/pipeline.md
@@ -12,6 +12,8 @@ Set task 3 ("Draft plan") to `in_progress`.
 
 Assemble a complete draft before review and scoring, so both operate on a concrete artifact instead of an imagined one. Leave `Score:` as a placeholder — the review step fills it.
 
+Draft the smallest reliable solution that satisfies the steelmanned intent: reuse what the Context Map already shows over adding, and prefer the option with the fewest moving parts that still holds. Every step must trace to that intent — no unrequested abstraction, no configurability nobody asked for, no error handling for states that cannot occur, and no opportunistic refactor of adjacent code. Where a simpler option was rejected because it would not hold, say so in a clause rather than leaving the larger design unexplained. Minimality is a drafting constraint, not only a scoring one: the review step spends a single capped revision pass, which cannot reliably strip scope a draft has already committed to.
+
 Work these dimensions against the Context Map as you draft. They are analysis, not a second crawl:
 
 | Dimension        | Key Questions                                             |
@@ -34,7 +36,7 @@ Score: [filled by the review step — leave as a placeholder in the draft]
 
 ## Implementation Steps
 
-Every step MUST include a `verify:` line — an observable check (test name, command, or behavior). Follow your stack's verify examples as the pattern.
+One numbered step per action, written as an imperative naming the file it touches and what changes there. Every step MUST include a `verify:` line — an observable check (test name, command, or behavior). Follow your stack's verify examples as the pattern. Reasoning belongs in `## Summary`; a step that explains itself instead of stating an action is prose, not a step. Use no checkboxes — the plan file is read, not ticked off.
 
 ## Files
 - `path/to/file.ts:NN` - [what changes]

--- a/claude-plugins/autopilot/skills/plan/references/stack-deltas.md
+++ b/claude-plugins/autopilot/skills/plan/references/stack-deltas.md
@@ -45,9 +45,9 @@ When `package.json` is missing, has no `agents` field, or carries an unrecognize
 
 **Verify examples** for the draft template's Implementation Steps:
 
-1. [ ] [Action] in `path/to/file.ts`
+1. [Action] in `path/to/file.ts`
    - verify: `bun test path/to/file.test.ts` passes
-2. [ ] [Action] in `path/to/file.ts`
+2. [Action] in `path/to/file.ts`
    - verify: CLI prints the new flag in `--help` output
 
 ## NodeJS+React
@@ -71,7 +71,7 @@ When `package.json` is missing, has no `agents` field, or carries an unrecognize
 
 **Verify examples** for the draft template's Implementation Steps:
 
-1. [ ] [Action] in `path/to/file.ts`
+1. [Action] in `path/to/file.ts`
    - verify: `vitest run path/to/file.test.ts` passes
-2. [ ] [Action] in `path/to/file.ts`
+2. [Action] in `path/to/file.ts`
    - verify: rendered component shows the new label in the page

--- a/docs/05-plan-run-skills.md
+++ b/docs/05-plan-run-skills.md
@@ -172,6 +172,10 @@ Defined once in [`references/pipeline.md`](../claude-plugins/autopilot/skills/pl
 
 Assemble a complete draft **before** review and scoring, so both operate on a concrete artifact rather than an imagined one. The draft follows a fixed template: `## Summary` (with steelmanned intent and a `Score:` placeholder), `## Implementation Steps` (each with an observable `verify:` line patterned on the stack's verify examples), `## Files`, and `## Post-Implementation` — the last of these stating in prose that documentation is updated and the work is committed or opened as a PR.
 
+Two constraints bound what that draft may contain. The first is minimality: the draft proposes the smallest reliable solution that satisfies the steelmanned intent, reusing what the Context Map already shows, and every step must trace to that intent — no unrequested abstraction, no configurability nobody asked for, no error handling for impossible states, no opportunistic refactor of adjacent code. The second is shape: a step is one imperative action naming the file it touches and its `verify:` line, with reasoning left to `## Summary` and no checkboxes, since the plan file is read rather than ticked off.
+
+Both apply at drafting rather than at scoring, even though the rubric already carries a Simplicity dimension. Scoring gets a single capped revision pass, and one pass cannot reliably strip scope a draft has already committed to — by then the over-built design is the thing being corrected rather than the thing being avoided. Constraining the draft also gives expert reviewers a tighter artifact to score.
+
 Drafting works five analysis dimensions against the Context Map — **Architecture**, **Patterns**, **Data Flow**, **Types**, and **Edge Cases**. This was previously a separate "Deep Analysis" phase that produced no artifact and needed its own paragraph warning it not to re-crawl the tree; folding it into drafting removes both the phase boundary and the temptation.
 
 For structural or visual changes, ASCII diagrams are embedded inline in the section each explains rather than collected in a standalone section.


### PR DESCRIPTION
The shared planning pipeline told the drafter to assemble a complete draft but never bounded how much solution that draft could contain, and never said how an Implementation Step should read. Minimality was judged only afterwards by the review rubric's Simplicity dimension, which gets a single capped revision pass — and one pass cannot reliably strip scope a draft has already committed to. Both constraints now apply at drafting time, in the one reference [`plan`](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/plan/SKILL.md) and [`run`](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/run/SKILL.md) share.

- Added a constraints paragraph to [pipeline.md](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/plan/references/pipeline.md) requiring the smallest reliable solution that satisfies the steelmanned intent, with every step tracing to that intent — no unrequested abstraction, configurability, error handling for impossible states, or opportunistic refactor of adjacent code
- Replaced the plan template's Implementation Steps line with a step shape: one imperative action per step naming the file it touches, its `verify:` line, reasoning left to `## Summary`, and no checkboxes, since the plan file is read rather than ticked off
- Dropped the checkbox from the four verify examples in [stack-deltas.md](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/plan/references/stack-deltas.md) so the pattern the template points at matches the shape it defines
- Documented both constraints in the "Draft plan" subsection of [docs/05-plan-run-skills.md](https://github.com/awinogradov/code-assistants/blob/main/docs/05-plan-run-skills.md), including why they sit at drafting rather than at scoring

`run/SKILL.md` needs no change — it executes the same pipeline reference, so it inherits both constraints. The fenced template still carries none of the agent-facing constructs [planFileOutputPurity.test.ts](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/code-review-action/src/planFileOutputPurity.test.ts) forbids, and both commits were verified green on their own checkout so the rebase-merge replay holds.

One honest caveat: this constrains the prompt text a drafter reads, so it shifts what a plan is likely to contain rather than enforcing it. The guard tests prove the template stays well-formed; they cannot prove an emitted plan obeys it — the same limitation that test documents about itself.

---

**Release notes:**

- Plans generated by `/autopilot:plan` and `/autopilot:run` now propose the smallest reliable change that satisfies the request, with no scope that does not trace back to it
- Implementation steps are written as concrete imperative actions instead of narrative prose, and no longer carry checkboxes

---

**Issues:**

Closes #494
