### PR TITLE
Record how a plan reached its score, not just the number

### DIFF
--- a/.github/actions/code-review-action/src/expertReviewContract.test.ts
+++ b/.github/actions/code-review-action/src/expertReviewContract.test.ts
@@ -120,6 +120,36 @@ describe("expert review contract", () => {
     expect(pipeline).toContain("report that the plan is unreviewed");
   });
 
+  /**
+   * The recorded score line is the sample that answers whether the threshold is set
+   * correctly. An aggregate alone cannot separate "cleared it immediately" from "burned
+   * the whole budget to land just short", so the passes and the exit reason have to be
+   * written down at the moment they are known — nothing reconstructs them later.
+   */
+  test.each(["target reached", "no improvement", "budget spent"])(
+    "the pipeline records the %s exit reason",
+    (reason) => {
+      expect(pipeline).toContain(reason);
+    },
+  );
+
+  test("the recorded score line carries passes, exit reason, and weakest dimension", () => {
+    expect(pipeline).toContain("pass(es)");
+    expect(pipeline).toContain("exit reason");
+    // Without this the below-target case records a number with no indication of what
+    // was weak, which is the half of the sample that says why the bar was missed.
+    expect(pipeline).toContain("weakest:");
+    expect(pipeline).toContain("weakest dimension");
+  });
+
+  test("chapter 5 documents the same recorded score line", () => {
+    expect(chapter).toContain("pass(es)");
+    expect(chapter).toContain("weakest dimension");
+    for (const reason of ["target reached", "no improvement", "budget spent"]) {
+      expect(chapter).toContain(reason);
+    }
+  });
+
   test("the agent still forbids asserting unread file contents", () => {
     expect(agent).toContain("an inferred file listing is a fabrication");
     expect(agent).toContain("Do not list a file you did not open");

--- a/claude-plugins/autopilot/skills/plan/references/pipeline.md
+++ b/claude-plugins/autopilot/skills/plan/references/pipeline.md
@@ -114,7 +114,15 @@ Set task 4 to `completed`.
 
 Set task 5 ("Finalize plan") to `in_progress`.
 
-Apply the aggregated findings and score to the draft, then write the plan file, replacing the `Score:` placeholder with `Score: [X]/100`.
+Apply the aggregated findings and score to the draft, then write the plan file, replacing the `Score:` placeholder with a line that records how the score was reached, not just what it was:
+
+```text
+Score: <N>/100 · <P> pass(es) · <exit reason>[ · weakest: <dimension>]
+```
+
+`<exit reason>` is one of `target reached`, `no improvement`, or `budget spent`, matching the three ways [the revision loop](#review-and-score-task-4) ends. Name the weakest dimension whenever the score is below the target; omit that clause when the target was reached.
+
+Recording the passes and the exit reason costs one line and makes every plan file a data point. The aggregate alone cannot distinguish a plan that cleared the bar immediately from one that burned the whole budget to land just short — and those two say opposite things about whether the threshold is set correctly. Without the line, answering that question later means re-running plans rather than reading the ones already written.
 
 Apply the reference-formatting rules (RFC-0001, inlined at the end of the calling skill) to every reference the plan contains — link files, docs, skills, agents, and sections, and never leave a reference as bare text.
 

--- a/docs/05-plan-run-skills.md
+++ b/docs/05-plan-run-skills.md
@@ -202,6 +202,8 @@ Scoring used to be a separate phase running a second rubric over what the expert
 
 Apply the aggregated findings and score to the draft, replace the `Score:` placeholder, and write the plan file, with every reference formatted per RFC-0001.
 
+The recorded line carries how the score was reached, not only what it was — `Score: <N>/100 · <P> pass(es) · <exit reason>`, where the exit reason is `target reached`, `no improvement`, or `budget spent`, plus the weakest dimension when the score fell short. That distinction is the point: an aggregate alone cannot separate a plan that cleared the bar on the first pass from one that spent the whole budget to land just under, and those two say opposite things about whether the threshold is set correctly. Because every plan file records it, the sample needed to answer that accrues on its own rather than requiring plans to be re-run.
+
 ## Phase 5 — Embed branch creation
 
 The skill embeds the branch step into the plan file so it runs first, before any code changes — in `plan` after the user approves, in `run` straight away. [`references/branch-blocks.md`](../claude-plugins/autopilot/skills/plan/references/branch-blocks.md) keys two things by input type: the prose body inserted into the plan file, and the **Mechanics** paragraph beside it holding the `branch-create` invocation the caller runs. Because the flags live in Mechanics rather than in the inserted text, all four bodies are identical for `plan` and `run` — a `run` variant is now a different argument at execution time, not a different section body.


### PR DESCRIPTION
#503 asks whether the 98 scoring target is reachable, or whether it just triples expert cost while never blocking three of its four callers. That cannot be settled by reasoning — it needs a sample. The blocker was that no sample was accruing: a plan file recorded its final score and nothing else, and an aggregate alone cannot separate a plan that cleared the bar on the first pass from one that spent the whole budget to land at 97. Those two say opposite things about whether the threshold is set correctly.

- The recorded line becomes `Score: <N>/100 · <P> pass(es) · <exit reason>`, with the weakest dimension appended when the score fell short.
- `<exit reason>` is one of `target reached`, `no improvement`, or `budget spent` — the three ways the revision loop can end, so the value distinguishes "cleared it" from "stopped improving" from "ran out of budget".
- Chapter 5's pipeline walkthrough documents the same line, and the guard asserts both copies plus all three exit reasons. That third-copy assertion exists because the previous change to this contract drifted in exactly that spot.

**This is `Part of` rather than `Closes`, deliberately.** It removes what was blocking #503 — the evidence now accrues on its own, in files that get written anyway, instead of requiring someone to re-run plans later to reconstruct it. But the issue asks whether 98 is reachable, and that question needs a sample this PR cannot manufacture. Closing it on the strength of instrumentation alone would mark a question answered that nobody has answered.

Cost is one line per plan file. The alternative was to leave the score alone and re-run plans when the question came up, which pays the full pipeline repeatedly to recover data that was free at the moment it existed.

Current sample, for the record: two runs, both landing at 97 after revision — consistent with the pre-mortem's prediction when the threshold was raised, but two points is not evidence.

---

**Issues:**

Part of #503
