### PR TITLE
Discard expert reviews that have no evidence behind them

### DIFF
--- a/.github/actions/code-review-action/src/expertReviewContract.test.ts
+++ b/.github/actions/code-review-action/src/expertReviewContract.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Guards the contract between the `expert-review` agent, which returns a scored plan
+ * review, and `pipeline.md`, which aggregates a panel of them into the plan's single score.
+ *
+ * The reason this guard exists: the agent repeatedly returned confident reviews built on
+ * file contents it had never read, reporting no tool use, and its own prose prohibition
+ * against doing so did not stop it. The fix is not a stronger instruction — it is a
+ * declared `grounding` field the parent can screen, and a parent that discards rather
+ * than averages a review that fails the screen. Both halves have to stay in place for
+ * either to be worth anything, and they live in two prompt files with no import between
+ * them, so nothing but a test relates them.
+ *
+ * Three properties are load-bearing:
+ *
+ * 1. The field list the agent emits matches the one the pipeline says it receives. The
+ *    field names are parsed from the agent's own output table rather than hardcoded, so
+ *    renaming one fails here instead of silently dropping from the screen.
+ * 2. The pipeline states the discard rule and every condition that triggers it. A
+ *    condition quietly deleted turns the screen back into an average-everything step.
+ * 3. The pipeline refuses to present a shrunken panel as a consensus. Two of five
+ *    reviewers failing is the observed case, and reporting the survivor's score as a
+ *    panel aggregate is how that becomes invisible.
+ *
+ * What this CANNOT prove: that the screen runs, or that a reviewer declares its grounding
+ * honestly — a fabricated `grounding` entry is still possible and is exactly why the
+ * pipeline also screens for the no-tool-use contradiction rather than trusting the field
+ * alone. CI sees text in a file, nothing more.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+const actionDir = join(import.meta.dirname, "..");
+const repoRoot = join(actionDir, "..", "..", "..");
+const autopilotDir = join(repoRoot, "claude-plugins/autopilot");
+
+const [agent, pipeline, chapter] = await Promise.all([
+  readFile(join(autopilotDir, "agents/expert-review.md"), "utf8"),
+  readFile(join(autopilotDir, "skills/plan/references/pipeline.md"), "utf8"),
+  readFile(join(repoRoot, "docs/05-plan-run-skills.md"), "utf8"),
+]);
+
+/**
+ * The `| \`field\` |` rows of the agent's Phase 4 output table, sliced to that section so
+ * the five-dimension rubric table above it does not leak in.
+ */
+function outputFields(source: string): string[] {
+  const section = source.split("## Phase 4: Output")[1]?.split("Example (illustrative")[0] ?? "";
+  return [...section.matchAll(/^\|\s*`(\w+)`/gm)].map((row) => row[1]);
+}
+
+/** The backticked names on the pipeline's "Each returns JSON (…)" line. */
+function pipelineFields(source: string): string[] {
+  const line = source.split("\n").find((l) => l.startsWith("Each returns JSON ("));
+  return [...(line ?? "").matchAll(/`(\w+)`/g)].map((m) => m[1]);
+}
+
+/**
+ * Top-level keys of the `expert-review` payload sketch in chapter 5's sub-agent contract
+ * list — a third copy of the same contract, and the one that already drifted once.
+ * Nested keys inside `dimensions{…}` are stripped so only the outer shape is compared.
+ */
+function chapterFields(source: string): string[] {
+  const line = source.split("\n").find((l) => l.startsWith("- `expert-review` →"));
+  const body = (line ?? "").replace(/(\w)\{[^{}]*\}/g, "$1");
+  return [...body.matchAll(/[{,]\s*(\w+)/g)].map((m) => m[1]);
+}
+
+const declared = outputFields(agent);
+
+describe("expert review contract", () => {
+  test("the agent's output table is parseable and non-trivial", () => {
+    expect(declared.length).toBeGreaterThan(4);
+    expect(declared).toContain("findings");
+  });
+
+  test("the agent declares a grounding field", () => {
+    expect(declared).toContain("grounding");
+  });
+
+  test("grounding is required, not optional", () => {
+    const row = agent.split("\n").find((l) => /^\|\s*`grounding`/.test(l)) ?? "";
+    expect(`grounding row: ${row}`).toContain("Never empty");
+  });
+
+  test("the example payload carries grounding, so the shape is copyable", () => {
+    const example = agent.split("```json")[1]?.split("```")[0] ?? "";
+    expect(example).toContain('"grounding"');
+  });
+
+  test("the pipeline receives exactly the fields the agent emits", () => {
+    expect(pipelineFields(pipeline).sort()).toEqual([...declared].sort());
+  });
+
+  test("chapter 5 documents exactly the fields the agent emits", () => {
+    expect(chapterFields(chapter).sort()).toEqual([...declared].sort());
+  });
+
+  test("chapter 5 records that an ungrounded review is discarded, not averaged", () => {
+    expect(chapter).toContain("discarded rather than averaged");
+  });
+
+  test.each([
+    ["empty grounding", "`grounding` is absent or empty"],
+    ["unparseable report", "not parseable as the JSON contract"],
+    ["no-tool-use contradiction", "reported no tool use"],
+  ])("the pipeline names the %s discard condition", (_label, needle) => {
+    expect(pipeline).toContain(needle);
+  });
+
+  test("the pipeline discards rather than averages", () => {
+    const [, screen = ""] = pipeline.split("Discard an ungrounded review");
+    expect(screen).toContain("Name every discard");
+    expect(screen).toContain("never silently shrink the panel");
+  });
+
+  test("a shrunken panel is not reported as a consensus", () => {
+    expect(pipeline).toContain("single surviving reviewer is a single opinion");
+    expect(pipeline).toContain("report that the plan is unreviewed");
+  });
+
+  test("the agent still forbids asserting unread file contents", () => {
+    expect(agent).toContain("an inferred file listing is a fabrication");
+    expect(agent).toContain("Do not list a file you did not open");
+  });
+});

--- a/claude-plugins/autopilot/agents/expert-review.md
+++ b/claude-plugins/autopilot/agents/expert-review.md
@@ -76,6 +76,7 @@ Output ONLY a single JSON object matching the schema below — no preamble, no s
 | `dimensions` | object                             | `{ "alignment": int, "completeness": int, "typeSafety": int, "testability": int, "simplicity": int }`, each 0–20; all five keys always present |
 | `verdict`    | `"approved"` \| `"needs-revision"` | `"approved"` when `score` meets the target, otherwise `"needs-revision"`                                                                       |
 | `findings`   | string[]                           | 3–5 entries, strongest first; stack minor objections together rather than listing each                                                         |
+| `grounding`  | string[]                           | What you actually consulted, one entry each — see [Phase 4a](#phase-4a-declare-your-grounding). Never empty                                    |
 | `revision`   | object \| null                     | `null` when no [Phase 3](#phase-3-recommend-changes) changes were needed; otherwise advisory `{ "changed": string, "rescore": integer }`       |
 
 Example (illustrative — emit the raw object, not this fenced form):
@@ -93,8 +94,17 @@ Example (illustrative — emit the raw object, not this fenced form):
   },
   "verdict": "approved",
   "findings": ["Finding 1", "Finding 2", "Finding 3"],
+  "grounding": ["plan text", "Context Map excerpt: relevant files, test conventions"],
   "revision": null
 }
 ```
 
 Do not output intermediate reasoning, analysis steps, or commentary — only the JSON object.
+
+## Phase 4a: Declare your grounding
+
+`grounding` names the evidence behind your findings, so the parent can tell a review built on something from one built on nothing. List one entry per source you actually used — `plan text`, `Context Map excerpt: <which sections>`, or the path of a file you genuinely read. It is never empty: at minimum you were given the plan.
+
+**Do not list a file you did not open.** You declare `tools: []`, so unless your prompt hands you a file's contents you have no way to read one — and naming it anyway is the fabrication this field exists to expose. When a question turns on a file you were not given, the honest entry is the excerpt you did have, and the finding says the plan is unverifiable on that point.
+
+The parent [discards a review whose grounding does not support its findings](../skills/plan/references/pipeline.md#review-and-score-task-4) rather than averaging it into the score, so an invented source costs the whole review rather than passing unnoticed.

--- a/claude-plugins/autopilot/skills/plan/references/pipeline.md
+++ b/claude-plugins/autopilot/skills/plan/references/pipeline.md
@@ -78,7 +78,17 @@ Use the Agent tool with:
 
 Pass the Context Map excerpt, not just the plan text. A reviewer with no view of the repository infers file contents, and an invented finding is worse than a missing one.
 
-Each returns JSON (`expertRole`, `score`, `dimensions`, `verdict`, `findings`, `revision`). Aggregate:
+Each returns JSON (`expertRole`, `score`, `dimensions`, `verdict`, `findings`, `grounding`, `revision`).
+
+**Discard an ungrounded review before aggregating.** A reviewer that asserts what a file contains without having read it produces findings that are confident and wrong, which costs more than a finding it never made — so screen each panel member first and drop, rather than average, any that fails:
+
+- Its `grounding` is absent or empty.
+- Its report is not parseable as the JSON contract at all.
+- It reported no tool use, yet its findings quote file contents, identifiers, or line numbers that neither the plan nor the Context Map excerpt contains. That combination is a contradiction: with no tools it could only have been given text, so anything beyond that text was invented.
+
+Name every discard in the run — `Discarded <role>: <reason>` — and never silently shrink the panel. A single surviving reviewer is a single opinion, so say so instead of presenting its score as a panel aggregate; when nothing survives, report that the plan is unreviewed rather than emitting a score. Re-launching a discarded role once is reasonable; doing it repeatedly is not, because the same prompt tends to fail the same way.
+
+Aggregate what survives:
 
 1. **Score** — average each reviewer's `dimensions` into the five-dimension rubric below, 20 points each, 100 total.
 

--- a/docs/05-plan-run-skills.md
+++ b/docs/05-plan-run-skills.md
@@ -251,7 +251,9 @@ Sub-agents isolate work from the parent's context. Each returns a single schema-
 - `resolve-issue-context` → `{ source, issueId, title, status, labels[], assignee|null, url|null, description, comments[], resolveError|null }`
 - `resolve-alert-context` → `{ source, alertNumber, ruleId, severity, state, file, line, message, htmlUrl, resolveError|null }` (alert input only)
 - `search-codebase-todos` → `{ todos[{location, text}], total }`
-- `expert-review` → `{ expertRole, score, dimensions{alignment,completeness,typeSafety,testability,simplicity}, verdict, findings[3–5], revision|null }`
+- `expert-review` → `{ expertRole, score, dimensions{alignment,completeness,typeSafety,testability,simplicity}, verdict, findings[3–5], grounding[], revision|null }`
+
+`grounding` names what a reviewer actually consulted, and the pipeline screens on it: a panel member with empty grounding, an unparseable report, or file claims it had no tools to make is **discarded rather than averaged**, every discard is named, and a panel that loses everyone reports the plan as unreviewed instead of emitting a score.
 
 ## How run differs: automated post-implementation
 


### PR DESCRIPTION
While planning #497, three of five `expert-review` invocations returned confident, detailed reviews built on file contents the agent had never read — each reporting `tool_uses: 0`. One printed two mutually contradictory versions of the same test file, inventing identifiers and an import that does not exist; retried with the prohibition restated more strongly, it fabricated again and emitted literal non-code. Two produced no parseable verdict at all, so the panel silently shrank to a single voice whose score was then presented as a panel aggregate.

The agent's Phase 1 already prohibited exactly this, in plain terms, and that did not stop it. So this does not add a stronger instruction — it adds something the parent can check.

- **The agent now declares its grounding.** A required `grounding` array names what it actually consulted, and is never empty (at minimum it was handed the plan). The prose is explicit that it must not name a file it did not open, and explains why it cannot have: it declares `tools: []`, so unless the prompt hands it a file's contents it has no way to read one.
- **The parent screens before it averages.** `pipeline.md` now discards a panel member whose `grounding` is empty, whose report is unparseable, or that reported no tool use while quoting file contents the plan and Context Map excerpt do not contain — that last one being a contradiction rather than a judgement call.
- **A shrunken panel is no longer reported as a consensus.** Every discard is named in the run, a single survivor is reported as a single opinion, and a panel where nothing survives reports the plan as unreviewed instead of emitting a score.
- **`expertReviewContract.test.ts`** pins both halves. The field names are parsed from the agent's own output table rather than hardcoded, so a rename fails the test instead of silently dropping a field from the screen, and the test asserts the pipeline receives exactly the set the agent emits.

The guard was mutation-tested: removing the `grounding` row from the agent's table fails three assertions including field parity, deleting any one discard condition fails its named case, and softening "never silently shrink the panel" fails the discard test.

Worth being straight about the limits. This cannot prove the screen runs, and a fabricated `grounding` entry remains possible — which is why the pipeline also screens for the no-tool-use contradiction rather than trusting the declared field alone. Granting the agent `Read` so it could verify was the other option in #499; it is not taken here, because it changes cost and latency on every planning run and the screen is worth having either way.

A note on this PR's own verification: `linkResolution` caught a broken heading anchor I introduced in the agent's cross-reference to `pipeline.md`, which is precisely the class of defect the check added in #506 now catches on every pull request.

---

**Issues:**

Closes #499
