### PR TITLE
Validate branch names before creation so invalid branches never reach a PR

### DIFF
--- a/.github/actions/code-review-action/src/branchGrammarSync.test.ts
+++ b/.github/actions/code-review-action/src/branchGrammarSync.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Guards the canonical branch-name regex against drift between its two encodings:
+ * the `regex` input of the contributing-check CI action and the executable pattern
+ * in the shared pr-title-grammar.md block that branch-create and preflight-check
+ * validate against before a branch is created or committed on.
+ *
+ * The CI action is the enforcement of last resort — it fires only once a PR is
+ * open, when a bad head branch can no longer be renamed and the PR must be
+ * re-created. The grammar block is what the skills check before the branch ever
+ * exists. If either encoding is edited alone, agents validate one shape and CI
+ * another, reintroducing exactly the late failure the early gates exist to
+ * prevent; this test makes such an edit fail in CI instead.
+ *
+ * Vacuous-pass defence: the extracted regex must be non-empty and above a minimum
+ * length, so a reworded `regex:` line cannot extract "" and trivially match.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+const actionDir = join(import.meta.dirname, "..");
+const repoRoot = join(actionDir, "..", "..", "..");
+const contributingCheckPath = join(
+  repoRoot,
+  ".github/actions/contributing-check/action.yml",
+);
+const grammarPath = join(
+  repoRoot,
+  "claude-plugins/autopilot/skills/shared-rules/references/pr-title-grammar.md",
+);
+
+/** Shortest the real pattern can be; anything smaller means the extraction went wrong. */
+const minRegexLength = 80;
+
+/** The single-quoted value of the action's `regex:` input line; null when absent. */
+function extractCiRegex(actionYml: string): string | null {
+  return /^\s*regex:\s*'(.+)'\s*$/m.exec(actionYml)?.[1] ?? null;
+}
+
+describe("branch grammar sync", () => {
+  test("pr-title-grammar.md carries the contributing-check regex verbatim", async () => {
+    const [actionYml, grammar] = await Promise.all([
+      readFile(contributingCheckPath, "utf8"),
+      readFile(grammarPath, "utf8"),
+    ]);
+    const ciRegex = extractCiRegex(actionYml);
+    expect(ciRegex).not.toBeNull();
+    expect(ciRegex!.length).toBeGreaterThan(minRegexLength);
+    // On its own line means inside the fenced canonical-regex block, not in prose.
+    expect(grammar).toContain(`\n${ciRegex!}\n`);
+  });
+});

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ Some changes don't require an issue (see [Special PR Prefixes](#special-pr-prefi
 - ✅ `security-tainted-format-string`
 
 > [!IMPORTANT]
-> Enforced locally by the `pre-push` git hook and in CI by [`deepakputhraya/action-branch-name`](https://github.com/deepakputhraya/action-branch-name). Invalid branch names block PR merge.
+> Enforced before creation by the `/autopilot:branch-create` command and at commit time by the autopilot preflight check — both validate against the [canonical regex](claude-plugins/autopilot/skills/shared-rules/references/pr-title-grammar.md) so violations surface while a rename is still free. Later gates: the `pre-push` git hook locally and [`deepakputhraya/action-branch-name`](https://github.com/deepakputhraya/action-branch-name) in CI. Invalid branch names block PR merge, and an open PR's head branch cannot be renamed — the PR must be re-created.
 
 > [!TIP]
 > Use the `/autopilot:branch-create` slash command to generate a branch name.

--- a/claude-plugins/autopilot/skills/branch-create/SKILL.md
+++ b/claude-plugins/autopilot/skills/branch-create/SKILL.md
@@ -212,6 +212,8 @@ Only proceed to [Phase 6](#phase-6-execute) after user selects "Create branch". 
 
 ## Phase 6: Execute
 
+**Validate the branch name (MANDATORY, before any git command):** read the canonical branch-name regex from [`pr-title-grammar.md`](../shared-rules/references/pr-title-grammar.md) and match the fully constructed `<branch-name>` against it, including the 100-character limit. The name must be exactly what the earlier phases constructed — never decorate it with extra path segments or prefixes (`feature/issue-123-slug` is invalid; the convention contains no `/`). On mismatch, regenerate the slug once via the [Phase 3](#phase-3-generate-branch-slug) rules and re-validate; if the name still fails, stop with an error naming the rejected name and the expected formats — the branch is NOT created. This gate is the last line before `git checkout -b`: a name that fails here in seconds would otherwise fail the contributing-check CI on an opened PR, where the only fix is a fresh branch and a fresh PR.
+
 1. **Fetch latest remote and create branch from origin/main:**
 
    ```bash

--- a/claude-plugins/autopilot/skills/preflight-check/SKILL.md
+++ b/claude-plugins/autopilot/skills/preflight-check/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: preflight-check
-description: Validate git working state before committing, branching, or opening a PR. Detects wrong branch, stale merged branches, uncommitted changes, and out-of-date main.
+description: Validate git working state before committing, branching, or opening a PR. Detects wrong branch, invalid branch names, stale merged branches, uncommitted changes, and out-of-date main.
 user-invocable: false
 allowed-tools:
   - Bash(git *)
+  - Read
   - AskUserQuestion
 ---
 
 Validate the git working environment before proceeding. This skill checks the current branch state, detects stale or merged branches, and — depending on mode — either prepares `main` for a new plan/branch or warns against committing/opening a PR directly on `main`.
 
-The skill protects two invariants; the phases below implement them:
+The skill protects three invariants; the phases below implement them:
 
 1. Never create a branch from a stale branch or a `main` that is behind its remote.
 2. Never commit or open a PR on `main` without the user explicitly acknowledging it.
+3. Never commit on a branch whose name violates the naming convention without the user explicitly acknowledging it — a violation caught at commit time costs a rename; caught on an open PR it costs the PR.
 
 ## Context
 
@@ -60,6 +62,15 @@ If the two values differ, the session is running inside a **git worktree**. Stor
 - Otherwise, go to [Phase 2](#phase-2-on-feature-branch).
 
 ## Phase 2: On Feature Branch
+
+### Check branch name format (commits mode only)
+
+If mode is `commits`, read the canonical branch-name regex from [`pr-title-grammar.md`](../shared-rules/references/pr-title-grammar.md) and match `currentBranch` against it. `plan` and `branch` modes skip this check — they run before the working branch exists, including on harness-created worktree branches — and `pr` mode skips it because `pr-create` validates the branch itself in its Phase 1 (one owner per gate, no double prompt).
+
+If the name does not match, ask (header "Branch name"): branch `<currentBranch>` does not follow the naming convention and would fail the contributing-check CI once a PR is open, where the only fix is a fresh branch and a fresh PR — how to proceed?
+
+- **Continue anyway** — commit on this branch at the user's explicit request: continue to the merged-branch check below.
+- **Cancel** — stop so the branch can be fixed while no PR exists and the rename is still free: output "Commit cancelled. Branch <currentBranch> does not follow the naming convention — re-create it with /autopilot:branch-create (uncommitted changes follow the checkout) or rename it with git branch -m, then retry." and abort.
 
 ### Check working tree (pr mode only)
 

--- a/claude-plugins/autopilot/skills/preflight-check/SKILL.md
+++ b/claude-plugins/autopilot/skills/preflight-check/SKILL.md
@@ -65,7 +65,7 @@ If the two values differ, the session is running inside a **git worktree**. Stor
 
 ### Check branch name format (commits mode only)
 
-If mode is `commits`, read the canonical branch-name regex from [`pr-title-grammar.md`](../shared-rules/references/pr-title-grammar.md) and match `currentBranch` against it. `plan` and `branch` modes skip this check — they run before the working branch exists, including on harness-created worktree branches — and `pr` mode skips it because `pr-create` validates the branch itself in its Phase 1 (one owner per gate, no double prompt).
+If mode is `commits`, read the canonical branch-name regex from [`pr-title-grammar.md`](../shared-rules/references/pr-title-grammar.md) and check `currentBranch` against it and against the length bounds beside it (5–100 characters) — an overlong name fails CI's `max_length` check just like a shape violation. `plan` and `branch` modes skip this check — they run before the working branch exists, including on harness-created worktree branches — and `pr` mode skips it because `pr-create` validates the branch itself in its Phase 1 (one owner per gate, no double prompt).
 
 If the name does not match, ask (header "Branch name"): branch `<currentBranch>` does not follow the naming convention and would fail the contributing-check CI once a PR is open, where the only fix is a fresh branch and a fresh PR — how to proceed?
 

--- a/claude-plugins/autopilot/skills/shared-rules/references/pr-title-grammar.md
+++ b/claude-plugins/autopilot/skills/shared-rules/references/pr-title-grammar.md
@@ -111,6 +111,18 @@ release-<version>
 - No short description required
 - Created automatically by release workflows
 
+**Canonical regex:**
+
+All four formats compress into one executable pattern — kept byte-identical to the `regex` input of the [contributing-check CI action](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/contributing-check/action.yml) by the `branchGrammarSync` guard test, so skills and CI validate the same shape:
+
+```text
+^(issue-\d+-[a-z0-9]+(-[a-z0-9]+)*|[a-z][a-z0-9]*-\d+-[a-z0-9]+(-[a-z0-9]+)*|(hotfix|trivial|maintenance|proposal|security)-[a-z0-9]+(-[a-z0-9]+)*|release-([a-z0-9]+(-[a-z0-9]+)*-)?\d+\.\d+\.\d+)$
+```
+
+- Length bounds: 5–100 characters (aim for under 60)
+- The regex is shape-only: a Linear-shaped name still requires a matching `linear` tracker key per the gating above, which no regex can express
+- A name that fails this pattern must never be created: `branch-create` validates the constructed name before `git checkout -b`, and `preflight-check` blocks commits from a non-conforming branch
+
 **Valid branch examples:**
 
 - `issue-123-add-password-reset`


### PR DESCRIPTION
Invalid branch names currently surface only once a PR is open, when the [contributing-check](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/contributing-check/action.yml) run fails — and a PR's head branch cannot be renamed, so the only fix is a fresh branch and a fresh PR. This change moves enforcement to the earliest points in the lifecycle: branch creation and the first commit.

- The exact CI regex is now part of the canonical [branch grammar block](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/shared-rules/references/pr-title-grammar.md), and the new `branchGrammarSync.test.ts` guard keeps the two encodings byte-identical
- The [branch-create skill](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/branch-create/SKILL.md) validates the fully constructed name against the canonical regex before `git checkout -b` and refuses to create on mismatch — including decorated names like `feature/issue-123-slug`
- The [preflight-check skill](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/preflight-check/SKILL.md) gains a commits-mode branch-format check with an explicit continue-or-cancel decision; `pr` mode is intentionally left to the [pr-create skill](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/pr-create/SKILL.md)'s existing Phase 1 validation, so each gate has one owner
- The [CONTRIBUTING § Branches](https://github.com/awinogradov/code-assistants/blob/main/CONTRIBUTING.md#branches) enforcement note now names the pre-creation and commit-time gates ahead of the pre-push hook and CI

---

**Release notes:**

- Branch names are validated against the canonical convention regex before the branch is created and again at commit time, so violations surface while a rename is free instead of as a CI failure on an opened PR

---

**Issues:**

Closes #565