### PR TITLE
MAINTENANCE: Split license workflow sync

### DIFF
--- a/.github/actions/contributing-sync/README.md
+++ b/.github/actions/contributing-sync/README.md
@@ -10,10 +10,9 @@ The synced set is:
 - `SECURITY.md`
 - `.github/workflows/contributing.yml`
 - `.github/workflows/auto-label.yml`
-- `.github/workflows/licenses.yml`
 - `.github/workflows/validate-actions.yml`
 
-The first four are the contributor-facing documentation. The four workflows propagate CI that
+The first four are the contributor-facing documentation. The three workflows propagate CI that
 references upstream actions on every run — the actions themselves stay in the upstream
 repository, so consumers do not need a local copy:
 
@@ -21,8 +20,6 @@ repository, so consumers do not need a local copy:
   `awinogradov/code-assistants/.github/actions/contributing-check@main`.
 - `auto-label.yml` runs [`auto-label`](../auto-label/README.md) via
   `awinogradov/code-assistants/.github/actions/auto-label@main`.
-- `licenses.yml` runs [`licenses-audit`](../licenses-audit/README.md) via
-  `awinogradov/code-assistants/.github/actions/licenses-audit@main`.
 - `validate-actions.yml` runs [`validate-actions`](../validate-actions/README.md) via
   `awinogradov/code-assistants/.github/actions/validate-actions@main`.
 
@@ -92,8 +89,7 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 
 - Delegates to `files-sync` with a fixed sync list — `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`,
   `LICENSE.md`, `SECURITY.md`, `.github/workflows/contributing.yml`, `.github/workflows/auto-label.yml`,
-  `.github/workflows/licenses.yml`, and `.github/workflows/validate-actions.yml` — sourced from
-  `source-repo` at `source-ref`.
+  and `.github/workflows/validate-actions.yml` — sourced from `source-repo` at `source-ref`.
 - The PR is opened on the fixed branch `maintenance-sync-contributing` with the title
   `MAINTENANCE: Sync contributing files from upstream` and the commit message
   `chore: sync contributing files from upstream`. These values are not configurable so the

--- a/.github/actions/files-sync/README.md
+++ b/.github/actions/files-sync/README.md
@@ -106,6 +106,8 @@ See GitHub's docs for [creating a fine-grained PAT](https://docs.github.com/en/a
 - A single PR with all changed files is created (or reused if `branch` already has an open PR).
 - The PR link is surfaced on the run page as a `::notice` annotation (titled with the PR title) in addition to the step-summary link, so a scheduled sync run leads straight to its PR.
 - The head `branch` is force-updated on every run.
+- If the declared file set has no differences, an open PR for `branch` is closed so a stale
+  sync diff cannot remain mergeable after inputs change.
 - A reused PR's title and body are refreshed on every run, so the `**Updated files:**` list always reflects the current diff — not just the files that differed when the PR was first opened.
 - If no files differ between source and destination, no PR is created and the action exits cleanly.
 - A missing source path fails the run with `Source not found at <repo>:<path>`.

--- a/.github/actions/files-sync/files-sync.ts
+++ b/.github/actions/files-sync/files-sync.ts
@@ -22,7 +22,10 @@ import { createOctokit } from '@code-assistants/actions-core/createOctokit';
 
 import { resolveBotIdentity } from './src/botIdentity.ts';
 import { computeChanges } from './src/changeDetector.ts';
-import { createSyncPullRequest } from './src/createSyncPullRequest.ts';
+import {
+  closeStaleSyncPullRequest,
+  createSyncPullRequest,
+} from './src/createSyncPullRequest.ts';
 import {
   isSymlinkEntry,
   parseFilesInput,
@@ -156,7 +159,17 @@ async function main(): Promise<void> {
   });
 
   if (changes.length === 0) {
-    core.info('No file differences detected. Skipping PR creation.');
+    const closed = await closeStaleSyncPullRequest({
+      octokit,
+      destRepo: env.destRepo,
+      base: env.base,
+      branch: env.branch,
+    });
+    if (closed === null) {
+      core.info('No file differences detected. Skipping PR creation.');
+    } else {
+      core.notice(`Closed obsolete sync pull request: ${closed.htmlUrl}`);
+    }
     core.setOutput('changed-files', '');
     core.setOutput('pr-number', '');
     core.setOutput('pr-url', '');

--- a/.github/actions/files-sync/src/createSyncPullRequest.test.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.test.ts
@@ -4,7 +4,7 @@ import type { Octokit } from '@octokit/rest';
 
 import type { BotIdentity } from './botIdentity.ts';
 import type { FileChange } from './changeDetector.ts';
-import { createSyncPullRequest } from './createSyncPullRequest.ts';
+import { closeStaleSyncPullRequest, createSyncPullRequest } from './createSyncPullRequest.ts';
 
 interface MockOverrides {
   listOpenPrs?: () => Promise<{ data: Array<{ number: number; html_url: string }> }>;
@@ -13,8 +13,9 @@ interface MockOverrides {
     owner: string;
     repo: string;
     pull_number: number;
-    title: string;
-    body: string;
+    title?: string;
+    body?: string;
+    state?: 'closed';
   }) => Promise<{ data: unknown }>;
   createCommit?: (args: {
     author: BotIdentity;
@@ -146,5 +147,48 @@ describe('createSyncPullRequest', () => {
     });
 
     await expect(createSyncPullRequest({ octokit, ...baseArgs })).rejects.toThrow(/^boom$/);
+  });
+});
+
+describe('closeStaleSyncPullRequest', () => {
+  test('closes an existing sync PR when declared files have no differences', async () => {
+    let captured: unknown;
+    const octokit = makeOctokit({
+      listOpenPrs: async () => ({
+        data: [{ number: 7, html_url: 'https://github.com/owner/repo/pull/7' }],
+      }),
+      updatePr: async (args) => {
+        captured = args;
+        return { data: {} };
+      },
+    });
+
+    const closed = await closeStaleSyncPullRequest({
+      octokit,
+      destRepo: baseArgs.destRepo,
+      base: baseArgs.base,
+      branch: baseArgs.branch,
+    });
+
+    expect(closed).toEqual({ number: 7, htmlUrl: 'https://github.com/owner/repo/pull/7' });
+    expect(captured).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+      pull_number: 7,
+      state: 'closed',
+    });
+  });
+
+  test('is a no-op when no sync PR is open', async () => {
+    const octokit = makeOctokit();
+
+    const closed = await closeStaleSyncPullRequest({
+      octokit,
+      destRepo: baseArgs.destRepo,
+      base: baseArgs.base,
+      branch: baseArgs.branch,
+    });
+
+    expect(closed).toBeNull();
   });
 });

--- a/.github/actions/files-sync/src/createSyncPullRequest.ts
+++ b/.github/actions/files-sync/src/createSyncPullRequest.ts
@@ -31,6 +31,44 @@ export interface SyncPullRequest {
   htmlUrl: string;
 }
 
+interface CloseStaleArgs {
+  octokit: Octokit;
+  destRepo: { owner: string; name: string };
+  base: string;
+  branch: string;
+}
+
+/** Close an obsolete sync PR after its declared file set becomes clean. */
+export async function closeStaleSyncPullRequest({
+  octokit,
+  destRepo,
+  base,
+  branch,
+}: CloseStaleArgs): Promise<SyncPullRequest | null> {
+  const { owner, name: repo } = destRepo;
+  const existing = await octokit.rest.pulls.list({
+    owner,
+    repo,
+    state: 'open',
+    head: `${owner}:${branch}`,
+    base,
+  });
+  const open = existing.data[0];
+
+  if (open === undefined) {
+    return null;
+  }
+
+  await octokit.rest.pulls.update({
+    owner,
+    repo,
+    pull_number: open.number,
+    state: 'closed',
+  });
+
+  return { number: open.number, htmlUrl: open.html_url };
+}
+
 export async function createSyncPullRequest({
   octokit,
   destRepo,

--- a/.github/actions/licenses-sync/README.md
+++ b/.github/actions/licenses-sync/README.md
@@ -1,0 +1,67 @@
+# Licenses sync
+
+Composite GitHub Action that syncs the canonical `.github/workflows/licenses.yml` from an
+upstream repository into the current repository and opens a pull request with the difference.
+Keeping licenses as a standalone sync kind lets consumers opt out without disabling the other
+contributing files and workflows.
+
+The action delegates the diff and PR mechanics to
+[`files-sync`](../files-sync/README.md). It does not require `actions/checkout` and never touches
+the runner's working tree.
+
+## Usage
+
+```yaml
+name: Sync licenses workflow
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: awinogradov/code-assistants/.github/actions/licenses-sync@v1
+        with:
+          bot_token: ${{ secrets.BOT_TOKEN }}
+          bot_username: ${{ vars.BOT_USERNAME }}
+```
+
+## Inputs
+
+| Input          | Required | Default                       | Description                                                                                                                                                    |
+| -------------- | -------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bot_token`    | yes      | —                             | PAT or GitHub App installation token with `contents: write` + `pull-requests: write` on this repo. The workflow's default `GITHUB_TOKEN` is **not** supported. |
+| `bot_username` | no       | `github-actions[bot]`         | Git author/committer login for the sync commit. Pass `${{ vars.BOT_USERNAME }}`. The PR itself is opened by the `bot_token` owner.                             |
+| `source-repo`  | no       | `awinogradov/code-assistants` | Source repository in `owner/name` form that hosts the canonical `.github/workflows/licenses.yml`.                                                              |
+| `source-ref`   | no       | _(empty)_                     | Branch, tag, or SHA to read the source file from. Empty means the source repository's default branch.                                                          |
+
+## Outputs
+
+| Output          | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `changed-files` | Newline-separated list of destination paths that were updated.       |
+| `pr-number`     | Number of the opened or reused PR. Empty when no changes detected.   |
+| `pr-url`        | HTML URL of the opened or reused PR. Empty when no changes detected. |
+
+## Behavior
+
+- Syncs only `.github/workflows/licenses.yml` from `source-repo` at `source-ref`.
+- Opens or force-updates `maintenance-sync-licenses` with the title
+  `MAINTENANCE: Sync licenses workflow from upstream`.
+- If the destination already matches upstream, no PR is created.
+- Missing source files fail the run with `Source not found at <repo>:<path>`.
+
+## Versioning
+
+Reference the action by tag of the autopilot repo, for example:
+
+```yaml
+uses: awinogradov/code-assistants/.github/actions/licenses-sync@v1
+```

--- a/.github/actions/licenses-sync/action.yml
+++ b/.github/actions/licenses-sync/action.yml
@@ -1,5 +1,5 @@
-name: Contributing sync
-description: Sync CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE.md, SECURITY.md, and the contributing, auto-label, and validate-actions workflows from an upstream repository into the current repository.
+name: Licenses sync
+description: Sync the licenses workflow from an upstream repository into the current repository.
 
 inputs:
   bot_token:
@@ -11,11 +11,11 @@ inputs:
       Git author/committer login for the sync commit. Defaults to `github-actions[bot]` when unset. Pass the `vars.BOT_USERNAME` repository variable to attribute commits to a dedicated bot identity.
     required: false
   source-repo:
-    description: Source repository in `owner/name` form that hosts the canonical `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, and `SECURITY.md`.
+    description: Source repository in `owner/name` form that hosts the canonical licenses workflow.
     required: false
     default: awinogradov/code-assistants
   source-ref:
-    description: Branch, tag, or SHA to read the source files from. Defaults to the source repository's default branch.
+    description: Branch, tag, or SHA to read the source file from. Defaults to the source repository's default branch.
     required: false
     default: ""
 
@@ -41,25 +41,14 @@ runs:
         INPUT_SOURCE_REF: ${{ inputs.source-ref }}
       run: |
         set -euo pipefail
-        paths=(
-          CONTRIBUTING.md
-          CODE_OF_CONDUCT.md
-          LICENSE.md
-          SECURITY.md
-          .github/workflows/contributing.yml
-          .github/workflows/auto-label.yml
-          .github/workflows/validate-actions.yml
-        )
         {
           echo "files<<__EOF__"
-          for path in "${paths[@]}"; do
-            echo "- repo: ${INPUT_SOURCE_REPO}"
-            echo "  source: ${path}"
-            echo "  dest: ${path}"
-            if [ -n "${INPUT_SOURCE_REF}" ]; then
-              echo "  ref: ${INPUT_SOURCE_REF}"
-            fi
-          done
+          echo "- repo: ${INPUT_SOURCE_REPO}"
+          echo "  source: .github/workflows/licenses.yml"
+          echo "  dest: .github/workflows/licenses.yml"
+          if [ -n "${INPUT_SOURCE_REF}" ]; then
+            echo "  ref: ${INPUT_SOURCE_REF}"
+          fi
           echo "__EOF__"
         } >> "${GITHUB_OUTPUT}"
 
@@ -70,7 +59,7 @@ runs:
         files: ${{ steps.resolve.outputs.files }}
         bot_token: ${{ inputs.bot_token }}
         bot_username: ${{ inputs.bot_username }}
-        branch: maintenance-sync-contributing
-        title: "MAINTENANCE: Sync contributing files from upstream"
-        body: Automated contributing files sync from upstream.
-        commit-message: "chore: sync contributing files from upstream"
+        branch: maintenance-sync-licenses
+        title: "MAINTENANCE: Sync licenses workflow from upstream"
+        body: Automated licenses workflow sync from upstream.
+        commit-message: "chore: sync licenses workflow from upstream"

--- a/.github/actions/upstream-sync/README.md
+++ b/.github/actions/upstream-sync/README.md
@@ -1,6 +1,6 @@
 # Upstream sync
 
-Composite GitHub Action that aggregates the five upstream maintenance syncs behind a single
+Composite GitHub Action that aggregates the six upstream maintenance syncs behind a single
 action. Every consumer runs one job instead of one job per kind. Each kind is opt-out: it runs
 by default and is disabled by setting its input to `false`. The kinds are:
 
@@ -8,7 +8,8 @@ by default and is disabled by setting its input to `false`. The kinds are:
 - `code-review` → [`code-review-sync`](../code-review-sync/README.md) — sync the AI code-review workflow.
 - `repomix` → [`repomix-sync`](../repomix-sync/README.md) — sync the `repomix-pack` workflow and `repomix.config.json`.
 - `release` → [`release-sync`](../release-sync/README.md) — sync the release pipeline workflows (create, publish, auto-merge).
-- `contributing` → [`contributing-sync`](../contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, `SECURITY.md`, and the contributing + auto-label workflows.
+- `licenses` → [`licenses-sync`](../licenses-sync/README.md) — sync the licenses workflow.
+- `contributing` → [`contributing-sync`](../contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, `SECURITY.md`, and the contributing, auto-label, and validate-actions workflows.
 
 Each kind is a gated step that delegates to its child `*-sync` action, which in turn delegates the
 diff and PR mechanics to [`files-sync`](../files-sync/README.md). New sync kinds added upstream
@@ -57,6 +58,7 @@ jobs:
 | `code-review`  | no       | `true`                | When `true`, sync the AI code-review workflow. Set to `false` to opt out.                                                                                                                        |
 | `repomix`      | no       | `true`                | When `true`, sync the repomix-pack workflow and `repomix.config.json`. Set to `false` to opt out.                                                                                                |
 | `release`      | no       | `true`                | When `true`, sync the release pipeline workflows. Set to `false` to opt out.                                                                                                                     |
+| `licenses`     | no       | `true`                | When `true`, sync the licenses workflow. Set to `false` to opt out.                                                                                                                              |
 | `contributing` | no       | `true`                | When `true`, sync the contributing artefacts and workflows. Set to `false` to opt out.                                                                                                           |
 
 The kind inputs are booleans expressed as strings — use `true` / `false`, not YAML's `yes` / `on`
@@ -84,7 +86,7 @@ The `repomix` kind additionally requires the `bot_token` identity to be a **bypa
 
 ## Behavior
 
-- Runs the five child syncs as steps in a single job, each gated by its `<kind>` input (`if: inputs['<kind>'] == 'true'`). A disabled kind is skipped.
+- Runs the six child syncs as steps in a single job, each gated by its `<kind>` input (`if: inputs['<kind>'] == 'true'`). A disabled kind is skipped.
 - Each enabled kind delegates to its `*-sync` action, which opens or force-updates exactly one PR on its fixed `maintenance-sync-<kind>` branch. Branch names, titles, and commit messages are owned by the child actions and are not configurable here.
 - Steps run serially (one job, one runner). Each child is API-only, so the run completes well within the workflow's timeout.
 - Failure isolation: every kind runs with `continue-on-error: true`, and a final aggregation step fails the job if any **enabled** kind failed. A skipped (disabled) kind never fails the job. The `::error::sync failed for: <kinds>` annotation names every kind that failed.

--- a/.github/actions/upstream-sync/action.yml
+++ b/.github/actions/upstream-sync/action.yml
@@ -1,5 +1,5 @@
 name: Upstream sync
-description: Aggregate the five upstream maintenance syncs (agent rules, code-review, repomix, release, contributing) behind one action. Every kind runs by default; set a kind to false to opt out.
+description: Aggregate the six upstream maintenance syncs (agent rules, code-review, repomix, release, licenses, contributing) behind one action. Every kind runs by default; set a kind to false to opt out.
 
 inputs:
   bot_token:
@@ -26,8 +26,12 @@ inputs:
     description: Sync the release pipeline workflows (create, publish, auto-merge). Default on; set to `false` to opt out.
     required: false
     default: "true"
+  licenses:
+    description: Sync the licenses workflow. Default on; set to `false` to opt out.
+    required: false
+    default: "true"
   contributing:
-    description: Sync CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE.md, SECURITY.md, and the contributing + auto-label workflows. Default on; set to `false` to opt out.
+    description: Sync CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE.md, SECURITY.md, and the contributing, auto-label, and validate-actions workflows. Default on; set to `false` to opt out.
     required: false
     default: "true"
 
@@ -70,6 +74,15 @@ runs:
         bot_token: ${{ inputs.bot_token }}
         bot_username: ${{ inputs.bot_username }}
 
+    - name: Sync licenses workflow
+      id: licenses
+      if: inputs['licenses'] == 'true'
+      continue-on-error: true
+      uses: awinogradov/code-assistants/.github/actions/licenses-sync@main
+      with:
+        bot_token: ${{ inputs.bot_token }}
+        bot_username: ${{ inputs.bot_username }}
+
     - name: Sync contributing files
       id: contributing
       if: inputs['contributing'] == 'true'
@@ -87,12 +100,14 @@ runs:
         CODE_REVIEW: ${{ steps['code-review'].outcome }}
         REPOMIX: ${{ steps['repomix'].outcome }}
         RELEASE: ${{ steps['release'].outcome }}
+        LICENSES: ${{ steps['licenses'].outcome }}
         CONTRIBUTING: ${{ steps['contributing'].outcome }}
       run: |
         set -euo pipefail
         failed=""
         for kv in "agents-rules:$AGENTS_RULES" "code-review:$CODE_REVIEW" \
-                  "repomix:$REPOMIX" "release:$RELEASE" "contributing:$CONTRIBUTING"; do
+                  "repomix:$REPOMIX" "release:$RELEASE" "licenses:$LICENSES" \
+                  "contributing:$CONTRIBUTING"; do
           outcome="${kv##*:}"
           if [ "$outcome" = "failure" ] || [ "$outcome" = "cancelled" ]; then
             failed="$failed ${kv%%:*}"

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ The `docs/` guides are numbered chapters in reading order — start at chapter 1
 ## GitHub Actions
 
 - [`files-sync`](./.github/actions/files-sync/README.md) — sync declared files from upstream repos and open one PR with the differences
-- [`upstream-sync`](./.github/actions/upstream-sync/README.md) — aggregate the five upstream maintenance syncs behind one action; every kind on by default, opt out per kind
+- [`upstream-sync`](./.github/actions/upstream-sync/README.md) — aggregate the six upstream maintenance syncs behind one action; every kind on by default, opt out per kind
 - [`agents-rules-sync`](./.github/actions/agents-rules-sync/README.md) — sync the stack-appropriate `rules/<stack>.md` into `CLAUDE.md` based on `package.json` `agents.rules`
 - [`contributing-check`](./.github/actions/contributing-check/README.md) — validate branch name, commit messages, and PR title against `CONTRIBUTING.md`
 - [`contributing-sync`](./.github/actions/contributing-sync/README.md) — sync `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, `SECURITY.md`, and the contributing workflow from upstream
+- [`licenses-sync`](./.github/actions/licenses-sync/README.md) — sync the canonical licenses workflow from upstream in its own opt-out maintenance kind
 - [`ban-patterns`](./.github/actions/ban-patterns/README.md) — fail the job when forbidden regex patterns match files in the working tree
 - [`licenses-audit`](./.github/actions/licenses-audit/README.md) — detect the consumer's package manager (pnpm/npm/bun) and regenerate the license report on dependency-changing PRs, auto-commit drift on same-repo PRs, and fail fork PRs that ship stale license data
 - [`release-action`](./.github/actions/release-action/README.md) — conventional-commit-driven release pipeline for npm packages, GitHub Actions, and Claude plugins; supports a custom Anthropic host (gateway/proxy) via `anthropic_base_url`

--- a/docs/08-upstream-sync.md
+++ b/docs/08-upstream-sync.md
@@ -14,13 +14,14 @@ every consumer automatically, with no consumer workflow edit.
 
 ## Sync kinds
 
-| Kind           | Files synced into the consumer                                                                                                                                                                                             | Maintenance branch              | Action                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------------------------------------------------- |
-| `agents-rules` | `rules/<stack>.md` → `CLAUDE.md`                                                                                                                                                                                           | `maintenance-sync-agents-rules` | [`agents-rules-sync`](../.github/actions/agents-rules-sync/README.md) |
-| `code-review`  | `.github/workflows/code-review.yml`, `.github/workflows/code-review-cost-monitor.yml`                                                                                                                                      | `maintenance-sync-code-review`  | [`code-review-sync`](../.github/actions/code-review-sync/README.md)   |
-| `repomix`      | `.github/workflows/repomix-pack.yml`, `repomix.config.json`                                                                                                                                                                | `maintenance-sync-repomix`      | [`repomix-sync`](../.github/actions/repomix-sync/README.md)           |
-| `release`      | `.github/workflows/release-create.yml`, `release-publish.yml`, `release-automerge.yml`                                                                                                                                     | `maintenance-sync-release`      | [`release-sync`](../.github/actions/release-sync/README.md)           |
-| `contributing` | `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, `SECURITY.md`, `.github/workflows/contributing.yml`, `.github/workflows/auto-label.yml`, `.github/workflows/licenses.yml`, `.github/workflows/validate-actions.yml` | `maintenance-sync-contributing` | [`contributing-sync`](../.github/actions/contributing-sync/README.md) |
+| Kind           | Files synced into the consumer                                                                                                                                                           | Maintenance branch              | Action                                                                |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------------------------------------------------- |
+| `agents-rules` | `rules/<stack>.md` → `CLAUDE.md`                                                                                                                                                         | `maintenance-sync-agents-rules` | [`agents-rules-sync`](../.github/actions/agents-rules-sync/README.md) |
+| `code-review`  | `.github/workflows/code-review.yml`, `.github/workflows/code-review-cost-monitor.yml`                                                                                                    | `maintenance-sync-code-review`  | [`code-review-sync`](../.github/actions/code-review-sync/README.md)   |
+| `repomix`      | `.github/workflows/repomix-pack.yml`, `repomix.config.json`                                                                                                                              | `maintenance-sync-repomix`      | [`repomix-sync`](../.github/actions/repomix-sync/README.md)           |
+| `release`      | `.github/workflows/release-create.yml`, `release-publish.yml`, `release-automerge.yml`                                                                                                   | `maintenance-sync-release`      | [`release-sync`](../.github/actions/release-sync/README.md)           |
+| `licenses`     | `.github/workflows/licenses.yml`                                                                                                                                                         | `maintenance-sync-licenses`     | [`licenses-sync`](../.github/actions/licenses-sync/README.md)         |
+| `contributing` | `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE.md`, `SECURITY.md`, `.github/workflows/contributing.yml`, `.github/workflows/auto-label.yml`, `.github/workflows/validate-actions.yml` | `maintenance-sync-contributing` | [`contributing-sync`](../.github/actions/contributing-sync/README.md) |
 
 Each kind delegates to its `*-sync` action, which delegates the diff and PR mechanics to
 [`files-sync`](../.github/actions/files-sync/README.md). The action directories these synced
@@ -49,7 +50,7 @@ job, one `upstream-sync@main` step.
 
 - **Opt-out:** every kind defaults to `true`. Disable a kind with `<kind>: false` in the step's
   `with:` block. Booleans are strings — use `true` / `false`, not YAML's `yes` / `on`.
-- **Serial, single job:** the five kinds run as steps on one runner. Each is API-only and fast,
+- **Serial, single job:** the six kinds run as steps on one runner. Each is API-only and fast,
   so the run finishes well within the workflow timeout.
 - **Failure isolation:** each kind runs with `continue-on-error`, and a final step fails the job
   if any _enabled_ kind failed, naming the failed kinds in a `::error::` annotation. A disabled
@@ -75,6 +76,7 @@ AFTER: upstream.yml = 1 thin job (same name, same cron)
     ├─ code-review-sync   │ each step: continue-on-error
     ├─ repomix-sync       ├─→ files-sync → 1 maintenance PR / kind
     ├─ release-sync       │
+    ├─ licenses-sync      │
     ├─ contributing-sync  ┘
     └─ aggregate outcomes → fail job if any enabled kind failed
 ```


### PR DESCRIPTION
## Summary

- move `.github/workflows/licenses.yml` out of `contributing-sync` into a standalone `licenses-sync` action
- add an independent `licenses` switch to `upstream-sync`, enabled by default for backward compatibility
- close obsolete file-sync pull requests when their declared file set no longer differs
- document the sixth sync component and the migration behavior

## Why

The license audit workflow is CI/policy infrastructure, not a contributor-facing document. Keeping it in `contributing-sync` makes it impossible to disable license synchronization independently. It also lets an old contributing-sync PR retain `licenses.yml` after the file is removed from that sync kind.

The new action gives licenses an independent lifecycle. The stale-PR reconciliation ensures an existing `maintenance-sync-contributing` PR cannot keep an obsolete license-only diff mergeable after migration or when `licenses: false`.

## Compatibility

The aggregate action keeps `licenses` enabled by default, so existing consumers continue synchronizing the workflow unless they explicitly opt out.

## Validation

- `bun run lint`
- `bun run test`
- `bun run .github/actions/validate-actions/src/validateActions.ts --files .github/actions/contributing-sync/action.yml .github/actions/upstream-sync/action.yml .github/actions/licenses-sync/action.yml .github/actions/files-sync/action.yml`
- `git diff --check`
- independent review: no blockers
