### PR TITLE
Run the contract guard tests on every pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+# Runs the workspace test suite on every pull request.
+#
+# Deliberately NOT path-filtered. Most of what these tests guard is markdown
+# rather than TypeScript — `linkResolution` walks the skills, agents, `docs/`,
+# `rfc/` and the root README, `sharedRulesInvocation` discovers skills by
+# readdir, and the producer/consumer contract tests parse SKILL.md templates.
+# A docs-only pull request is therefore the case most likely to break them, so
+# filtering on `**/*.ts` would skip exactly the runs that matter.
+#
+# This workflow is not part of any downstream sync: the suite it runs is
+# specific to this repository's Turbo workspace.
+
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.x
+
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun run test


### PR DESCRIPTION
The contract guard tests that keep this repository's prompt files honest have never run in CI. Nothing under `.github/workflows/` invoked `bun test`, so `linkResolution`, `sharedRulesInvocation`, `primedBriefContract` and `linearPlanContract` gated locally and in review only — on the honour system for anyone opening a pull request.

- Adds a `Test` workflow running `bun run test` (the Turbo `test` task across all 11 workspace members) on every pull request into `main`.
- **Deliberately not path-filtered.** Most of what these tests guard is markdown, not TypeScript: `linkResolution` walks the skills, agents, `docs/`, `rfc/` and the root README, `sharedRulesInvocation` discovers skills by `readdir`, and the two producer/consumer guards parse `SKILL.md` templates. A docs-only pull request is the case most likely to break them, so filtering on `**/*.ts` would skip exactly the runs that matter. The workflow comment records this so it is not "optimised" away later.
- Self-contained rather than a thin delegate to a composite action, which is the usual shape here. A new thin workflow referencing its own action at `@main` fails on the pull request that introduces it, because the action is not on `main` yet — and the suite being run is specific to this repository's Turbo workspace, so there is nothing for a downstream consumer to reuse. No sync aggregator lists it.
- Uses the conventions already in place: `actions/checkout@v7`, `oven-sh/setup-bun@v2` with `bun-version: 1.x`, and `bun install --frozen-lockfile` as every composite action does.

Verified before opening: `bun run test` is green across all 11 members, `bun run lint` passes, `actionlint` accepts the workflow, and the `run` blocks are shellcheck-clean.

Worth noting for whoever reviews: this check will not become a *gate* until it is added to the repository's required-status-check set. The workflow is what makes that possible; flipping it to required is a settings change outside this diff.

---

**Issues:**

Closes #500
