### PR TITLE
TRIVIAL: Preserve Graphify sync support

### DIFF
--- a/.github/actions/repomix-sync/README.md
+++ b/.github/actions/repomix-sync/README.md
@@ -82,6 +82,8 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 
 - Delegates to `files-sync` with a fixed sync list — `.github/workflows/repomix-pack.yml` and
   `repomix.config.json` — sourced from `source-repo` at `source-ref`.
+- The synced config excludes both `.repomix/**` and `graphify-out/**`, so repositories that
+  commit a graphify knowledge graph do not duplicate it inside the Repomix snapshot.
 - The PR is opened on the fixed branch `maintenance-sync-repomix` with the title
   `MAINTENANCE: Sync repomix pack from upstream` and the commit message
   `chore: sync repomix pack from upstream`. These values are not configurable so the action

--- a/docs/09-repomix-pack.md
+++ b/docs/09-repomix-pack.md
@@ -47,7 +47,7 @@ The `.github/workflows/repomix-pack.yml` workflow regenerates the pack on every 
 `repomix.config.json` at the repo root pins the output for a clean, reviewable diff:
 
 - `output.filePath: ".repomix/pack.xml"` and `output.style: "xml"` — fixed location and format.
-- `ignore.customPatterns: [".repomix/**"]` — excludes the pack itself, so each run does not re-pack the previously committed snapshot (which would cause recursive bloat and a perpetually-dirty diff).
+- `ignore.customPatterns: [".repomix/**", "graphify-out/**"]` — excludes the pack itself and any committed graphify knowledge graph, avoiding both recursive pack growth and duplication of the graph artifact in the flat snapshot.
 - `output.git.sortByChanges: false` — Repomix defaults this to `true`, ordering files by git-change frequency, which shifts on every merge and produces noise unrelated to actual code changes.
 
 `node_modules/`, `dist/`, `.turbo/`, and `coverage/` are excluded automatically because Repomix honors `.gitignore` and its built-in default patterns.

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -7,6 +7,6 @@
     }
   },
   "ignore": {
-    "customPatterns": [".repomix/**"]
+    "customPatterns": [".repomix/**", "graphify-out/**"]
   }
 }

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -402,3 +402,12 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 ## 17. Code Review
 
 - All rules from CLAUDE.md must be applied to the code review
+
+## 18. Graphify
+
+When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
+
+- Read `graphify-out/GRAPH_REPORT.md` first for the architecture overview.
+- Query the graph offline with `graphify query "<question>" --graph graphify-out/graph.json`, `graphify path "<A>" "<B>" --graph graphify-out/graph.json`, and `graphify explain "<concept>" --graph graphify-out/graph.json`.
+- Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -271,3 +271,12 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 ## 17. Code Review
 
 - All rules from CLAUDE.md must be applied to the code review
+
+## 18. Graphify
+
+When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
+
+- Read `graphify-out/GRAPH_REPORT.md` first for the architecture overview.
+- Query the graph offline with `graphify query "<question>" --graph graphify-out/graph.json`, `graphify path "<A>" "<B>" --graph graphify-out/graph.json`, and `graphify explain "<concept>" --graph graphify-out/graph.json`.
+- Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -393,3 +393,12 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 ## 17. Code Review
 
 - All rules from CLAUDE.md must be applied to the code review
+
+## 18. Graphify
+
+When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
+
+- Read `graphify-out/GRAPH_REPORT.md` first for the architecture overview.
+- Query the graph offline with `graphify query "<question>" --graph graphify-out/graph.json`, `graphify path "<A>" "<B>" --graph graphify-out/graph.json`, and `graphify explain "<concept>" --graph graphify-out/graph.json`.
+- Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -389,3 +389,12 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 ## 17. Code Review
 
 - All rules from CLAUDE.md must be applied to the code review
+
+## 18. Graphify
+
+When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
+
+- Read `graphify-out/GRAPH_REPORT.md` first for the architecture overview.
+- Query the graph offline with `graphify query "<question>" --graph graphify-out/graph.json`, `graphify path "<A>" "<B>" --graph graphify-out/graph.json`, and `graphify explain "<concept>" --graph graphify-out/graph.json`.
+- Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).


### PR DESCRIPTION
## Summary

- exclude the generated `graphify-out/**` knowledge graph from distributed Repomix packs
- distribute the canonical Graphify context guidance through all four stack rules
- document the synchronized Graphify contract

## Why

#541 added Graphify-aware context gathering, but the synchronized Repomix config and stack rules were not updated with the same contract. That makes downstream maintenance syncs incorrectly propose removing Graphify configuration and guidance, as seen in `wefortis/fortune-os#507` and `wefortis/fortune-os#508`.

The distributed guidance follows the shared Autopilot contract: read `GRAPH_REPORT.md` before targeted graph queries.

## Verification

- `bun run lint`
- `bun run test`
- `git diff --check`