### PR TITLE
MAINTENANCE: Align distributed context rules

### DIFF
--- a/claude-plugins/autopilot/skills/shared-rules/references/repomix-snapshot.md
+++ b/claude-plugins/autopilot/skills/shared-rules/references/repomix-snapshot.md
@@ -4,16 +4,15 @@
 
 Codebase context comes from an ordered source chain. Check the tiers top-down and use the first one that works; any failure inside a tier falls through to the next rather than aborting.
 
-**Tier 1 — graphify knowledge graph.** Fires when the consuming repository carries a committed graph: `graphify-out/graph.json` exists at the repository root AND the `graphify` CLI resolves on PATH (`command -v graphify`). Read `graphify-out/GRAPH_REPORT.md` for the architecture overview, then query the graph offline — no LLM, no network:
+**Tier 1 — graphify knowledge graph.** Fires when the consuming repository carries a committed graph: `graphify-out/graph.json` exists at the repository root AND the `graphify` CLI resolves on PATH (`command -v graphify`). For natural-language codebase questions, query the graph first — no LLM, no network:
 
 ```
-graphify query "<plain-language question>" --graph graphify-out/graph.json
-graphify path "<EntityA>" "<EntityB>" --graph graphify-out/graph.json
-graphify explain "<Concept>" --graph graphify-out/graph.json
-graphify affected "<Entity>" --graph graphify-out/graph.json
+graphify query "<plain-language question>"
+graphify path "<EntityA>" "<EntityB>"
+graphify explain "<Concept>"
 ```
 
-Graph queries are whole-repo by nature; the caller's `includePatterns` does not apply to this tier.
+Graph queries are whole-repo by nature; the caller's `includePatterns` does not apply to this tier. Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
 
 **Tier 2 — repomix pack.** Prefer the committed pack over re-packing — the refresh is merge-triggered, so the pack is current for anything already on the default branch.
 

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -407,7 +407,7 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 
 When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
 
-- Read `graphify-out/GRAPH_REPORT.md` first for the architecture overview.
-- Query the graph offline with `graphify query "<question>" --graph graphify-out/graph.json`, `graphify path "<A>" "<B>" --graph graphify-out/graph.json`, and `graphify explain "<concept>" --graph graphify-out/graph.json`.
+- For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
 - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+- Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -276,7 +276,7 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 
 When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
 
-- Read `graphify-out/GRAPH_REPORT.md` first for the architecture overview.
-- Query the graph offline with `graphify query "<question>" --graph graphify-out/graph.json`, `graphify path "<A>" "<B>" --graph graphify-out/graph.json`, and `graphify explain "<concept>" --graph graphify-out/graph.json`.
+- For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
 - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+- Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -53,7 +53,7 @@ Before making any changes:
 ### 2.1 Technology Stack
 
 - Full-stack React + Node.js with Express
-- TypeScript 6.x, React 19, Vite
+- TypeScript, React, Vite — inspect the repository's package manifests, scripts, and docs for exact versions and compiler/tooling roles
 - npm or pnpm for package management
 - Tailwind CSS for styling
 - shadcn/ui + Radix UI for components
@@ -398,7 +398,7 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 
 When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
 
-- Read `graphify-out/GRAPH_REPORT.md` first for the architecture overview.
-- Query the graph offline with `graphify query "<question>" --graph graphify-out/graph.json`, `graphify path "<A>" "<B>" --graph graphify-out/graph.json`, and `graphify explain "<concept>" --graph graphify-out/graph.json`.
+- For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
 - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+- Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -394,7 +394,7 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 
 When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
 
-- Read `graphify-out/GRAPH_REPORT.md` first for the architecture overview.
-- Query the graph offline with `graphify query "<question>" --graph graphify-out/graph.json`, `graphify path "<A>" "<B>" --graph graphify-out/graph.json`, and `graphify explain "<concept>" --graph graphify-out/graph.json`.
+- For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
 - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+- Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).


### PR DESCRIPTION
Distributed agent rules should not claim project-specific compiler versions or prescribe Graphify commands that differ from the installed CLI contract.

- Resolve TypeScript, React, and Vite versions and compiler roles from each consumer repository instead of hard-coding TypeScript 6
- Restore Graphify query-first context acquisition across all four stack rules
- Remove stale `--graph` and `affected` command forms from the shared context contract
- Keep `GRAPH_REPORT.md` as a broad architecture/fallback source rather than the mandatory first read

This corrects the regressions exposed by `wefortis/fortune-os#552`: the generated rule no longer falsely rolls the project back to TypeScript 6, and its Graphify instructions match the installed Graphify skill.

## Verification

- `bun run format:check`
- `bun run validate`
- `git diff --check`
- compared the proposed `rules/NodeJS+React+Tailwind.md` directly against `wefortis/fortune-os@main:CLAUDE.md`
- no tests added for Markdown contracts