### PR TITLE
PROPOSAL: Modernize the synced stack rules for any coding agent

### DIFF
--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -338,7 +338,7 @@ Choose ONE backend based on the project's needs. Do not mix.
 - 👤 Never enable debug inspector in production
 - 👤 Never pass untrusted data to Object.assign()
 - 👤 Use Object.create(null) for user-provided keys
-- 👤 Use bun ci in CI/CD, not bun install
+- 👤 Use lockfile-based installs in CI/CD (`bun install --frozen-lockfile`)
 - 👤 Run bun audit before deploying
 - 🤖 Never use eval() or Function() constructor (`no-eval`)
 - 👤 Avoid dynamic require()/import() with user-controlled paths

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -312,7 +312,7 @@ Choose ONE backend based on the project's needs. Do not mix.
 - Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
 - Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
 - Remove the TODO and its `@see` line when the linked issue closes
-- Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Use the autopilot `todo-cleanup` skill to create, link, and clean up TODO issues; without the plugin, follow CONTRIBUTING.md
 
 ### 11.3 docs/ structure
 
@@ -365,21 +365,19 @@ Choose ONE backend based on the project's needs. Do not mix.
 
 - **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
 - Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- **MANDATORY**: With the autopilot plugin installed, perform these operations only through its skills — `Skill(autopilot:branch-create)` for branches, `Skill(autopilot:commits-create)` for commits, `Skill(autopilot:pr-create)` for pull requests, `Skill(autopilot:issue-create)` for issues, `Skill(autopilot:plan)` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the plugin, follow CONTRIBUTING.md directly
+- **MANDATORY**: With the autopilot skills installed, perform these operations only through them — `branch-create` for branches, `commits-create` for commits, `pr-create` for pull requests, `issue-create` for issues, `plan` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the skills, follow CONTRIBUTING.md directly
 - Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
 
-### 16.1 Claude Code
-
-- Use TodoWrite to track complex tasks
+- Use the built-in todo list to track complex tasks
 - Mark todos as completed immediately
 - Parallel tool execution when possible
 - Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
 
-### 16.2 MCP Servers
+### 16.1 MCP Servers
 
 Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -36,7 +36,7 @@ In a monorepo, `README.md`, `llms.txt`, `docs/`, `design.md`, and `package.json`
 - Progressive enhancement: Build incrementally, test frequently
 - Functional/declarative patterns; avoid classes
 - Keep dependencies minimal - prefer built-in features
-- The fewer lines the better: every line used or removed, duplication factored into reuse
+- The fewer lines the better: every line and export used or removed, duplication factored into reuse
 - Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
 - Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
 - Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -21,31 +21,27 @@ Before making any changes:
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
 6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
-7. Acquire codebase context from the first source that works, falling through to the next on any failure:
+7. Inspect `package.json` before assuming scripts or package-manager commands
+8. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.
 
 ## 1. Core Principles
 
-- Context first: Gather complete understanding before changes
-- Pattern matching: Check existing codebase for similar implementations
+- Context first: gather complete understanding before changes; check the codebase for similar implementations to mirror
 - Progressive enhancement: Build incrementally, test frequently
 - Functional/declarative patterns; avoid classes
 - Keep dependencies minimal - prefer built-in features
-- Every line of code must be used or removed
-- The fewer lines of code the better
-- Avoid code duplication - maximize reuse
+- The fewer lines the better: every line used or removed, duplication factored into reuse
 - Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
 - Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
-- Define verifiable success criteria before implementing (test, command, or observable behavior)
 - Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
 - When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - Be consistent with existing code style
 - Write failing tests first, then write code to pass tests
 - Run tests after any code changes
 - Do not remove existing code/comments unless necessary
-- Write plan before changes, not report after
 
 ## 2. Architecture
 
@@ -84,6 +80,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - Always import from actual files - never barrel files
 - Import order: builtin → external → internal → parent → sibling
+- Use ES6 imports, never CommonJS require()
+- Use `bun:` protocol prefix for built-in modules
 - Client cannot import server code
 - No generic names (index.ts, init.ts) - use descriptive names
 
@@ -105,18 +103,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Files: Components PascalCase, utilities camelCase
 - Test files: `*.test.ts` suffix
 - Named exports only - no default exports
-- IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
+- camelCase for constants (not SCREAMING_SNAKE_CASE)
 - Descriptive names with auxiliary verbs (isLoading, hasError)
-
-## 5. Development Setup
-
-- Bun 1.x (latest stable)
-- `bun install` – Install dependencies
-- `bun run` – Run script
-- `bun run lint` / `bun run lint:fix` – Linting
-- `bun run format` / `bun run format:check` – Formatting
-- `bun run typecheck` – Type checking
-- `bun test` – Run tests
 
 ## 6. Common Standards
 
@@ -137,6 +125,9 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Limit nesting depth to 2 levels max
 - Limit cyclomatic complexity - few conditional branches
 - Use early returns (fail fast) instead of nested else
+- Extend Error class for custom errors with context properties
+- Await promises before returning for complete stack traces
+- Subscribe to 'error' events on EventEmitters and streams
 - Functions should be 100 lines max
 
 ### 6.2 TypeScript
@@ -157,6 +148,16 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Server: `process.env.*`
 - All variables have fallback defaults
 - Use .env.example as template
+- Validate env variables at startup
+
+### 6.4 File Operations
+
+- Use `bun:fs/promises` for files < 100MB
+- Use streams for files > 100MB
+- Use `pipeline()` for stream chaining
+- Use `import.meta.dirname` for module-relative paths
+- Handle error codes: ENOENT, EACCES, etc.
+- Always close file handles in finally blocks
 
 ## 7. Client-Side Standards
 
@@ -182,7 +183,6 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - Don't useEffect to sync state - causes loops
 - Prefer derived state (useMemo) over synced state
-- Map/Set for lookups, Array only when order matters
 - Initialize text states with "", not undefined
 - Keep state in the lowest component that needs it
 - Split state into individual pieces, not entire objects
@@ -207,14 +207,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 8.1 Bun
 
-- Use ES6 imports, not CommonJS
-- Use fs/promises for file operations
-- Graceful shutdown with signal handlers
-- Validate env variables at startup
-- Use `bun:` protocol prefix for built-in modules
-- Extend Error class for custom errors with context properties
-- Await promises before returning for complete stack traces
-- Subscribe to 'error' events on EventEmitters and streams
+- Graceful shutdown with signal handlers; never call process.exit() directly
 
 ### 8.2 Storage
 
@@ -234,15 +227,6 @@ Choose ONE backend based on the project's needs. Do not mix.
 - Use atomic writes (write-to-tmp + rename) for any user-visible state file
 - Validate file contents on read with Zod schemas — never trust on-disk shape
 - Handle ENOENT/EACCES explicitly; never swallow filesystem errors
-
-### 8.3 File Operations
-
-- Use `bun:fs/promises` for files < 100MB
-- Use streams for files > 100MB
-- Use `pipeline()` for stream chaining
-- Use `import.meta.dirname` for module-relative paths
-- Handle error codes: ENOENT, EACCES, etc.
-- Always close file handles in finally blocks
 
 ## 9. API Standards
 
@@ -285,7 +269,7 @@ Choose ONE backend based on the project's needs. Do not mix.
 - Use data-testid for stable selectors
 - ES module imports require .js extensions
 - Uses Playwright under the hood, use Playwright MCP for UI tests
-- IMPORTANT: Use browser_snapshot before ANY UI work
+- Use browser_snapshot before ANY UI work
 - Never assume element types/labels without verification
 - Workflow: start dev server → browser_navigate → browser_snapshot → verify → interact
 
@@ -305,15 +289,8 @@ Choose ONE backend based on the project's needs. Do not mix.
 
 ### 11.2 Code comments
 
-- Avoid obvious comments, only when necessary
-- Avoid link to exact lines of code
-- Focus on "why" and "how to use", not "what"
-- Avoid duplicates comments — it means code must be refactored
-- Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
-- Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
-- Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
-- Remove the TODO and its `@see` line when the linked issue closes
-- Use the autopilot `todo-cleanup` skill to create, link, and clean up TODO issues; without the plugin, follow CONTRIBUTING.md
+- Avoid obvious comments, links to exact code lines, and duplicated comments — duplication means the code needs refactoring
+- Track deferred work as issue-linked `TODO`/`FIXME` comments per CONTRIBUTING.md "TODO Comments"; use the autopilot `todo-cleanup` skill to scan, create, and link issues
 
 ### 11.3 docs/ structure
 
@@ -332,13 +309,11 @@ Choose ONE backend based on the project's needs. Do not mix.
 ## 13. Security
 
 - Validate all external input before processing
-- Never trust user data in object operations
+- Never trust user data in object operations — no untrusted input to Object.assign(), use Object.create(null) for user-provided keys
 - Use crypto.timingSafeEqual() for secret comparison
 - Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
 - Use exact versions in package.json (no ^ or ~)
 - Never enable debug inspector in production
-- Never pass untrusted data to Object.assign()
-- Use Object.create(null) for user-provided keys
 - Use lockfile-based installs in CI/CD (`bun install --frozen-lockfile`)
 - Run bun audit before deploying
 - Never use eval() or Function() constructor
@@ -347,20 +322,11 @@ Choose ONE backend based on the project's needs. Do not mix.
 
 ## 14. Anti-Patterns
 
-- No CommonJS require() - use ES6 imports
-- No callback-based APIs - use Promise-based
 - No sync file operations in servers
-- No direct process.exit() - use graceful shutdown
-- No CSS Modules/CSS-in-JS - use Tailwind CSS
-- No barrel files (index.ts re-exports)
-- No unused exports - delete immediately
 - No commented-out code - delete it (recover from version control if needed)
 - No empty catch blocks - never swallow errors; rethrow or handle with context
 - No wrapper functions without added logic
-- No Array.find() for lookups - use Map/Object
-- No useEffect for state sync
 - No inline functions in loops
-- No incomplete configurations
 
 ## 15. Git Workflow
 
@@ -371,10 +337,8 @@ Choose ONE backend based on the project's needs. Do not mix.
 
 ## 16. AI Assistant Workflow
 
-- Use the built-in todo list to track complex tasks
-- Mark todos as completed immediately
+- Track complex tasks with the built-in todo list; mark items completed immediately
 - Parallel tool execution when possible
-- Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
 

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -44,7 +44,7 @@ Before making any changes:
 - Write failing tests first, then write code to pass tests
 - Run tests after any code changes
 - Do not remove existing code/comments unless necessary
-- Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
+- Write plan before changes, not report after
 
 ## 2. Architecture
 
@@ -360,17 +360,12 @@ Choose ONE backend based on the project's needs. Do not mix.
 - No useEffect for state sync
 - No inline functions in loops
 - No incomplete configurations
-- No raw `git commit` — use `Skill(autopilot:commits-create)`
-- No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
-- No raw `gh pr create` — use `Skill(autopilot:pr-create)`
-- No raw `gh issue create` — use `Skill(autopilot:issue-create)`
-- No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
 - **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
 - Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- **MANDATORY**: With the autopilot plugin installed, perform these operations only through its skills — `Skill(autopilot:branch-create)` for branches, `Skill(autopilot:commits-create)` for commits, `Skill(autopilot:pr-create)` for pull requests, `Skill(autopilot:issue-create)` for issues, `Skill(autopilot:plan)` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the plugin, follow CONTRIBUTING.md directly
 - Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
@@ -383,11 +378,6 @@ Choose ONE backend based on the project's needs. Do not mix.
 - Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -16,11 +16,16 @@ To change it, open a pull request against the source file above.
 Before making any changes:
 
 1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
-2. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README
-3. Read files that appear relevant to the current task
-4. Treat `docs/` as the source of truth for project-specific conventions and follow those documents over this file when they conflict
-5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
-6. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+2. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
+3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
+5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
+6. Use the Repomix MCP server to pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
+7. When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
+   - For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
+   - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+   - Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
+   - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 
 ## 1. Core Principles
 
@@ -394,17 +399,7 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 - **shadcn MCP server** — search, browse, add, or audit shadcn/ui registry components; prefer it over hand-editing component source
 - **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
 - **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
-- **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 
 - All rules from AGENTS.md must be applied to the code review
-
-## 18. Graphify
-
-When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
-
-- For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
-- Use `graphify-out/wiki/index.md` for broad navigation when it exists.
-- Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
-- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -20,7 +20,8 @@ Before making any changes:
 3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. Acquire codebase context from the first source that works, falling through to the next on any failure:
+6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
+7. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -22,31 +22,26 @@ Before making any changes:
 5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 6. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 
-**Rule Markers Legend:**
-
-- 🤖 = Automated by linter (ESLint/Stylelint enforces this)
-- 👤 = Human-enforced (requires manual review)
-
 ## 1. Core Principles
 
-- 👤 Context first: Gather complete understanding before changes
-- 👤 Pattern matching: Check existing codebase for similar implementations
-- 👤 Progressive enhancement: Build incrementally, test frequently
-- 👤 Functional/declarative patterns; avoid classes
-- 👤 Keep dependencies minimal - prefer built-in features
-- 👤 Every line of code must be used or removed
-- 👤 The fewer lines of code the better
-- 👤 Avoid code duplication - maximize reuse
-- 👤 Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
-- 👤 Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
-- 👤 Define verifiable success criteria before implementing (test, command, or observable behavior)
-- 👤 Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
-- 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
-- 👤 Be consistent with existing code style
-- 👤 Write failing tests first, then write code to pass tests
-- 👤 Run tests after any code changes
-- 👤 Do not remove existing code/comments unless necessary
-- 👤 Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
+- Context first: Gather complete understanding before changes
+- Pattern matching: Check existing codebase for similar implementations
+- Progressive enhancement: Build incrementally, test frequently
+- Functional/declarative patterns; avoid classes
+- Keep dependencies minimal - prefer built-in features
+- Every line of code must be used or removed
+- The fewer lines of code the better
+- Avoid code duplication - maximize reuse
+- Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
+- Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
+- Define verifiable success criteria before implementing (test, command, or observable behavior)
+- Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
+- When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
+- Be consistent with existing code style
+- Write failing tests first, then write code to pass tests
+- Run tests after any code changes
+- Do not remove existing code/comments unless necessary
+- Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
 
 ## 2. Architecture
 
@@ -79,35 +74,35 @@ example/       # multiple modules: a directory, no index.ts barrel
 └── example.types.ts
 ```
 
-- 👤 Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
+- Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
 
 ### 3.2 Import Rules
 
-- 🤖 Always import from actual files - never barrel files (`import/order`)
-- 🤖 Import order: builtin → external → internal → parent → sibling
-- 🤖 Client cannot import server code (`import/no-restricted-paths`)
-- 👤 No generic names (index.ts, init.ts) - use descriptive names
+- Always import from actual files - never barrel files
+- Import order: builtin → external → internal → parent → sibling
+- Client cannot import server code
+- No generic names (index.ts, init.ts) - use descriptive names
 
 ### 3.3 Tailwind CSS
 
-- 👤 Use Tailwind utility classes directly in JSX via `className`
-- 👤 Use a `cn()` helper for conditional, Tailwind-aware class merging with conflict resolution (e.g. `clsx` + `tailwind-merge`, or an equivalent drop-in such as `cnfast`)
-- 👤 Extract reusable components instead of `@apply` for repeated patterns
-- 👤 Use Tailwind config for design tokens (colors, spacing, typography)
-- 👤 Use responsive prefixes (`sm:`, `md:`, `lg:`) for breakpoints
-- 👤 Use dark mode via `dark:` variant
+- Use Tailwind utility classes directly in JSX via `className`
+- Use a `cn()` helper for conditional, Tailwind-aware class merging with conflict resolution (e.g. `clsx` + `tailwind-merge`, or an equivalent drop-in such as `cnfast`)
+- Extract reusable components instead of `@apply` for repeated patterns
+- Use Tailwind config for design tokens (colors, spacing, typography)
+- Use responsive prefixes (`sm:`, `md:`, `lg:`) for breakpoints
+- Use dark mode via `dark:` variant
 
 ## 4. Naming Conventions
 
-- 🤖 Variables/functions: camelCase (`@typescript-eslint/naming-convention`)
-- 🤖 Components/types/interfaces: PascalCase
-- 🤖 No I prefix for interfaces
-- 👤 Hooks: camelCase with 'use' prefix
-- 👤 Files: Components PascalCase, utilities camelCase
-- 👤 Test files: `*.test.ts` suffix
-- 🤖 Named exports only - no default exports (`import/no-default-export`)
-- 👤 IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
-- 👤 Descriptive names with auxiliary verbs (isLoading, hasError)
+- Variables/functions: camelCase
+- Components/types/interfaces: PascalCase
+- No I prefix for interfaces
+- Hooks: camelCase with 'use' prefix
+- Files: Components PascalCase, utilities camelCase
+- Test files: `*.test.ts` suffix
+- Named exports only - no default exports
+- IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
+- Descriptive names with auxiliary verbs (isLoading, hasError)
 
 ## 5. Development Setup
 
@@ -119,101 +114,103 @@ example/       # multiple modules: a directory, no index.ts barrel
 - `bun run typecheck` – Type checking
 - `bun test` – Run tests
 
-## 6. Environment Variables
+## 6. Common Standards
 
-- 🤖 No direct process.env or import.meta.env outside config (`no-restricted-syntax`)
-- 👤 Client: `import.meta.env.VITE_*`
-- 👤 Server: `process.env.*`
-- 👤 All variables have fallback defaults
-- 👤 Use .env.example as template
+### 6.1 JavaScript
+
+- Use async/await, not callbacks
+- Use template literals for string interpolation, not concatenation
+- Use `Object.hasOwn()` instead of `hasOwnProperty()`
+- Use `for...of` for array iteration, avoid classical `for` loops
+- Write pure functions - same input returns same output, no side effects
+- Prefer immutable array methods (map, filter, spread) over mutating (push, splice)
+- Use destructuring to extract object/array values
+- Use strict equality `===` and `!==`, never `==` or `!=`
+- Never mutate function parameters
+- Always throw Error objects, not primitives
+- Always reject Promises with Error objects
+- Use rest params `...args` instead of `arguments`
+- Limit nesting depth to 2 levels max
+- Limit cyclomatic complexity - few conditional branches
+- Use early returns (fail fast) instead of nested else
+- Functions should be 100 lines max
+
+### 6.2 TypeScript
+
+- Prefer interfaces over types
+- Avoid enums; use const assertions
+- Never use @ts-ignore
+- No type assertions without runtime validation (use Zod)
+- Return specific types, not generic (string → KnownCallOutcome)
+- Use type guards for narrowing
+- Use React.ComponentProps for extending props
+- Ask user for type information when `any` is unavoidable
+
+### 6.3 Environment Variables
+
+- No direct process.env or import.meta.env outside config
+- Client: `import.meta.env.VITE_*`
+- Server: `process.env.*`
+- All variables have fallback defaults
+- Use .env.example as template
 
 ## 7. Client-Side Standards
 
 ### 7.1 React
 
-- 🤖 Arrow function components only (`react/function-component-definition`)
-- 👤 Use `nullable()` helper for conditional rendering (not &&)
-- 🤖 Props: interfaces, not types
-- 👤 Composition over inheritance
-- 👤 useCallback for handlers passed as props
-- 👤 useMemo for expensive computations
-- 🤖 No inline arrow functions in JSX (`react/jsx-no-bind`)
-- 👤 Components > 200 lines should be split
-- 👤 Use Suspense for data fetching
-- 👤 Use useSuspenseQuery instead of useQuery
-- 🤖 One component per file (`react/no-multi-comp`)
-- 🤖 Never use array index as `key` prop (`react/no-array-index-key`)
-- 🤖 Self-close components with no children (`react/self-closing-comp`)
-- 👤 Use Tailwind `className` for styling, avoid inline `style` prop
-- 👤 Proactively identify reusable component patterns
+- Arrow function components only
+- Use `nullable()` helper for conditional rendering (not &&)
+- Props: interfaces, not types
+- Composition over inheritance
+- useCallback for handlers passed as props
+- useMemo for expensive computations
+- No inline arrow functions in JSX
+- Components > 200 lines should be split
+- Use Suspense for data fetching
+- Use useSuspenseQuery instead of useQuery
+- One component per file
+- Never use array index as `key` prop
+- Self-close components with no children
+- Use Tailwind `className` for styling, avoid inline `style` prop
+- Proactively identify reusable component patterns
 
-### 7.2 JavaScript
+### 7.2 State Management
 
-- 👤 Use async/await, not callbacks
-- 🤖 Use template literals for string interpolation, not concatenation (`prefer-template`)
-- 🤖 Use `Object.hasOwn()` instead of `hasOwnProperty()` (`prefer-object-has-own`)
-- 👤 Use `for...of` for array iteration, avoid classical `for` loops
-- 👤 Write pure functions - same input returns same output, no side effects
-- 👤 Prefer immutable array methods (map, filter, spread) over mutating (push, splice)
-- 🤖 Use destructuring to extract object/array values (`prefer-destructuring`)
-- 🤖 Use strict equality `===` and `!==`, never `==` or `!=` (`eqeqeq`)
-- 🤖 Never mutate function parameters (`no-param-reassign`)
-- 🤖 Always throw Error objects, not primitives (`no-throw-literal`)
-- 🤖 Always reject Promises with Error objects (`prefer-promise-reject-errors`)
-- 🤖 Use rest params `...args` instead of `arguments` (`prefer-rest-params`)
-- 🤖 Limit nesting depth to 2 levels max (`max-depth`)
-- 🤖 Limit cyclomatic complexity - few conditional branches (`complexity`)
-- 🤖 Use early returns (fail fast) instead of nested else (`no-else-return`)
-- 🤖 Functions should be 100 lines max (`max-lines-per-function`)
+- Don't useEffect to sync state - causes loops
+- Prefer derived state (useMemo) over synced state
+- Map/Set for lookups, Array only when order matters
+- Initialize text states with "", not undefined
+- Keep state in the lowest component that needs it
+- Split state into individual pieces, not entire objects
 
-### 7.3 TypeScript
+### 7.3 React Query
 
-- 🤖 Prefer interfaces over types (`@typescript-eslint/consistent-type-definitions`)
-- 👤 Avoid enums; use const assertions
-- 🤖 Never use @ts-ignore (`@typescript-eslint/ban-ts-comment`)
-- 👤 No type assertions without runtime validation (use Zod)
-- 👤 Return specific types, not generic (string → KnownCallOutcome)
-- 👤 Use type guards for narrowing
-- 👤 Use React.ComponentProps for extending props
-- 👤 Ask user for type information when `any` is unavoidable
+- Handle isLoading, error, data states (use Suspense)
+- Set appropriate staleTime
+- Invalidate queries after mutations
+- Use onError for specific handling
+- DevTools in development only
 
-### 7.4 State Management
+### 7.4 shadcn/ui + Radix UI
 
-- 👤 Don't useEffect to sync state - causes loops
-- 👤 Prefer derived state (useMemo) over synced state
-- 👤 Map/Set for lookups, Array only when order matters
-- 👤 Initialize text states with "", not undefined
-- 👤 Keep state in the lowest component that needs it
-- 👤 Split state into individual pieces, not entire objects
-
-### 7.5 React Query
-
-- 👤 Handle isLoading, error, data states (use Suspense)
-- 👤 Set appropriate staleTime
-- 👤 Invalidate queries after mutations
-- 👤 Use onError for specific handling
-- 👤 DevTools in development only
-
-### 7.6 shadcn/ui + Radix UI
-
-- 👤 Use shadcn/ui components built on Radix UI primitives
-- 👤 Customize components via Tailwind classes in the component source
-- 👤 Use Radix UI directly for primitives not covered by shadcn/ui
-- 👤 Keep component variants in the component file using `cva` (class-variance-authority)
-- 👤 Use `cn()` utility for merging class names
+- Use shadcn/ui components built on Radix UI primitives
+- Customize components via Tailwind classes in the component source
+- Use Radix UI directly for primitives not covered by shadcn/ui
+- Keep component variants in the component file using `cva` (class-variance-authority)
+- Use `cn()` utility for merging class names
 
 ## 8. Server-Side Standards
 
 ### 8.1 Bun
 
-- 👤 Use ES6 imports, not CommonJS
-- 🤖 Use fs/promises for file operations (`n/prefer-promises/fs`)
-- 👤 Graceful shutdown with signal handlers
-- 👤 Validate env variables at startup
-- 🤖 Use `bun:` protocol prefix for built-in modules (`unicorn/prefer-node-protocol`)
-- 👤 Extend Error class for custom errors with context properties
-- 👤 Await promises before returning for complete stack traces
-- 👤 Subscribe to 'error' events on EventEmitters and streams
+- Use ES6 imports, not CommonJS
+- Use fs/promises for file operations
+- Graceful shutdown with signal handlers
+- Validate env variables at startup
+- Use `bun:` protocol prefix for built-in modules
+- Extend Error class for custom errors with context properties
+- Await promises before returning for complete stack traces
+- Subscribe to 'error' events on EventEmitters and streams
 
 ### 8.2 Storage
 
@@ -221,183 +218,183 @@ Choose ONE backend based on the project's needs. Do not mix.
 
 **Option A — Relational database (Prisma + Kysely + PostgreSQL)**
 
-- 👤 Prisma: migrations and type generation ONLY
-- 👤 Kysely: ALL application queries
-- 👤 Never use Prisma Client in application code
-- 👤 Use explicit junction tables
-- 👤 Use `/// @kyselyType()` in schema.prisma for typed Json fields (never edit kysely.ts directly)
+- Prisma: migrations and type generation ONLY
+- Kysely: ALL application queries
+- Never use Prisma Client in application code
+- Use explicit junction tables
+- Use `/// @kyselyType()` in schema.prisma for typed Json fields (never edit kysely.ts directly)
 
 **Option B — Filesystem (local-first, single-user apps; no database)**
 
-- 👤 Persist user-visible state to the filesystem under a per-app directory (e.g. `~/.<app>/`)
-- 👤 Use atomic writes (write-to-tmp + rename) for any user-visible state file
-- 👤 Validate file contents on read with Zod schemas — never trust on-disk shape
-- 👤 Handle ENOENT/EACCES explicitly; never swallow filesystem errors
+- Persist user-visible state to the filesystem under a per-app directory (e.g. `~/.<app>/`)
+- Use atomic writes (write-to-tmp + rename) for any user-visible state file
+- Validate file contents on read with Zod schemas — never trust on-disk shape
+- Handle ENOENT/EACCES explicitly; never swallow filesystem errors
 
 ### 8.3 File Operations
 
-- 👤 Use `bun:fs/promises` for files < 100MB
-- 👤 Use streams for files > 100MB
-- 👤 Use `pipeline()` for stream chaining
-- 👤 Use `import.meta.dirname` for module-relative paths
-- 👤 Handle error codes: ENOENT, EACCES, etc.
-- 👤 Always close file handles in finally blocks
+- Use `bun:fs/promises` for files < 100MB
+- Use streams for files > 100MB
+- Use `pipeline()` for stream chaining
+- Use `import.meta.dirname` for module-relative paths
+- Handle error codes: ENOENT, EACCES, etc.
+- Always close file handles in finally blocks
 
 ## 9. API Standards
 
 ### 9.1 oRPC / tRPC
 
-- 👤 Descriptive procedure names
-- 👤 Always use Zod schemas for input
-- 👤 Use tRPC error codes (NOT_FOUND, UNAUTHORIZED)
-- 👤 Export router type for client
+- Descriptive procedure names
+- Always use Zod schemas for input
+- Use tRPC error codes (NOT_FOUND, UNAUTHORIZED)
+- Export router type for client
 
 ### 9.2 Zod
 
-- 👤 Use .merge(), .partial(), .pick(), .omit()
-- 👤 Use z.infer<> for types
-- 👤 Add custom error messages
-- 👤 Use .transform() for normalization
-- 👤 Use .refine() for complex validation
+- Use .merge(), .partial(), .pick(), .omit()
+- Use z.infer<> for types
+- Add custom error messages
+- Use .transform() for normalization
+- Use .refine() for complex validation
 
 ## 10. Testing
 
 ### 10.1 Quality Standards
 
-- 👤 No duplicate tests - each verifies unique behavior
-- 👤 Test distinct code paths, not variations
-- 👤 Iterate after tests passed to minimize the number of tests and duplications
+- No duplicate tests - each verifies unique behavior
+- Test distinct code paths, not variations
+- Iterate after tests passed to minimize the number of tests and duplications
 
 ### 10.2 Vitest
 
-- 👤 Co-located with source (\*.test.ts)
-- 👤 For: functions, services, utilities in isolation
+- Co-located with source (\*.test.ts)
+- For: functions, services, utilities in isolation
 
 ### 10.3 MSW
 
-- 👤 Use for HTTP mocking in tests
+- Use for HTTP mocking in tests
 
 ### 10.4 Playwright-BDD
 
-- 👤 Features in features/ directory
-- 👤 All helpers must be pure functions
-- 👤 Use data-testid for stable selectors
-- 👤 ES module imports require .js extensions
-- 👤 Uses Playwright under the hood, use Playwright MCP for UI tests
-- 👤 IMPORTANT: Use browser_snapshot before ANY UI work
-- 👤 Never assume element types/labels without verification
-- 👤 Workflow: start dev server → browser_navigate → browser_snapshot → verify → interact
+- Features in features/ directory
+- All helpers must be pure functions
+- Use data-testid for stable selectors
+- ES module imports require .js extensions
+- Uses Playwright under the hood, use Playwright MCP for UI tests
+- IMPORTANT: Use browser_snapshot before ANY UI work
+- Never assume element types/labels without verification
+- Workflow: start dev server → browser_navigate → browser_snapshot → verify → interact
 
 ## 11. Documentation
 
 ### 11.1 JSDoc
 
-- 👤 Every exported interface/type must have JSDoc
-- 👤 File-level JSDoc for config modules
-- 👤 Use @example where usage isn't obvious
-- 👤 Use @see <link> to add links to documentation
-- 👤 Focus on "why" and "how to use", not "what"
-- 👤 No useless descriptions repeating function name
-- 👤 Skip JSDoc only if no params AND obvious from name
-- 👤 Use @deprecated <reason> to mark deprecated code
-- 👤 All modules must have top level JSDoc with description and usage examples
+- Every exported interface/type must have JSDoc
+- File-level JSDoc for config modules
+- Use @example where usage isn't obvious
+- Use @see <link> to add links to documentation
+- Focus on "why" and "how to use", not "what"
+- No useless descriptions repeating function name
+- Skip JSDoc only if no params AND obvious from name
+- Use @deprecated <reason> to mark deprecated code
+- All modules must have top level JSDoc with description and usage examples
 
 ### 11.2 Code comments
 
-- 👤 Avoid obvious comments, only when necessary
-- 👤 Avoid link to exact lines of code
-- 👤 Focus on "why" and "how to use", not "what"
-- 👤 Avoid duplicates comments — it means code must be refactored
-- 👤 Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
-- 👤 Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
-- 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
-- 👤 Remove the TODO and its `@see` line when the linked issue closes
-- 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Avoid obvious comments, only when necessary
+- Avoid link to exact lines of code
+- Focus on "why" and "how to use", not "what"
+- Avoid duplicates comments — it means code must be refactored
+- Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
+- Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
+- Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
+- Remove the TODO and its `@see` line when the linked issue closes
+- Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 11.3 docs/ structure
 
-- 👤 Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
+- Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
 
 ## 12. Performance
 
-- 👤 O(1) lookups: Use Object/Map, not Array.find()
-- 👤 Avoid map/reduce/for combinations
-- 👤 Pre-compute lookups, not in render
-- 👤 Memoize data transformations creating objects/arrays
-- 👤 Use React.memo with displayName for stable-prop components
-- 👤 Use factory functions for handlers with parameters
-- 👤 Profile with React DevTools before adding useMemo/useCallback
+- O(1) lookups: Use Object/Map, not Array.find()
+- Avoid map/reduce/for combinations
+- Pre-compute lookups, not in render
+- Memoize data transformations creating objects/arrays
+- Use React.memo with displayName for stable-prop components
+- Use factory functions for handlers with parameters
+- Profile with React DevTools before adding useMemo/useCallback
 
 ## 13. Security
 
-- 👤 Validate all external input before processing
-- 👤 Never trust user data in object operations
-- 👤 Use crypto.timingSafeEqual() for secret comparison
-- 👤 Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
-- 👤 Use exact versions in package.json (no ^ or ~)
-- 👤 Never enable debug inspector in production
-- 👤 Never pass untrusted data to Object.assign()
-- 👤 Use Object.create(null) for user-provided keys
-- 👤 Use lockfile-based installs in CI/CD (`bun install --frozen-lockfile`)
-- 👤 Run bun audit before deploying
-- 🤖 Never use eval() or Function() constructor (`no-eval`)
-- 👤 Avoid dynamic require()/import() with user-controlled paths
-- 👤 Use textContent for DOM text insertion, not innerHTML (XSS risk)
+- Validate all external input before processing
+- Never trust user data in object operations
+- Use crypto.timingSafeEqual() for secret comparison
+- Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
+- Use exact versions in package.json (no ^ or ~)
+- Never enable debug inspector in production
+- Never pass untrusted data to Object.assign()
+- Use Object.create(null) for user-provided keys
+- Use lockfile-based installs in CI/CD (`bun install --frozen-lockfile`)
+- Run bun audit before deploying
+- Never use eval() or Function() constructor
+- Avoid dynamic require()/import() with user-controlled paths
+- Use textContent for DOM text insertion, not innerHTML (XSS risk)
 
 ## 14. Anti-Patterns
 
-- 🤖 No CommonJS require() - use ES6 imports
-- 👤 No callback-based APIs - use Promise-based
-- 🤖 No sync file operations in servers (`n/no-sync`)
-- 👤 No direct process.exit() - use graceful shutdown
-- 👤 No CSS Modules/CSS-in-JS - use Tailwind CSS
-- 👤 No barrel files (index.ts re-exports)
-- 👤 No unused exports - delete immediately
-- 👤 No commented-out code - delete it (recover from version control if needed)
-- 👤 No empty catch blocks - never swallow errors; rethrow or handle with context
-- 👤 No wrapper functions without added logic
-- 👤 No Array.find() for lookups - use Map/Object
-- 👤 No useEffect for state sync
-- 👤 No inline functions in loops
-- 👤 No incomplete configurations
-- 👤 No raw `git commit` — use `Skill(autopilot:commits-create)`
-- 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
-- 👤 No raw `gh pr create` — use `Skill(autopilot:pr-create)`
-- 👤 No raw `gh issue create` — use `Skill(autopilot:issue-create)`
-- 👤 No ad-hoc planning — use `Skill(autopilot:plan)`
+- No CommonJS require() - use ES6 imports
+- No callback-based APIs - use Promise-based
+- No sync file operations in servers
+- No direct process.exit() - use graceful shutdown
+- No CSS Modules/CSS-in-JS - use Tailwind CSS
+- No barrel files (index.ts re-exports)
+- No unused exports - delete immediately
+- No commented-out code - delete it (recover from version control if needed)
+- No empty catch blocks - never swallow errors; rethrow or handle with context
+- No wrapper functions without added logic
+- No Array.find() for lookups - use Map/Object
+- No useEffect for state sync
+- No inline functions in loops
+- No incomplete configurations
+- No raw `git commit` — use `Skill(autopilot:commits-create)`
+- No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
+- No raw `gh pr create` — use `Skill(autopilot:pr-create)`
+- No raw `gh issue create` — use `Skill(autopilot:issue-create)`
+- No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
-- 👤 **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
-- 👤 Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- 👤 The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
-- 👤 Never bypass validation hooks with `--no-verify` — fix the violation instead
+- **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
+- Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
+- The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
 
 ### 16.1 Claude Code
 
-- 👤 Use TodoWrite to track complex tasks
-- 👤 Mark todos as completed immediately
-- 👤 Parallel tool execution when possible
-- 👤 Gather context before editing
-- 👤 Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
-- 👤 Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- 👤 **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Use TodoWrite to track complex tasks
+- Mark todos as completed immediately
+- Parallel tool execution when possible
+- Gather context before editing
+- Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
+- Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
+- **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 
 Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 
-- 👤 **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
-- 👤 **shadcn MCP server** — search, browse, add, or audit shadcn/ui registry components; prefer it over hand-editing component source
-- 👤 **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
-- 👤 **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
-- 👤 **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
+- **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
+- **shadcn MCP server** — search, browse, add, or audit shadcn/ui registry components; prefer it over hand-editing component source
+- **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
+- **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
+- **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -28,6 +28,8 @@ Before making any changes:
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.
 
+In a monorepo, `README.md`, `llms.txt`, `docs/`, `design.md`, and `package.json` may also exist per workspace member (`apps/*`, `packages/*`, …). When working inside a member, apply the steps above at both levels — the member's own copies govern that member's code and take precedence over the root copies; the root copies govern repo-wide concerns.
+
 ## 1. Core Principles
 
 - Context first: gather complete understanding before changes; check the codebase for similar implementations to mirror

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -20,12 +20,10 @@ Before making any changes:
 3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. Use the Repomix MCP server to pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
-7. When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
-   - For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
-   - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
-   - Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
-   - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+6. Acquire codebase context from the first source that works, falling through to the next on any failure:
+   - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+   - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
+   - **Default tools** — with neither available, search and read the repository files directly.
 
 ## 1. Core Principles
 

--- a/rules/Bun+React+Tailwind.md
+++ b/rules/Bun+React+Tailwind.md
@@ -16,13 +16,14 @@ To change it, open a pull request against the source file above.
 Before making any changes:
 
 1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
-2. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
-3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
-4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
-5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
-7. Inspect `package.json` before assuming scripts or package-manager commands
-8. Acquire codebase context from the first source that works, falling through to the next on any failure:
+2. When an `llms.txt` exists at the repository root, use it as the curated documentation index — follow its links before crawling docs manually
+3. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
+4. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
+6. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
+7. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
+8. Inspect `package.json` before assuming scripts or package-manager commands
+9. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -16,11 +16,16 @@ To change it, open a pull request against the source file above.
 Before making any changes:
 
 1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
-2. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README
-3. Read files that appear relevant to the current task
-4. Treat `docs/` as the source of truth for project-specific conventions and follow those documents over this file when they conflict
-5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
-6. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+2. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
+3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
+5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
+6. Use the Repomix MCP server to pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
+7. When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
+   - For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
+   - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+   - Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
+   - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 
 ## 1. Core Principles
 
@@ -252,17 +257,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 
 - **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
-- **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 
 - All rules from AGENTS.md must be applied to the code review
-
-## 18. Graphify
-
-When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
-
-- For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
-- Use `graphify-out/wiki/index.md` for broad navigation when it exists.
-- Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
-- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -179,7 +179,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
 - Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
 - Remove the TODO and its `@see` line when the linked issue closes
-- Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Use the autopilot `todo-cleanup` skill to create, link, and clean up TODO issues; without the plugin, follow CONTRIBUTING.md
 
 ### 11.3 docs/ structure
 
@@ -226,21 +226,19 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
 - Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- **MANDATORY**: With the autopilot plugin installed, perform these operations only through its skills — `Skill(autopilot:branch-create)` for branches, `Skill(autopilot:commits-create)` for commits, `Skill(autopilot:pr-create)` for pull requests, `Skill(autopilot:issue-create)` for issues, `Skill(autopilot:plan)` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the plugin, follow CONTRIBUTING.md directly
+- **MANDATORY**: With the autopilot skills installed, perform these operations only through them — `branch-create` for branches, `commits-create` for commits, `pr-create` for pull requests, `issue-create` for issues, `plan` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the skills, follow CONTRIBUTING.md directly
 - Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
 
-### 16.1 Claude Code
-
-- Use TodoWrite to track complex tasks
+- Use the built-in todo list to track complex tasks
 - Mark todos as completed immediately
 - Parallel tool execution when possible
 - Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
 
-### 16.2 MCP Servers
+### 16.1 MCP Servers
 
 Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -43,6 +43,8 @@ Before making any changes:
 - 👤 Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
 - 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - 👤 Be consistent with existing code style
+- 👤 Write failing tests first, then write code to pass tests
+- 👤 Run tests after any code changes
 - 👤 Do not remove existing code/comments unless necessary
 - 👤 Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
 
@@ -53,10 +55,6 @@ Before making any changes:
 - Bun, TypeScript 6.x
 - ESLint for linting
 - Prettier for formatting
-
-### 2.2 Directory Layout
-
-- `scripts/` - Scripts
 
 ## 3. Project Structure
 
@@ -71,6 +69,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 ├── example.types.ts
 └── example.module.css
 ```
+
+- 👤 Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
 
 ### 3.2 Import Rules
 
@@ -92,12 +92,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 ## 5. Development Setup
 
 - Bun 1.x (latest stable)
-- `bun install` – Install dependencies
-- `bun run` – Run script
-- `bun run lint` / `bun run lint:fix` – Linting
-- `bun run format` / `bun run format:check` – Formatting
-- `bun run typecheck` – Type checking
-- `bun test` – Run tests
+- 👤 Inspect @package.json before assuming scripts or package-manager commands
 
 ## 6. Common Standards
 
@@ -128,10 +123,11 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 No type assertions without runtime validation (use Zod)
 - 👤 Return specific types, not generic (string → KnownCallOutcome)
 - 👤 Use type guards for narrowing
-- 👤 Use React.ComponentProps for extending props
 - 👤 Ask user for type information when `any` is unavoidable
 
-### 6.3 Bun
+## 8. Server-Side Standards
+
+### 8.1 Bun
 
 - 👤 Use ES6 imports, not CommonJS
 - 🤖 Use fs/promises for file operations (`n/prefer-promises/fs`)
@@ -155,7 +151,6 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 9.2 Zod
 
-- 👤 Schemas in scripts/schemas/ by domain
 - 👤 Use .merge(), .partial(), .pick(), .omit()
 - 👤 Use z.infer<> for types
 - 👤 Add custom error messages
@@ -167,7 +162,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 ### 11.1 JSDoc
 
 - 👤 Every exported interface/type must have JSDoc
-- 👤 File-level JSDoc for src/config/ modules
+- 👤 File-level JSDoc for config modules
 - 👤 Use @example where usage isn't obvious
 - 👤 Use @see <link> to add links to documentation
 - 👤 Focus on "why" and "how to use", not "what"
@@ -196,11 +191,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - 👤 O(1) lookups: Use Object/Map, not Array.find()
 - 👤 Avoid map/reduce/for combinations
-- 👤 Pre-compute lookups, not in render
 - 👤 Memoize data transformations creating objects/arrays
-- 👤 Use React.memo with displayName for stable-prop components
 - 👤 Use factory functions for handlers with parameters
-- 👤 Profile with React DevTools before adding useMemo/useCallback
 
 ## 13. Security
 
@@ -212,7 +204,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 Never enable debug inspector in production
 - 👤 Never pass untrusted data to Object.assign()
 - 👤 Use Object.create(null) for user-provided keys
-- 👤 Use bun ci in CI/CD, not bun install
+- 👤 Use lockfile-based installs in CI/CD (`bun install --frozen-lockfile`)
 - 👤 Run bun audit before deploying
 - 🤖 Never use eval() or Function() constructor (`no-eval`)
 - 👤 Avoid dynamic require()/import() with user-controlled paths
@@ -223,14 +215,12 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 No callback-based APIs - use Promise-based
 - 🤖 No sync file operations in servers (`n/no-sync`)
 - 👤 No direct process.exit() - use graceful shutdown
-- 👤 No TailwindCSS/CSS-in-JS - use CSS Modules
 - 👤 No barrel files (index.ts re-exports)
 - 👤 No unused exports - delete immediately
 - 👤 No commented-out code - delete it (recover from version control if needed)
 - 👤 No empty catch blocks - never swallow errors; rethrow or handle with context
 - 👤 No wrapper functions without added logic
 - 👤 No Array.find() for lookups - use Map/Object
-- 👤 No useEffect for state sync
 - 👤 No inline functions in loops
 - 👤 No incomplete configurations
 - 👤 No raw `git commit` — use `Skill(autopilot:commits-create)`
@@ -254,6 +244,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - 👤 Mark todos as completed immediately
 - 👤 Parallel tool execution when possible
 - 👤 Gather context before editing
+- 👤 Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - 👤 Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
 - 👤 **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 - 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -21,31 +21,27 @@ Before making any changes:
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
 6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
-7. Acquire codebase context from the first source that works, falling through to the next on any failure:
+7. Inspect `package.json` before assuming scripts or package-manager commands
+8. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.
 
 ## 1. Core Principles
 
-- Context first: Gather complete understanding before changes
-- Pattern matching: Check existing codebase for similar implementations
+- Context first: gather complete understanding before changes; check the codebase for similar implementations to mirror
 - Progressive enhancement: Build incrementally, test frequently
 - Functional/declarative patterns; avoid classes
 - Keep dependencies minimal - prefer built-in features
-- Every line of code must be used or removed
-- The fewer lines of code the better
-- Avoid code duplication - maximize reuse
+- The fewer lines the better: every line used or removed, duplication factored into reuse
 - Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
 - Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
-- Define verifiable success criteria before implementing (test, command, or observable behavior)
 - Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
 - When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - Be consistent with existing code style
 - Write failing tests first, then write code to pass tests
 - Run tests after any code changes
 - Do not remove existing code/comments unless necessary
-- Write plan before changes, not report after
 
 ## 2. Architecture
 
@@ -75,6 +71,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - Always import from actual files - never barrel files
 - Import order: builtin → external → internal → parent → sibling
+- Use ES6 imports, never CommonJS require()
+- Use `bun:` protocol prefix for built-in modules
 - No generic names (index.ts, init.ts) - use descriptive names
 
 ## 4. Naming Conventions
@@ -85,13 +83,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Files: Components PascalCase, utilities camelCase
 - Test files: `*.test.ts` suffix
 - Named exports only - no default exports
-- IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
+- camelCase for constants (not SCREAMING_SNAKE_CASE)
 - Descriptive names with auxiliary verbs (isLoading, hasError)
-
-## 5. Development Setup
-
-- Bun 1.x (latest stable)
-- Inspect @package.json before assuming scripts or package-manager commands
 
 ## 6. Common Standards
 
@@ -112,6 +105,9 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Limit nesting depth to 2 levels max
 - Limit cyclomatic complexity - few conditional branches
 - Use early returns (fail fast) instead of nested else
+- Extend Error class for custom errors with context properties
+- Await promises before returning for complete stack traces
+- Subscribe to 'error' events on EventEmitters and streams
 - Functions should be 100 lines max
 
 ### 6.2 TypeScript
@@ -124,20 +120,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Use type guards for narrowing
 - Ask user for type information when `any` is unavoidable
 
-## 8. Server-Side Standards
-
-### 8.1 Bun
-
-- Use ES6 imports, not CommonJS
-- Use fs/promises for file operations
-- Graceful shutdown with signal handlers
-- Validate env variables at startup
-- Use `bun:` protocol prefix for built-in modules
-- Extend Error class for custom errors with context properties
-- Await promises before returning for complete stack traces
-- Subscribe to 'error' events on EventEmitters and streams
-
-### 8.4 File Operations
+### 6.3 File Operations
 
 - Use `bun:fs/promises` for files < 100MB
 - Use streams for files > 100MB
@@ -145,6 +128,13 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Use `import.meta.dirname` for module-relative paths
 - Handle error codes: ENOENT, EACCES, etc.
 - Always close file handles in finally blocks
+
+## 8. Server-Side Standards
+
+### 8.1 Bun
+
+- Graceful shutdown with signal handlers; never call process.exit() directly
+- Validate env variables at startup
 
 ## 9. API Standards
 
@@ -172,15 +162,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 11.2 Code comments
 
-- Avoid obvious comments, only when necessary
-- Avoid link to exact lines of code
-- Focus on "why" and "how to use", not "what"
-- Avoid duplicates comments — it means code must be refactored
-- Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
-- Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
-- Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
-- Remove the TODO and its `@see` line when the linked issue closes
-- Use the autopilot `todo-cleanup` skill to create, link, and clean up TODO issues; without the plugin, follow CONTRIBUTING.md
+- Avoid obvious comments, links to exact code lines, and duplicated comments — duplication means the code needs refactoring
+- Track deferred work as issue-linked `TODO`/`FIXME` comments per CONTRIBUTING.md "TODO Comments"; use the autopilot `todo-cleanup` skill to scan, create, and link issues
 
 ### 11.3 docs/ structure
 
@@ -196,13 +179,11 @@ example/       # multiple modules: a directory, no index.ts barrel
 ## 13. Security
 
 - Validate all external input before processing
-- Never trust user data in object operations
+- Never trust user data in object operations — no untrusted input to Object.assign(), use Object.create(null) for user-provided keys
 - Use crypto.timingSafeEqual() for secret comparison
 - Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
 - Use exact versions in package.json (no ^ or ~)
 - Never enable debug inspector in production
-- Never pass untrusted data to Object.assign()
-- Use Object.create(null) for user-provided keys
 - Use lockfile-based installs in CI/CD (`bun install --frozen-lockfile`)
 - Run bun audit before deploying
 - Never use eval() or Function() constructor
@@ -210,18 +191,11 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ## 14. Anti-Patterns
 
-- No CommonJS require() - use ES6 imports
-- No callback-based APIs - use Promise-based
 - No sync file operations in servers
-- No direct process.exit() - use graceful shutdown
-- No barrel files (index.ts re-exports)
-- No unused exports - delete immediately
 - No commented-out code - delete it (recover from version control if needed)
 - No empty catch blocks - never swallow errors; rethrow or handle with context
 - No wrapper functions without added logic
-- No Array.find() for lookups - use Map/Object
 - No inline functions in loops
-- No incomplete configurations
 
 ## 15. Git Workflow
 
@@ -232,10 +206,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ## 16. AI Assistant Workflow
 
-- Use the built-in todo list to track complex tasks
-- Mark todos as completed immediately
+- Track complex tasks with the built-in todo list; mark items completed immediately
 - Parallel tool execution when possible
-- Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -36,7 +36,7 @@ In a monorepo, `README.md`, `llms.txt`, `docs/`, `design.md`, and `package.json`
 - Progressive enhancement: Build incrementally, test frequently
 - Functional/declarative patterns; avoid classes
 - Keep dependencies minimal - prefer built-in features
-- The fewer lines the better: every line used or removed, duplication factored into reuse
+- The fewer lines the better: every line and export used or removed, duplication factored into reuse
 - Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
 - Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
 - Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -20,7 +20,8 @@ Before making any changes:
 3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. Acquire codebase context from the first source that works, falling through to the next on any failure:
+6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
+7. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -28,6 +28,8 @@ Before making any changes:
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.
 
+In a monorepo, `README.md`, `llms.txt`, `docs/`, `design.md`, and `package.json` may also exist per workspace member (`apps/*`, `packages/*`, …). When working inside a member, apply the steps above at both levels — the member's own copies govern that member's code and take precedence over the root copies; the root copies govern repo-wide concerns.
+
 ## 1. Core Principles
 
 - Context first: gather complete understanding before changes; check the codebase for similar implementations to mirror

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -22,31 +22,26 @@ Before making any changes:
 5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 6. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 
-**Rule Markers Legend:**
-
-- 🤖 = Automated by linter (ESLint/Stylelint enforces this)
-- 👤 = Human-enforced (requires manual review)
-
 ## 1. Core Principles
 
-- 👤 Context first: Gather complete understanding before changes
-- 👤 Pattern matching: Check existing codebase for similar implementations
-- 👤 Progressive enhancement: Build incrementally, test frequently
-- 👤 Functional/declarative patterns; avoid classes
-- 👤 Keep dependencies minimal - prefer built-in features
-- 👤 Every line of code must be used or removed
-- 👤 The fewer lines of code the better
-- 👤 Avoid code duplication - maximize reuse
-- 👤 Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
-- 👤 Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
-- 👤 Define verifiable success criteria before implementing (test, command, or observable behavior)
-- 👤 Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
-- 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
-- 👤 Be consistent with existing code style
-- 👤 Write failing tests first, then write code to pass tests
-- 👤 Run tests after any code changes
-- 👤 Do not remove existing code/comments unless necessary
-- 👤 Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
+- Context first: Gather complete understanding before changes
+- Pattern matching: Check existing codebase for similar implementations
+- Progressive enhancement: Build incrementally, test frequently
+- Functional/declarative patterns; avoid classes
+- Keep dependencies minimal - prefer built-in features
+- Every line of code must be used or removed
+- The fewer lines of code the better
+- Avoid code duplication - maximize reuse
+- Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
+- Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
+- Define verifiable success criteria before implementing (test, command, or observable behavior)
+- Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
+- When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
+- Be consistent with existing code style
+- Write failing tests first, then write code to pass tests
+- Run tests after any code changes
+- Do not remove existing code/comments unless necessary
+- Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
 
 ## 2. Architecture
 
@@ -70,194 +65,194 @@ example/       # multiple modules: a directory, no index.ts barrel
 └── example.module.css
 ```
 
-- 👤 Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
+- Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
 
 ### 3.2 Import Rules
 
-- 🤖 Always import from actual files - never barrel files (`import/order`)
-- 🤖 Import order: builtin → external → internal → parent → sibling
-- 👤 No generic names (index.ts, init.ts) - use descriptive names
+- Always import from actual files - never barrel files
+- Import order: builtin → external → internal → parent → sibling
+- No generic names (index.ts, init.ts) - use descriptive names
 
 ## 4. Naming Conventions
 
-- 🤖 Variables/functions: camelCase (`@typescript-eslint/naming-convention`)
-- 🤖 Components/types/interfaces: PascalCase
-- 🤖 No I prefix for interfaces
-- 👤 Files: Components PascalCase, utilities camelCase
-- 👤 Test files: `*.test.ts` suffix
-- 🤖 Named exports only - no default exports (`import/no-default-export`)
-- 👤 IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
-- 👤 Descriptive names with auxiliary verbs (isLoading, hasError)
+- Variables/functions: camelCase
+- Components/types/interfaces: PascalCase
+- No I prefix for interfaces
+- Files: Components PascalCase, utilities camelCase
+- Test files: `*.test.ts` suffix
+- Named exports only - no default exports
+- IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
+- Descriptive names with auxiliary verbs (isLoading, hasError)
 
 ## 5. Development Setup
 
 - Bun 1.x (latest stable)
-- 👤 Inspect @package.json before assuming scripts or package-manager commands
+- Inspect @package.json before assuming scripts or package-manager commands
 
 ## 6. Common Standards
 
 ### 6.1 JavaScript
 
-- 👤 Use async/await, not callbacks
-- 🤖 Use template literals for string interpolation, not concatenation (`prefer-template`)
-- 🤖 Use `Object.hasOwn()` instead of `hasOwnProperty()` (`prefer-object-has-own`)
-- 👤 Use `for...of` for array iteration, avoid classical `for` loops
-- 👤 Write pure functions - same input returns same output, no side effects
-- 👤 Prefer immutable array methods (map, filter, spread) over mutating (push, splice)
-- 🤖 Use destructuring to extract object/array values (`prefer-destructuring`)
-- 🤖 Use strict equality `===` and `!==`, never `==` or `!=` (`eqeqeq`)
-- 🤖 Never mutate function parameters (`no-param-reassign`)
-- 🤖 Always throw Error objects, not primitives (`no-throw-literal`)
-- 🤖 Always reject Promises with Error objects (`prefer-promise-reject-errors`)
-- 🤖 Use rest params `...args` instead of `arguments` (`prefer-rest-params`)
-- 🤖 Limit nesting depth to 2 levels max (`max-depth`)
-- 🤖 Limit cyclomatic complexity - few conditional branches (`complexity`)
-- 🤖 Use early returns (fail fast) instead of nested else (`no-else-return`)
-- 🤖 Functions should be 100 lines max (`max-lines-per-function`)
+- Use async/await, not callbacks
+- Use template literals for string interpolation, not concatenation
+- Use `Object.hasOwn()` instead of `hasOwnProperty()`
+- Use `for...of` for array iteration, avoid classical `for` loops
+- Write pure functions - same input returns same output, no side effects
+- Prefer immutable array methods (map, filter, spread) over mutating (push, splice)
+- Use destructuring to extract object/array values
+- Use strict equality `===` and `!==`, never `==` or `!=`
+- Never mutate function parameters
+- Always throw Error objects, not primitives
+- Always reject Promises with Error objects
+- Use rest params `...args` instead of `arguments`
+- Limit nesting depth to 2 levels max
+- Limit cyclomatic complexity - few conditional branches
+- Use early returns (fail fast) instead of nested else
+- Functions should be 100 lines max
 
 ### 6.2 TypeScript
 
-- 🤖 Prefer interfaces over types (`@typescript-eslint/consistent-type-definitions`)
-- 👤 Avoid enums; use const assertions
-- 🤖 Never use @ts-ignore (`@typescript-eslint/ban-ts-comment`)
-- 👤 No type assertions without runtime validation (use Zod)
-- 👤 Return specific types, not generic (string → KnownCallOutcome)
-- 👤 Use type guards for narrowing
-- 👤 Ask user for type information when `any` is unavoidable
+- Prefer interfaces over types
+- Avoid enums; use const assertions
+- Never use @ts-ignore
+- No type assertions without runtime validation (use Zod)
+- Return specific types, not generic (string → KnownCallOutcome)
+- Use type guards for narrowing
+- Ask user for type information when `any` is unavoidable
 
 ## 8. Server-Side Standards
 
 ### 8.1 Bun
 
-- 👤 Use ES6 imports, not CommonJS
-- 🤖 Use fs/promises for file operations (`n/prefer-promises/fs`)
-- 👤 Graceful shutdown with signal handlers
-- 👤 Validate env variables at startup
-- 🤖 Use `bun:` protocol prefix for built-in modules (`unicorn/prefer-node-protocol`)
-- 👤 Extend Error class for custom errors with context properties
-- 👤 Await promises before returning for complete stack traces
-- 👤 Subscribe to 'error' events on EventEmitters and streams
+- Use ES6 imports, not CommonJS
+- Use fs/promises for file operations
+- Graceful shutdown with signal handlers
+- Validate env variables at startup
+- Use `bun:` protocol prefix for built-in modules
+- Extend Error class for custom errors with context properties
+- Await promises before returning for complete stack traces
+- Subscribe to 'error' events on EventEmitters and streams
 
 ### 8.4 File Operations
 
-- 👤 Use `bun:fs/promises` for files < 100MB
-- 👤 Use streams for files > 100MB
-- 👤 Use `pipeline()` for stream chaining
-- 👤 Use `import.meta.dirname` for module-relative paths
-- 👤 Handle error codes: ENOENT, EACCES, etc.
-- 👤 Always close file handles in finally blocks
+- Use `bun:fs/promises` for files < 100MB
+- Use streams for files > 100MB
+- Use `pipeline()` for stream chaining
+- Use `import.meta.dirname` for module-relative paths
+- Handle error codes: ENOENT, EACCES, etc.
+- Always close file handles in finally blocks
 
 ## 9. API Standards
 
 ### 9.2 Zod
 
-- 👤 Use .merge(), .partial(), .pick(), .omit()
-- 👤 Use z.infer<> for types
-- 👤 Add custom error messages
-- 👤 Use .transform() for normalization
-- 👤 Use .refine() for complex validation
+- Use .merge(), .partial(), .pick(), .omit()
+- Use z.infer<> for types
+- Add custom error messages
+- Use .transform() for normalization
+- Use .refine() for complex validation
 
 ## 11. Documentation
 
 ### 11.1 JSDoc
 
-- 👤 Every exported interface/type must have JSDoc
-- 👤 File-level JSDoc for config modules
-- 👤 Use @example where usage isn't obvious
-- 👤 Use @see <link> to add links to documentation
-- 👤 Focus on "why" and "how to use", not "what"
-- 👤 No useless descriptions repeating function name
-- 👤 Skip JSDoc only if no params AND obvious from name
-- 👤 Use @deprecated <reason> to mark deprecated code
-- 👤 All modules must have top level JSDoc with description and usage examples
+- Every exported interface/type must have JSDoc
+- File-level JSDoc for config modules
+- Use @example where usage isn't obvious
+- Use @see <link> to add links to documentation
+- Focus on "why" and "how to use", not "what"
+- No useless descriptions repeating function name
+- Skip JSDoc only if no params AND obvious from name
+- Use @deprecated <reason> to mark deprecated code
+- All modules must have top level JSDoc with description and usage examples
 
 ### 11.2 Code comments
 
-- 👤 Avoid obvious comments, only when necessary
-- 👤 Avoid link to exact lines of code
-- 👤 Focus on "why" and "how to use", not "what"
-- 👤 Avoid duplicates comments — it means code must be refactored
-- 👤 Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
-- 👤 Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
-- 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
-- 👤 Remove the TODO and its `@see` line when the linked issue closes
-- 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Avoid obvious comments, only when necessary
+- Avoid link to exact lines of code
+- Focus on "why" and "how to use", not "what"
+- Avoid duplicates comments — it means code must be refactored
+- Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
+- Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
+- Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
+- Remove the TODO and its `@see` line when the linked issue closes
+- Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 11.3 docs/ structure
 
-- 👤 Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
+- Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
 
 ## 12. Performance
 
-- 👤 O(1) lookups: Use Object/Map, not Array.find()
-- 👤 Avoid map/reduce/for combinations
-- 👤 Memoize data transformations creating objects/arrays
-- 👤 Use factory functions for handlers with parameters
+- O(1) lookups: Use Object/Map, not Array.find()
+- Avoid map/reduce/for combinations
+- Memoize data transformations creating objects/arrays
+- Use factory functions for handlers with parameters
 
 ## 13. Security
 
-- 👤 Validate all external input before processing
-- 👤 Never trust user data in object operations
-- 👤 Use crypto.timingSafeEqual() for secret comparison
-- 👤 Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
-- 👤 Use exact versions in package.json (no ^ or ~)
-- 👤 Never enable debug inspector in production
-- 👤 Never pass untrusted data to Object.assign()
-- 👤 Use Object.create(null) for user-provided keys
-- 👤 Use lockfile-based installs in CI/CD (`bun install --frozen-lockfile`)
-- 👤 Run bun audit before deploying
-- 🤖 Never use eval() or Function() constructor (`no-eval`)
-- 👤 Avoid dynamic require()/import() with user-controlled paths
+- Validate all external input before processing
+- Never trust user data in object operations
+- Use crypto.timingSafeEqual() for secret comparison
+- Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
+- Use exact versions in package.json (no ^ or ~)
+- Never enable debug inspector in production
+- Never pass untrusted data to Object.assign()
+- Use Object.create(null) for user-provided keys
+- Use lockfile-based installs in CI/CD (`bun install --frozen-lockfile`)
+- Run bun audit before deploying
+- Never use eval() or Function() constructor
+- Avoid dynamic require()/import() with user-controlled paths
 
 ## 14. Anti-Patterns
 
-- 🤖 No CommonJS require() - use ES6 imports
-- 👤 No callback-based APIs - use Promise-based
-- 🤖 No sync file operations in servers (`n/no-sync`)
-- 👤 No direct process.exit() - use graceful shutdown
-- 👤 No barrel files (index.ts re-exports)
-- 👤 No unused exports - delete immediately
-- 👤 No commented-out code - delete it (recover from version control if needed)
-- 👤 No empty catch blocks - never swallow errors; rethrow or handle with context
-- 👤 No wrapper functions without added logic
-- 👤 No Array.find() for lookups - use Map/Object
-- 👤 No inline functions in loops
-- 👤 No incomplete configurations
-- 👤 No raw `git commit` — use `Skill(autopilot:commits-create)`
-- 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
-- 👤 No raw `gh pr create` — use `Skill(autopilot:pr-create)`
-- 👤 No raw `gh issue create` — use `Skill(autopilot:issue-create)`
-- 👤 No ad-hoc planning — use `Skill(autopilot:plan)`
+- No CommonJS require() - use ES6 imports
+- No callback-based APIs - use Promise-based
+- No sync file operations in servers
+- No direct process.exit() - use graceful shutdown
+- No barrel files (index.ts re-exports)
+- No unused exports - delete immediately
+- No commented-out code - delete it (recover from version control if needed)
+- No empty catch blocks - never swallow errors; rethrow or handle with context
+- No wrapper functions without added logic
+- No Array.find() for lookups - use Map/Object
+- No inline functions in loops
+- No incomplete configurations
+- No raw `git commit` — use `Skill(autopilot:commits-create)`
+- No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
+- No raw `gh pr create` — use `Skill(autopilot:pr-create)`
+- No raw `gh issue create` — use `Skill(autopilot:issue-create)`
+- No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
-- 👤 **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
-- 👤 Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- 👤 The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
-- 👤 Never bypass validation hooks with `--no-verify` — fix the violation instead
+- **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
+- Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
+- The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
 
 ### 16.1 Claude Code
 
-- 👤 Use TodoWrite to track complex tasks
-- 👤 Mark todos as completed immediately
-- 👤 Parallel tool execution when possible
-- 👤 Gather context before editing
-- 👤 Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
-- 👤 Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- 👤 **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Use TodoWrite to track complex tasks
+- Mark todos as completed immediately
+- Parallel tool execution when possible
+- Gather context before editing
+- Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
+- Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
+- **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 
 Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 
-- 👤 **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
-- 👤 **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
+- **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
+- **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -44,7 +44,7 @@ Before making any changes:
 - Write failing tests first, then write code to pass tests
 - Run tests after any code changes
 - Do not remove existing code/comments unless necessary
-- Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
+- Write plan before changes, not report after
 
 ## 2. Architecture
 
@@ -221,17 +221,12 @@ example/       # multiple modules: a directory, no index.ts barrel
 - No Array.find() for lookups - use Map/Object
 - No inline functions in loops
 - No incomplete configurations
-- No raw `git commit` — use `Skill(autopilot:commits-create)`
-- No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
-- No raw `gh pr create` — use `Skill(autopilot:pr-create)`
-- No raw `gh issue create` — use `Skill(autopilot:issue-create)`
-- No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
 - **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
 - Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- **MANDATORY**: With the autopilot plugin installed, perform these operations only through its skills — `Skill(autopilot:branch-create)` for branches, `Skill(autopilot:commits-create)` for commits, `Skill(autopilot:pr-create)` for pull requests, `Skill(autopilot:issue-create)` for issues, `Skill(autopilot:plan)` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the plugin, follow CONTRIBUTING.md directly
 - Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
@@ -244,11 +239,6 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -20,12 +20,10 @@ Before making any changes:
 3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. Use the Repomix MCP server to pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
-7. When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
-   - For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
-   - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
-   - Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
-   - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+6. Acquire codebase context from the first source that works, falling through to the next on any failure:
+   - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+   - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
+   - **Default tools** — with neither available, search and read the repository files directly.
 
 ## 1. Core Principles
 

--- a/rules/Bun.md
+++ b/rules/Bun.md
@@ -16,13 +16,14 @@ To change it, open a pull request against the source file above.
 Before making any changes:
 
 1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
-2. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
-3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
-4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
-5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
-7. Inspect `package.json` before assuming scripts or package-manager commands
-8. Acquire codebase context from the first source that works, falling through to the next on any failure:
+2. When an `llms.txt` exists at the repository root, use it as the curated documentation index — follow its links before crawling docs manually
+3. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
+4. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
+6. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
+7. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
+8. Inspect `package.json` before assuming scripts or package-manager commands
+9. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -303,7 +303,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
 - Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
 - Remove the TODO and its `@see` line when the linked issue closes
-- Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Use the autopilot `todo-cleanup` skill to create, link, and clean up TODO issues; without the plugin, follow CONTRIBUTING.md
 
 ### 11.3 docs/ structure
 
@@ -356,21 +356,19 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
 - Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- **MANDATORY**: With the autopilot plugin installed, perform these operations only through its skills — `Skill(autopilot:branch-create)` for branches, `Skill(autopilot:commits-create)` for commits, `Skill(autopilot:pr-create)` for pull requests, `Skill(autopilot:issue-create)` for issues, `Skill(autopilot:plan)` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the plugin, follow CONTRIBUTING.md directly
+- **MANDATORY**: With the autopilot skills installed, perform these operations only through them — `branch-create` for branches, `commits-create` for commits, `pr-create` for pull requests, `issue-create` for issues, `plan` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the skills, follow CONTRIBUTING.md directly
 - Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
 
-### 16.1 Claude Code
-
-- Use TodoWrite to track complex tasks
+- Use the built-in todo list to track complex tasks
 - Mark todos as completed immediately
 - Parallel tool execution when possible
 - Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
 
-### 16.2 MCP Servers
+### 16.1 MCP Servers
 
 Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -22,31 +22,26 @@ Before making any changes:
 5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 6. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 
-**Rule Markers Legend:**
-
-- 🤖 = Automated by linter (ESLint/Stylelint enforces this)
-- 👤 = Human-enforced (requires manual review)
-
 ## 1. Core Principles
 
-- 👤 Context first: Gather complete understanding before changes
-- 👤 Pattern matching: Check existing codebase for similar implementations
-- 👤 Progressive enhancement: Build incrementally, test frequently
-- 👤 Functional/declarative patterns; avoid classes
-- 👤 Keep dependencies minimal - prefer built-in features
-- 👤 Every line of code must be used or removed
-- 👤 The fewer lines of code the better
-- 👤 Avoid code duplication - maximize reuse
-- 👤 Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
-- 👤 Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
-- 👤 Define verifiable success criteria before implementing (test, command, or observable behavior)
-- 👤 Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
-- 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
-- 👤 Be consistent with existing code style
-- 👤 Write failing tests first, then write code to pass tests
-- 👤 Run tests after any code changes
-- 👤 Do not remove existing code/comments unless necessary
-- 👤 Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
+- Context first: Gather complete understanding before changes
+- Pattern matching: Check existing codebase for similar implementations
+- Progressive enhancement: Build incrementally, test frequently
+- Functional/declarative patterns; avoid classes
+- Keep dependencies minimal - prefer built-in features
+- Every line of code must be used or removed
+- The fewer lines of code the better
+- Avoid code duplication - maximize reuse
+- Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
+- Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
+- Define verifiable success criteria before implementing (test, command, or observable behavior)
+- Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
+- When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
+- Be consistent with existing code style
+- Write failing tests first, then write code to pass tests
+- Run tests after any code changes
+- Do not remove existing code/comments unless necessary
+- Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
 
 ## 2. Architecture
 
@@ -80,315 +75,317 @@ example/       # multiple modules: a directory, no index.ts barrel
 └── example.types.ts
 ```
 
-- 👤 Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
+- Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
 
 ### 3.2 Import Rules
 
-- 🤖 Always import from actual files - never barrel files (`import/order`)
-- 🤖 Import order: builtin → external → internal → parent → sibling
-- 🤖 Client cannot import server code (`import/no-restricted-paths`)
-- 👤 No generic names (index.ts, init.ts) - use descriptive names
+- Always import from actual files - never barrel files
+- Import order: builtin → external → internal → parent → sibling
+- Client cannot import server code
+- No generic names (index.ts, init.ts) - use descriptive names
 
 ### 3.3 Tailwind CSS
 
-- 👤 Use Tailwind utility classes directly in JSX via `className`
-- 👤 Use a `cn()` helper for conditional, Tailwind-aware class merging with conflict resolution (e.g. `clsx` + `tailwind-merge`, or an equivalent drop-in such as `cnfast`)
-- 👤 Extract reusable components instead of `@apply` for repeated patterns
-- 👤 Use Tailwind config for design tokens (colors, spacing, typography)
-- 👤 Use responsive prefixes (`sm:`, `md:`, `lg:`) for breakpoints
-- 👤 Use dark mode via `dark:` variant
+- Use Tailwind utility classes directly in JSX via `className`
+- Use a `cn()` helper for conditional, Tailwind-aware class merging with conflict resolution (e.g. `clsx` + `tailwind-merge`, or an equivalent drop-in such as `cnfast`)
+- Extract reusable components instead of `@apply` for repeated patterns
+- Use Tailwind config for design tokens (colors, spacing, typography)
+- Use responsive prefixes (`sm:`, `md:`, `lg:`) for breakpoints
+- Use dark mode via `dark:` variant
 
 ## 4. Naming Conventions
 
-- 🤖 Variables/functions: camelCase (`@typescript-eslint/naming-convention`)
-- 🤖 Components/types/interfaces: PascalCase
-- 🤖 No I prefix for interfaces
-- 👤 Hooks: camelCase with 'use' prefix
-- 👤 Files: Components PascalCase, utilities camelCase
-- 👤 Test files: `*.test.ts` suffix
-- 🤖 Named exports only - no default exports (`import/no-default-export`)
-- 👤 IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
-- 👤 Descriptive names with auxiliary verbs (isLoading, hasError)
+- Variables/functions: camelCase
+- Components/types/interfaces: PascalCase
+- No I prefix for interfaces
+- Hooks: camelCase with 'use' prefix
+- Files: Components PascalCase, utilities camelCase
+- Test files: `*.test.ts` suffix
+- Named exports only - no default exports
+- IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
+- Descriptive names with auxiliary verbs (isLoading, hasError)
 
 ## 5. Development Setup
 
 - Node.js 24 LTS via nvm
-- 👤 Inspect @package.json before assuming scripts or package-manager commands
+- Inspect @package.json before assuming scripts or package-manager commands
 
-## 6. Environment Variables
+## 6. Common Standards
 
-- 🤖 No direct process.env or import.meta.env outside config (`no-restricted-syntax`)
-- 👤 Client: `import.meta.env.VITE_*`
-- 👤 Server: `process.env.*`
-- 👤 All variables have fallback defaults
-- 👤 Use .env.example as template
+### 6.1 JavaScript
+
+- Use async/await, not callbacks
+- Use template literals for string interpolation, not concatenation
+- Use `Object.hasOwn()` instead of `hasOwnProperty()`
+- Use `for...of` for array iteration, avoid classical `for` loops
+- Write pure functions - same input returns same output, no side effects
+- Prefer immutable array methods (map, filter, spread) over mutating (push, splice)
+- Use destructuring to extract object/array values
+- Use strict equality `===` and `!==`, never `==` or `!=`
+- Never mutate function parameters
+- Always throw Error objects, not primitives
+- Always reject Promises with Error objects
+- Use rest params `...args` instead of `arguments`
+- Limit nesting depth to 2 levels max
+- Limit cyclomatic complexity - few conditional branches
+- Use early returns (fail fast) instead of nested else
+- Functions should be 100 lines max
+
+### 6.2 TypeScript
+
+- Prefer interfaces over types
+- Avoid enums; use const assertions
+- Never use @ts-ignore
+- No type assertions without runtime validation (use Zod)
+- Return specific types, not generic (string → KnownCallOutcome)
+- Use type guards for narrowing
+- Use React.ComponentProps for extending props
+- Ask user for type information when `any` is unavoidable
+
+### 6.3 Environment Variables
+
+- No direct process.env or import.meta.env outside config
+- Client: `import.meta.env.VITE_*`
+- Server: `process.env.*`
+- All variables have fallback defaults
+- Use .env.example as template
 
 ## 7. Client-Side Standards
 
 ### 7.1 React
 
-- 🤖 Arrow function components only (`react/function-component-definition`)
-- 👤 Use `nullable()` helper for conditional rendering (not &&)
-- 🤖 Props: interfaces, not types
-- 👤 Composition over inheritance
-- 👤 useCallback for handlers passed as props
-- 👤 useMemo for expensive computations
-- 🤖 No inline arrow functions in JSX (`react/jsx-no-bind`)
-- 👤 Components > 200 lines should be split
-- 👤 Use Suspense for data fetching
-- 👤 Use useSuspenseQuery instead of useQuery
-- 🤖 One component per file (`react/no-multi-comp`)
-- 🤖 Never use array index as `key` prop (`react/no-array-index-key`)
-- 🤖 Self-close components with no children (`react/self-closing-comp`)
-- 👤 Use Tailwind `className` for styling, avoid inline `style` prop
-- 👤 Proactively identify reusable component patterns
+- Arrow function components only
+- Use `nullable()` helper for conditional rendering (not &&)
+- Props: interfaces, not types
+- Composition over inheritance
+- useCallback for handlers passed as props
+- useMemo for expensive computations
+- No inline arrow functions in JSX
+- Components > 200 lines should be split
+- Use Suspense for data fetching
+- Use useSuspenseQuery instead of useQuery
+- One component per file
+- Never use array index as `key` prop
+- Self-close components with no children
+- Use Tailwind `className` for styling, avoid inline `style` prop
+- Proactively identify reusable component patterns
 
-### 7.2 JavaScript
+### 7.2 State Management
 
-- 👤 Use async/await, not callbacks
-- 🤖 Use template literals for string interpolation, not concatenation (`prefer-template`)
-- 🤖 Use `Object.hasOwn()` instead of `hasOwnProperty()` (`prefer-object-has-own`)
-- 👤 Use `for...of` for array iteration, avoid classical `for` loops
-- 👤 Write pure functions - same input returns same output, no side effects
-- 👤 Prefer immutable array methods (map, filter, spread) over mutating (push, splice)
-- 🤖 Use destructuring to extract object/array values (`prefer-destructuring`)
-- 🤖 Use strict equality `===` and `!==`, never `==` or `!=` (`eqeqeq`)
-- 🤖 Never mutate function parameters (`no-param-reassign`)
-- 🤖 Always throw Error objects, not primitives (`no-throw-literal`)
-- 🤖 Always reject Promises with Error objects (`prefer-promise-reject-errors`)
-- 🤖 Use rest params `...args` instead of `arguments` (`prefer-rest-params`)
-- 🤖 Limit nesting depth to 2 levels max (`max-depth`)
-- 🤖 Limit cyclomatic complexity - few conditional branches (`complexity`)
-- 🤖 Use early returns (fail fast) instead of nested else (`no-else-return`)
-- 🤖 Functions should be 100 lines max (`max-lines-per-function`)
+- Don't useEffect to sync state - causes loops
+- Prefer derived state (useMemo) over synced state
+- Map/Set for lookups, Array only when order matters
+- Initialize text states with "", not undefined
+- Keep state in the lowest component that needs it
+- Split state into individual pieces, not entire objects
 
-### 7.3 TypeScript
+### 7.3 React Query
 
-- 🤖 Prefer interfaces over types (`@typescript-eslint/consistent-type-definitions`)
-- 👤 Avoid enums; use const assertions
-- 🤖 Never use @ts-ignore (`@typescript-eslint/ban-ts-comment`)
-- 👤 No type assertions without runtime validation (use Zod)
-- 👤 Return specific types, not generic (string → KnownCallOutcome)
-- 👤 Use type guards for narrowing
-- 👤 Use React.ComponentProps for extending props
-- 👤 Ask user for type information when `any` is unavoidable
+- Handle isLoading, error, data states (use Suspense)
+- Set appropriate staleTime
+- Invalidate queries after mutations
+- Use onError for specific handling
+- DevTools in development only
 
-### 7.4 State Management
+### 7.4 shadcn/ui + Radix UI
 
-- 👤 Don't useEffect to sync state - causes loops
-- 👤 Prefer derived state (useMemo) over synced state
-- 👤 Map/Set for lookups, Array only when order matters
-- 👤 Initialize text states with "", not undefined
-- 👤 Keep state in the lowest component that needs it
-- 👤 Split state into individual pieces, not entire objects
-
-### 7.5 React Query
-
-- 👤 Handle isLoading, error, data states (use Suspense)
-- 👤 Set appropriate staleTime
-- 👤 Invalidate queries after mutations
-- 👤 Use onError for specific handling
-- 👤 DevTools in development only
-
-### 7.6 shadcn/ui + Radix UI
-
-- 👤 Use shadcn/ui components built on Radix UI primitives
-- 👤 Customize components via Tailwind classes in the component source
-- 👤 Use Radix UI directly for primitives not covered by shadcn/ui
-- 👤 Keep component variants in the component file using `cva` (class-variance-authority)
-- 👤 Use `cn()` utility for merging class names
+- Use shadcn/ui components built on Radix UI primitives
+- Customize components via Tailwind classes in the component source
+- Use Radix UI directly for primitives not covered by shadcn/ui
+- Keep component variants in the component file using `cva` (class-variance-authority)
+- Use `cn()` utility for merging class names
 
 ## 8. Server-Side Standards
 
 ### 8.1 NodeJS
 
-- 👤 Use ES6 imports, not CommonJS
-- 🤖 Use fs/promises for file operations (`n/prefer-promises/fs`)
-- 👤 Graceful shutdown with signal handlers
-- 👤 Validate env variables at startup
-- 🤖 Use `node:` protocol prefix for built-in modules (`unicorn/prefer-node-protocol`)
-- 👤 Extend Error class for custom errors with context properties
-- 👤 Await promises before returning for complete stack traces
-- 👤 Subscribe to 'error' events on EventEmitters and streams
+- Use ES6 imports, not CommonJS
+- Use fs/promises for file operations
+- Graceful shutdown with signal handlers
+- Validate env variables at startup
+- Use `node:` protocol prefix for built-in modules
+- Extend Error class for custom errors with context properties
+- Await promises before returning for complete stack traces
+- Subscribe to 'error' events on EventEmitters and streams
 
 ### 8.2 Express
 
-- 👤 Use helmet for security headers
-- 👤 Use compression middleware
-- 👤 Middleware pattern for request handling
+- Use helmet for security headers
+- Use compression middleware
+- Middleware pattern for request handling
 
 ### 8.3 Database (Prisma/Kysely)
 
-- 👤 Prisma: migrations and type generation ONLY
-- 👤 Kysely: ALL application queries
-- 👤 Never use Prisma Client in application code
-- 👤 Use explicit junction tables
-- 👤 Use `/// @kyselyType()` in schema.prisma for typed Json fields (never edit kysely.ts directly)
+- Prisma: migrations and type generation ONLY
+- Kysely: ALL application queries
+- Never use Prisma Client in application code
+- Use explicit junction tables
+- Use `/// @kyselyType()` in schema.prisma for typed Json fields (never edit kysely.ts directly)
 
 ### 8.4 File Operations
 
-- 👤 Use `node:fs/promises` for files < 100MB
-- 👤 Use streams for files > 100MB
-- 👤 Use `pipeline()` for stream chaining
-- 👤 Use `import.meta.dirname` for module-relative paths
-- 👤 Handle error codes: ENOENT, EACCES, etc.
-- 👤 Always close file handles in finally blocks
+- Use `node:fs/promises` for files < 100MB
+- Use streams for files > 100MB
+- Use `pipeline()` for stream chaining
+- Use `import.meta.dirname` for module-relative paths
+- Handle error codes: ENOENT, EACCES, etc.
+- Always close file handles in finally blocks
 
 ## 9. API Standards
 
 ### 9.1 oRPC / tRPC
 
-- 👤 Descriptive procedure names
-- 👤 Always use Zod schemas for input
-- 👤 Use tRPC error codes (NOT_FOUND, UNAUTHORIZED)
-- 👤 Export router type for client
+- Descriptive procedure names
+- Always use Zod schemas for input
+- Use tRPC error codes (NOT_FOUND, UNAUTHORIZED)
+- Export router type for client
 
 ### 9.2 Zod
 
-- 👤 Use .merge(), .partial(), .pick(), .omit()
-- 👤 Use z.infer<> for types
-- 👤 Add custom error messages
-- 👤 Use .transform() for normalization
-- 👤 Use .refine() for complex validation
+- Use .merge(), .partial(), .pick(), .omit()
+- Use z.infer<> for types
+- Add custom error messages
+- Use .transform() for normalization
+- Use .refine() for complex validation
 
 ## 10. Testing
 
 ### 10.1 Quality Standards
 
-- 👤 No duplicate tests - each verifies unique behavior
-- 👤 Test distinct code paths, not variations
-- 👤 Iterate after tests passed to minimize the number of tests and duplications
+- No duplicate tests - each verifies unique behavior
+- Test distinct code paths, not variations
+- Iterate after tests passed to minimize the number of tests and duplications
 
 ### 10.2 Vitest
 
-- 👤 Co-located with source (\*.test.ts)
-- 👤 For: functions, services, utilities in isolation
+- Co-located with source (\*.test.ts)
+- For: functions, services, utilities in isolation
 
 ### 10.3 MSW
 
-- 👤 Use for HTTP mocking in tests
+- Use for HTTP mocking in tests
 
 ### 10.4 Playwright-BDD
 
-- 👤 Features in features/ directory
-- 👤 All helpers must be pure functions
-- 👤 Use data-testid for stable selectors
-- 👤 ES module imports require .js extensions
-- 👤 Uses Playwright under the hood, use Playwright MCP for UI tests
-- 👤 IMPORTANT: Use browser_snapshot before ANY UI work
-- 👤 Never assume element types/labels without verification
-- 👤 Workflow: start dev server → browser_navigate → browser_snapshot → verify → interact
+- Features in features/ directory
+- All helpers must be pure functions
+- Use data-testid for stable selectors
+- ES module imports require .js extensions
+- Uses Playwright under the hood, use Playwright MCP for UI tests
+- IMPORTANT: Use browser_snapshot before ANY UI work
+- Never assume element types/labels without verification
+- Workflow: start dev server → browser_navigate → browser_snapshot → verify → interact
 
 ## 11. Documentation
 
 ### 11.1 JSDoc
 
-- 👤 Every exported interface/type must have JSDoc
-- 👤 File-level JSDoc for config modules
-- 👤 Use @example where usage isn't obvious
-- 👤 Use @see <link> to add links to documentation
-- 👤 Focus on "why" and "how to use", not "what"
-- 👤 No useless descriptions repeating function name
-- 👤 Skip JSDoc only if no params AND obvious from name
-- 👤 Use @deprecated <reason> to mark deprecated code
-- 👤 All modules must have top level JSDoc with description and usage examples
+- Every exported interface/type must have JSDoc
+- File-level JSDoc for config modules
+- Use @example where usage isn't obvious
+- Use @see <link> to add links to documentation
+- Focus on "why" and "how to use", not "what"
+- No useless descriptions repeating function name
+- Skip JSDoc only if no params AND obvious from name
+- Use @deprecated <reason> to mark deprecated code
+- All modules must have top level JSDoc with description and usage examples
 
 ### 11.2 Code comments
 
-- 👤 Avoid obvious comments, only when necessary
-- 👤 Avoid link to exact lines of code
-- 👤 Focus on "why" and "how to use", not "what"
-- 👤 Avoid duplicates comments — it means code must be refactored
-- 👤 Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
-- 👤 Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
-- 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
-- 👤 Remove the TODO and its `@see` line when the linked issue closes
-- 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Avoid obvious comments, only when necessary
+- Avoid link to exact lines of code
+- Focus on "why" and "how to use", not "what"
+- Avoid duplicates comments — it means code must be refactored
+- Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
+- Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
+- Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
+- Remove the TODO and its `@see` line when the linked issue closes
+- Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 11.3 docs/ structure
 
-- 👤 Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
+- Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
 
 ## 12. Performance
 
-- 👤 O(1) lookups: Use Object/Map, not Array.find()
-- 👤 Avoid map/reduce/for combinations
-- 👤 Pre-compute lookups, not in render
-- 👤 Memoize data transformations creating objects/arrays
-- 👤 Use React.memo with displayName for stable-prop components
-- 👤 Use factory functions for handlers with parameters
-- 👤 Profile with React DevTools before adding useMemo/useCallback
+- O(1) lookups: Use Object/Map, not Array.find()
+- Avoid map/reduce/for combinations
+- Pre-compute lookups, not in render
+- Memoize data transformations creating objects/arrays
+- Use React.memo with displayName for stable-prop components
+- Use factory functions for handlers with parameters
+- Profile with React DevTools before adding useMemo/useCallback
 
 ## 13. Security
 
-- 👤 Validate all external input before processing
-- 👤 Never trust user data in object operations
-- 👤 Use crypto.timingSafeEqual() for secret comparison
-- 👤 Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
-- 👤 Use exact versions in package.json (no ^ or ~)
-- 👤 Never enable debug inspector in production
-- 👤 Never pass untrusted data to Object.assign()
-- 👤 Use Object.create(null) for user-provided keys
-- 👤 Use lockfile-based installs in CI/CD (`pnpm install --frozen-lockfile` or `npm ci`)
-- 👤 Run the matching audit command before deploying (`pnpm audit` or `npm audit`)
-- 🤖 Never use eval() or Function() constructor (`no-eval`)
-- 👤 Avoid dynamic require()/import() with user-controlled paths
-- 👤 Use textContent for DOM text insertion, not innerHTML (XSS risk)
+- Validate all external input before processing
+- Never trust user data in object operations
+- Use crypto.timingSafeEqual() for secret comparison
+- Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
+- Use exact versions in package.json (no ^ or ~)
+- Never enable debug inspector in production
+- Never pass untrusted data to Object.assign()
+- Use Object.create(null) for user-provided keys
+- Use lockfile-based installs in CI/CD (`pnpm install --frozen-lockfile` or `npm ci`)
+- Run the matching audit command before deploying (`pnpm audit` or `npm audit`)
+- Never use eval() or Function() constructor
+- Avoid dynamic require()/import() with user-controlled paths
+- Use textContent for DOM text insertion, not innerHTML (XSS risk)
 
 ## 14. Anti-Patterns
 
-- 🤖 No CommonJS require() - use ES6 imports
-- 👤 No callback-based APIs - use Promise-based
-- 🤖 No sync file operations in servers (`n/no-sync`)
-- 👤 No direct process.exit() - use graceful shutdown
-- 👤 No CSS Modules/CSS-in-JS - use Tailwind CSS
-- 👤 No barrel files (index.ts re-exports)
-- 👤 No unused exports - delete immediately
-- 👤 No commented-out code - delete it (recover from version control if needed)
-- 👤 No empty catch blocks - never swallow errors; rethrow or handle with context
-- 👤 No wrapper functions without added logic
-- 👤 No Array.find() for lookups - use Map/Object
-- 👤 No useEffect for state sync
-- 👤 No inline functions in loops
-- 👤 No incomplete configurations
-- 👤 No raw `git commit` — use `Skill(autopilot:commits-create)`
-- 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
-- 👤 No raw `gh pr create` — use `Skill(autopilot:pr-create)`
-- 👤 No raw `gh issue create` — use `Skill(autopilot:issue-create)`
-- 👤 No ad-hoc planning — use `Skill(autopilot:plan)`
+- No CommonJS require() - use ES6 imports
+- No callback-based APIs - use Promise-based
+- No sync file operations in servers
+- No direct process.exit() - use graceful shutdown
+- No CSS Modules/CSS-in-JS - use Tailwind CSS
+- No barrel files (index.ts re-exports)
+- No unused exports - delete immediately
+- No commented-out code - delete it (recover from version control if needed)
+- No empty catch blocks - never swallow errors; rethrow or handle with context
+- No wrapper functions without added logic
+- No Array.find() for lookups - use Map/Object
+- No useEffect for state sync
+- No inline functions in loops
+- No incomplete configurations
+- No raw `git commit` — use `Skill(autopilot:commits-create)`
+- No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
+- No raw `gh pr create` — use `Skill(autopilot:pr-create)`
+- No raw `gh issue create` — use `Skill(autopilot:issue-create)`
+- No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
-- 👤 **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
-- 👤 Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- 👤 The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
-- 👤 Never bypass validation hooks with `--no-verify` — fix the violation instead
+- **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
+- Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
+- The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
 
 ### 16.1 Claude Code
 
-- 👤 Use TodoWrite to track complex tasks
-- 👤 Mark todos as completed immediately
-- 👤 Parallel tool execution when possible
-- 👤 Gather context before editing
-- 👤 Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
-- 👤 Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- 👤 **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Use TodoWrite to track complex tasks
+- Mark todos as completed immediately
+- Parallel tool execution when possible
+- Gather context before editing
+- Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
+- Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
+- **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 
 Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 
-- 👤 **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
-- 👤 **shadcn MCP server** — search, browse, add, or audit shadcn/ui registry components; prefer it over hand-editing component source
-- 👤 **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
-- 👤 **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
-- 👤 **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
+- **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
+- **shadcn MCP server** — search, browse, add, or audit shadcn/ui registry components; prefer it over hand-editing component source
+- **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
+- **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
+- **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -36,7 +36,7 @@ In a monorepo, `README.md`, `llms.txt`, `docs/`, `design.md`, and `package.json`
 - Progressive enhancement: Build incrementally, test frequently
 - Functional/declarative patterns; avoid classes
 - Keep dependencies minimal - prefer built-in features
-- The fewer lines the better: every line used or removed, duplication factored into reuse
+- The fewer lines the better: every line and export used or removed, duplication factored into reuse
 - Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
 - Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
 - Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -16,11 +16,16 @@ To change it, open a pull request against the source file above.
 Before making any changes:
 
 1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
-2. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README
-3. Read files that appear relevant to the current task
-4. Treat `docs/` as the source of truth for project-specific conventions and follow those documents over this file when they conflict
-5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
-6. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+2. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
+3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
+5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
+6. Use the Repomix MCP server to pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
+7. When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
+   - For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
+   - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+   - Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
+   - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 
 ## 1. Core Principles
 
@@ -385,17 +390,7 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 - **shadcn MCP server** — search, browse, add, or audit shadcn/ui registry components; prefer it over hand-editing component source
 - **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
 - **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
-- **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 
 - All rules from AGENTS.md must be applied to the code review
-
-## 18. Graphify
-
-When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
-
-- For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
-- Use `graphify-out/wiki/index.md` for broad navigation when it exists.
-- Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
-- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -44,7 +44,7 @@ Before making any changes:
 - Write failing tests first, then write code to pass tests
 - Run tests after any code changes
 - Do not remove existing code/comments unless necessary
-- Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
+- Write plan before changes, not report after
 
 ## 2. Architecture
 
@@ -351,17 +351,12 @@ example/       # multiple modules: a directory, no index.ts barrel
 - No useEffect for state sync
 - No inline functions in loops
 - No incomplete configurations
-- No raw `git commit` — use `Skill(autopilot:commits-create)`
-- No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
-- No raw `gh pr create` — use `Skill(autopilot:pr-create)`
-- No raw `gh issue create` — use `Skill(autopilot:issue-create)`
-- No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
 - **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
 - Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- **MANDATORY**: With the autopilot plugin installed, perform these operations only through its skills — `Skill(autopilot:branch-create)` for branches, `Skill(autopilot:commits-create)` for commits, `Skill(autopilot:pr-create)` for pull requests, `Skill(autopilot:issue-create)` for issues, `Skill(autopilot:plan)` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the plugin, follow CONTRIBUTING.md directly
 - Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
@@ -374,11 +369,6 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -20,7 +20,8 @@ Before making any changes:
 3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. Acquire codebase context from the first source that works, falling through to the next on any failure:
+6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
+7. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -21,31 +21,27 @@ Before making any changes:
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
 6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
-7. Acquire codebase context from the first source that works, falling through to the next on any failure:
+7. Inspect `package.json` before assuming scripts or package-manager commands
+8. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.
 
 ## 1. Core Principles
 
-- Context first: Gather complete understanding before changes
-- Pattern matching: Check existing codebase for similar implementations
+- Context first: gather complete understanding before changes; check the codebase for similar implementations to mirror
 - Progressive enhancement: Build incrementally, test frequently
 - Functional/declarative patterns; avoid classes
 - Keep dependencies minimal - prefer built-in features
-- Every line of code must be used or removed
-- The fewer lines of code the better
-- Avoid code duplication - maximize reuse
+- The fewer lines the better: every line used or removed, duplication factored into reuse
 - Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
 - Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
-- Define verifiable success criteria before implementing (test, command, or observable behavior)
 - Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
 - When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - Be consistent with existing code style
 - Write failing tests first, then write code to pass tests
 - Run tests after any code changes
 - Do not remove existing code/comments unless necessary
-- Write plan before changes, not report after
 
 ## 2. Architecture
 
@@ -85,6 +81,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - Always import from actual files - never barrel files
 - Import order: builtin → external → internal → parent → sibling
+- Use ES6 imports, never CommonJS require()
+- Use `node:` protocol prefix for built-in modules
 - Client cannot import server code
 - No generic names (index.ts, init.ts) - use descriptive names
 
@@ -106,13 +104,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Files: Components PascalCase, utilities camelCase
 - Test files: `*.test.ts` suffix
 - Named exports only - no default exports
-- IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
+- camelCase for constants (not SCREAMING_SNAKE_CASE)
 - Descriptive names with auxiliary verbs (isLoading, hasError)
-
-## 5. Development Setup
-
-- Node.js 24 LTS via nvm
-- Inspect @package.json before assuming scripts or package-manager commands
 
 ## 6. Common Standards
 
@@ -133,6 +126,9 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Limit nesting depth to 2 levels max
 - Limit cyclomatic complexity - few conditional branches
 - Use early returns (fail fast) instead of nested else
+- Extend Error class for custom errors with context properties
+- Await promises before returning for complete stack traces
+- Subscribe to 'error' events on EventEmitters and streams
 - Functions should be 100 lines max
 
 ### 6.2 TypeScript
@@ -153,6 +149,16 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Server: `process.env.*`
 - All variables have fallback defaults
 - Use .env.example as template
+- Validate env variables at startup
+
+### 6.4 File Operations
+
+- Use `node:fs/promises` for files < 100MB
+- Use streams for files > 100MB
+- Use `pipeline()` for stream chaining
+- Use `import.meta.dirname` for module-relative paths
+- Handle error codes: ENOENT, EACCES, etc.
+- Always close file handles in finally blocks
 
 ## 7. Client-Side Standards
 
@@ -178,7 +184,6 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - Don't useEffect to sync state - causes loops
 - Prefer derived state (useMemo) over synced state
-- Map/Set for lookups, Array only when order matters
 - Initialize text states with "", not undefined
 - Keep state in the lowest component that needs it
 - Split state into individual pieces, not entire objects
@@ -203,14 +208,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 8.1 NodeJS
 
-- Use ES6 imports, not CommonJS
-- Use fs/promises for file operations
-- Graceful shutdown with signal handlers
-- Validate env variables at startup
-- Use `node:` protocol prefix for built-in modules
-- Extend Error class for custom errors with context properties
-- Await promises before returning for complete stack traces
-- Subscribe to 'error' events on EventEmitters and streams
+- Graceful shutdown with signal handlers; never call process.exit() directly
 
 ### 8.2 Express
 
@@ -225,15 +223,6 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Never use Prisma Client in application code
 - Use explicit junction tables
 - Use `/// @kyselyType()` in schema.prisma for typed Json fields (never edit kysely.ts directly)
-
-### 8.4 File Operations
-
-- Use `node:fs/promises` for files < 100MB
-- Use streams for files > 100MB
-- Use `pipeline()` for stream chaining
-- Use `import.meta.dirname` for module-relative paths
-- Handle error codes: ENOENT, EACCES, etc.
-- Always close file handles in finally blocks
 
 ## 9. API Standards
 
@@ -276,7 +265,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Use data-testid for stable selectors
 - ES module imports require .js extensions
 - Uses Playwright under the hood, use Playwright MCP for UI tests
-- IMPORTANT: Use browser_snapshot before ANY UI work
+- Use browser_snapshot before ANY UI work
 - Never assume element types/labels without verification
 - Workflow: start dev server → browser_navigate → browser_snapshot → verify → interact
 
@@ -296,15 +285,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 11.2 Code comments
 
-- Avoid obvious comments, only when necessary
-- Avoid link to exact lines of code
-- Focus on "why" and "how to use", not "what"
-- Avoid duplicates comments — it means code must be refactored
-- Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
-- Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
-- Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
-- Remove the TODO and its `@see` line when the linked issue closes
-- Use the autopilot `todo-cleanup` skill to create, link, and clean up TODO issues; without the plugin, follow CONTRIBUTING.md
+- Avoid obvious comments, links to exact code lines, and duplicated comments — duplication means the code needs refactoring
+- Track deferred work as issue-linked `TODO`/`FIXME` comments per CONTRIBUTING.md "TODO Comments"; use the autopilot `todo-cleanup` skill to scan, create, and link issues
 
 ### 11.3 docs/ structure
 
@@ -323,13 +305,11 @@ example/       # multiple modules: a directory, no index.ts barrel
 ## 13. Security
 
 - Validate all external input before processing
-- Never trust user data in object operations
+- Never trust user data in object operations — no untrusted input to Object.assign(), use Object.create(null) for user-provided keys
 - Use crypto.timingSafeEqual() for secret comparison
 - Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
 - Use exact versions in package.json (no ^ or ~)
 - Never enable debug inspector in production
-- Never pass untrusted data to Object.assign()
-- Use Object.create(null) for user-provided keys
 - Use lockfile-based installs in CI/CD (`pnpm install --frozen-lockfile` or `npm ci`)
 - Run the matching audit command before deploying (`pnpm audit` or `npm audit`)
 - Never use eval() or Function() constructor
@@ -338,20 +318,11 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ## 14. Anti-Patterns
 
-- No CommonJS require() - use ES6 imports
-- No callback-based APIs - use Promise-based
 - No sync file operations in servers
-- No direct process.exit() - use graceful shutdown
-- No CSS Modules/CSS-in-JS - use Tailwind CSS
-- No barrel files (index.ts re-exports)
-- No unused exports - delete immediately
 - No commented-out code - delete it (recover from version control if needed)
 - No empty catch blocks - never swallow errors; rethrow or handle with context
 - No wrapper functions without added logic
-- No Array.find() for lookups - use Map/Object
-- No useEffect for state sync
 - No inline functions in loops
-- No incomplete configurations
 
 ## 15. Git Workflow
 
@@ -362,10 +333,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ## 16. AI Assistant Workflow
 
-- Use the built-in todo list to track complex tasks
-- Mark todos as completed immediately
+- Track complex tasks with the built-in todo list; mark items completed immediately
 - Parallel tool execution when possible
-- Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -28,6 +28,8 @@ Before making any changes:
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.
 
+In a monorepo, `README.md`, `llms.txt`, `docs/`, `design.md`, and `package.json` may also exist per workspace member (`apps/*`, `packages/*`, …). When working inside a member, apply the steps above at both levels — the member's own copies govern that member's code and take precedence over the root copies; the root copies govern repo-wide concerns.
+
 ## 1. Core Principles
 
 - Context first: gather complete understanding before changes; check the codebase for similar implementations to mirror

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -20,12 +20,10 @@ Before making any changes:
 3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. Use the Repomix MCP server to pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
-7. When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
-   - For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
-   - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
-   - Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
-   - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+6. Acquire codebase context from the first source that works, falling through to the next on any failure:
+   - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+   - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
+   - **Default tools** — with neither available, search and read the repository files directly.
 
 ## 1. Core Principles
 

--- a/rules/NodeJS+React+Tailwind.md
+++ b/rules/NodeJS+React+Tailwind.md
@@ -16,13 +16,14 @@ To change it, open a pull request against the source file above.
 Before making any changes:
 
 1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
-2. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
-3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
-4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
-5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
-7. Inspect `package.json` before assuming scripts or package-manager commands
-8. Acquire codebase context from the first source that works, falling through to the next on any failure:
+2. When an `llms.txt` exists at the repository root, use it as the curated documentation index — follow its links before crawling docs manually
+3. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
+4. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
+6. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
+7. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
+8. Inspect `package.json` before assuming scripts or package-manager commands
+9. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -36,7 +36,7 @@ In a monorepo, `README.md`, `llms.txt`, `docs/`, `design.md`, and `package.json`
 - Progressive enhancement: Build incrementally, test frequently
 - Functional/declarative patterns; avoid classes
 - Keep dependencies minimal - prefer built-in features
-- The fewer lines the better: every line used or removed, duplication factored into reuse
+- The fewer lines the better: every line and export used or removed, duplication factored into reuse
 - Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
 - Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
 - Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -300,7 +300,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
 - Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
 - Remove the TODO and its `@see` line when the linked issue closes
-- Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Use the autopilot `todo-cleanup` skill to create, link, and clean up TODO issues; without the plugin, follow CONTRIBUTING.md
 
 ### 11.3 docs/ structure
 
@@ -353,21 +353,19 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
 - Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- **MANDATORY**: With the autopilot plugin installed, perform these operations only through its skills — `Skill(autopilot:branch-create)` for branches, `Skill(autopilot:commits-create)` for commits, `Skill(autopilot:pr-create)` for pull requests, `Skill(autopilot:issue-create)` for issues, `Skill(autopilot:plan)` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the plugin, follow CONTRIBUTING.md directly
+- **MANDATORY**: With the autopilot skills installed, perform these operations only through them — `branch-create` for branches, `commits-create` for commits, `pr-create` for pull requests, `issue-create` for issues, `plan` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the skills, follow CONTRIBUTING.md directly
 - Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
 
-### 16.1 Claude Code
-
-- Use TodoWrite to track complex tasks
+- Use the built-in todo list to track complex tasks
 - Mark todos as completed immediately
 - Parallel tool execution when possible
 - Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
 
-### 16.2 MCP Servers
+### 16.1 MCP Servers
 
 Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -20,7 +20,8 @@ Before making any changes:
 3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. Acquire codebase context from the first source that works, falling through to the next on any failure:
+6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
+7. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -16,11 +16,16 @@ To change it, open a pull request against the source file above.
 Before making any changes:
 
 1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
-2. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README
-3. Read files that appear relevant to the current task
-4. Treat `docs/` as the source of truth for project-specific conventions and follow those documents over this file when they conflict
-5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
-6. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+2. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
+3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
+5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
+6. Use the Repomix MCP server to pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
+7. When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
+   - For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
+   - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
+   - Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
+   - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 
 ## 1. Core Principles
 
@@ -381,17 +386,7 @@ Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`
 - **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
 - **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
 - **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
-- **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 
 - All rules from AGENTS.md must be applied to the code review
-
-## 18. Graphify
-
-When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
-
-- For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
-- Use `graphify-out/wiki/index.md` for broad navigation when it exists.
-- Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
-- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -21,31 +21,27 @@ Before making any changes:
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
 6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
-7. Acquire codebase context from the first source that works, falling through to the next on any failure:
+7. Inspect `package.json` before assuming scripts or package-manager commands
+8. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.
 
 ## 1. Core Principles
 
-- Context first: Gather complete understanding before changes
-- Pattern matching: Check existing codebase for similar implementations
+- Context first: gather complete understanding before changes; check the codebase for similar implementations to mirror
 - Progressive enhancement: Build incrementally, test frequently
 - Functional/declarative patterns; avoid classes
 - Keep dependencies minimal - prefer built-in features
-- Every line of code must be used or removed
-- The fewer lines of code the better
-- Avoid code duplication - maximize reuse
+- The fewer lines the better: every line used or removed, duplication factored into reuse
 - Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
 - Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
-- Define verifiable success criteria before implementing (test, command, or observable behavior)
 - Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
 - When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
 - Be consistent with existing code style
 - Write failing tests first, then write code to pass tests
 - Run tests after any code changes
 - Do not remove existing code/comments unless necessary
-- Write plan before changes, not report after
 
 ## 2. Architecture
 
@@ -86,6 +82,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - Always import from actual files - never barrel files
 - Import order: builtin → external → internal → parent → sibling
+- Use ES6 imports, never CommonJS require()
+- Use `node:` protocol prefix for built-in modules
 - Client cannot import server code
 - No generic names (index.ts, init.ts) - use descriptive names
 
@@ -104,13 +102,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Files: Components PascalCase, utilities camelCase
 - Test files: `*.test.ts` suffix
 - Named exports only - no default exports
-- IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
+- camelCase for constants (not SCREAMING_SNAKE_CASE)
 - Descriptive names with auxiliary verbs (isLoading, hasError)
-
-## 5. Development Setup
-
-- Node.js 24 LTS via nvm
-- Inspect @package.json before assuming scripts or package-manager commands
 
 ## 6. Common Standards
 
@@ -131,6 +124,9 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Limit nesting depth to 2 levels max
 - Limit cyclomatic complexity - few conditional branches
 - Use early returns (fail fast) instead of nested else
+- Extend Error class for custom errors with context properties
+- Await promises before returning for complete stack traces
+- Subscribe to 'error' events on EventEmitters and streams
 - Functions should be 100 lines max
 
 ### 6.2 TypeScript
@@ -151,6 +147,16 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Server: `process.env.*`
 - All variables have fallback defaults
 - Use .env.example as template
+- Validate env variables at startup
+
+### 6.4 File Operations
+
+- Use `node:fs/promises` for files < 100MB
+- Use streams for files > 100MB
+- Use `pipeline()` for stream chaining
+- Use `import.meta.dirname` for module-relative paths
+- Handle error codes: ENOENT, EACCES, etc.
+- Always close file handles in finally blocks
 
 ## 7. Client-Side Standards
 
@@ -176,7 +182,6 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 - Don't useEffect to sync state - causes loops
 - Prefer derived state (useMemo) over synced state
-- Map/Set for lookups, Array only when order matters
 - Initialize text states with "", not undefined
 - Keep state in the lowest component that needs it
 - Split state into individual pieces, not entire objects
@@ -200,14 +205,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 8.1 NodeJS
 
-- Use ES6 imports, not CommonJS
-- Use fs/promises for file operations
-- Graceful shutdown with signal handlers
-- Validate env variables at startup
-- Use `node:` protocol prefix for built-in modules
-- Extend Error class for custom errors with context properties
-- Await promises before returning for complete stack traces
-- Subscribe to 'error' events on EventEmitters and streams
+- Graceful shutdown with signal handlers; never call process.exit() directly
 
 ### 8.2 Express
 
@@ -222,15 +220,6 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Never use Prisma Client in application code
 - Use explicit junction tables
 - Use `/// @kyselyType()` in schema.prisma for typed Json fields (never edit kysely.ts directly)
-
-### 8.4 File Operations
-
-- Use `node:fs/promises` for files < 100MB
-- Use streams for files > 100MB
-- Use `pipeline()` for stream chaining
-- Use `import.meta.dirname` for module-relative paths
-- Handle error codes: ENOENT, EACCES, etc.
-- Always close file handles in finally blocks
 
 ## 9. API Standards
 
@@ -273,7 +262,7 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Use data-testid for stable selectors
 - ES module imports require .js extensions
 - Uses Playwright under the hood, use Playwright MCP for UI tests
-- IMPORTANT: Use browser_snapshot before ANY UI work
+- Use browser_snapshot before ANY UI work
 - Never assume element types/labels without verification
 - Workflow: start dev server → browser_navigate → browser_snapshot → verify → interact
 
@@ -293,15 +282,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ### 11.2 Code comments
 
-- Avoid obvious comments, only when necessary
-- Avoid link to exact lines of code
-- Focus on "why" and "how to use", not "what"
-- Avoid duplicates comments — it means code must be refactored
-- Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
-- Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
-- Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
-- Remove the TODO and its `@see` line when the linked issue closes
-- Use the autopilot `todo-cleanup` skill to create, link, and clean up TODO issues; without the plugin, follow CONTRIBUTING.md
+- Avoid obvious comments, links to exact code lines, and duplicated comments — duplication means the code needs refactoring
+- Track deferred work as issue-linked `TODO`/`FIXME` comments per CONTRIBUTING.md "TODO Comments"; use the autopilot `todo-cleanup` skill to scan, create, and link issues
 
 ### 11.3 docs/ structure
 
@@ -320,13 +302,11 @@ example/       # multiple modules: a directory, no index.ts barrel
 ## 13. Security
 
 - Validate all external input before processing
-- Never trust user data in object operations
+- Never trust user data in object operations — no untrusted input to Object.assign(), use Object.create(null) for user-provided keys
 - Use crypto.timingSafeEqual() for secret comparison
 - Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
 - Use exact versions in package.json (no ^ or ~)
 - Never enable debug inspector in production
-- Never pass untrusted data to Object.assign()
-- Use Object.create(null) for user-provided keys
 - Use lockfile-based installs in CI/CD (`pnpm install --frozen-lockfile` or `npm ci`)
 - Run the matching audit command before deploying (`pnpm audit` or `npm audit`)
 - Never use eval() or Function() constructor
@@ -335,20 +315,11 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ## 14. Anti-Patterns
 
-- No CommonJS require() - use ES6 imports
-- No callback-based APIs - use Promise-based
 - No sync file operations in servers
-- No direct process.exit() - use graceful shutdown
-- No TailwindCSS/CSS-in-JS - use CSS Modules
-- No barrel files (index.ts re-exports)
-- No unused exports - delete immediately
 - No commented-out code - delete it (recover from version control if needed)
 - No empty catch blocks - never swallow errors; rethrow or handle with context
 - No wrapper functions without added logic
-- No Array.find() for lookups - use Map/Object
-- No useEffect for state sync
 - No inline functions in loops
-- No incomplete configurations
 
 ## 15. Git Workflow
 
@@ -359,10 +330,8 @@ example/       # multiple modules: a directory, no index.ts barrel
 
 ## 16. AI Assistant Workflow
 
-- Use the built-in todo list to track complex tasks
-- Mark todos as completed immediately
+- Track complex tasks with the built-in todo list; mark items completed immediately
 - Parallel tool execution when possible
-- Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -28,6 +28,8 @@ Before making any changes:
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.
 
+In a monorepo, `README.md`, `llms.txt`, `docs/`, `design.md`, and `package.json` may also exist per workspace member (`apps/*`, `packages/*`, …). When working inside a member, apply the steps above at both levels — the member's own copies govern that member's code and take precedence over the root copies; the root copies govern repo-wide concerns.
+
 ## 1. Core Principles
 
 - Context first: gather complete understanding before changes; check the codebase for similar implementations to mirror

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -22,31 +22,26 @@ Before making any changes:
 5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 6. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 
-**Rule Markers Legend:**
-
-- 🤖 = Automated by linter (ESLint/Stylelint enforces this)
-- 👤 = Human-enforced (requires manual review)
-
 ## 1. Core Principles
 
-- 👤 Context first: Gather complete understanding before changes
-- 👤 Pattern matching: Check existing codebase for similar implementations
-- 👤 Progressive enhancement: Build incrementally, test frequently
-- 👤 Functional/declarative patterns; avoid classes
-- 👤 Keep dependencies minimal - prefer built-in features
-- 👤 Every line of code must be used or removed
-- 👤 The fewer lines of code the better
-- 👤 Avoid code duplication - maximize reuse
-- 👤 Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
-- 👤 Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
-- 👤 Define verifiable success criteria before implementing (test, command, or observable behavior)
-- 👤 Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
-- 👤 When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
-- 👤 Be consistent with existing code style
-- 👤 Write failing tests first, then write code to pass tests
-- 👤 Run tests after any code changes
-- 👤 Do not remove existing code/comments unless necessary
-- 👤 Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
+- Context first: Gather complete understanding before changes
+- Pattern matching: Check existing codebase for similar implementations
+- Progressive enhancement: Build incrementally, test frequently
+- Functional/declarative patterns; avoid classes
+- Keep dependencies minimal - prefer built-in features
+- Every line of code must be used or removed
+- The fewer lines of code the better
+- Avoid code duplication - maximize reuse
+- Do not over-engineer - only make directly requested changes. No abstractions for single-use code, no unrequested configurability, no error handling for impossible scenarios. If 200 lines could be 50, rewrite
+- Surface assumptions and ambiguities before coding; if multiple interpretations exist, present them - don't pick silently
+- Define verifiable success criteria before implementing (test, command, or observable behavior)
+- Every changed line must trace to the request - no opportunistic refactors of adjacent code or unrelated formatting
+- When deleting unused code, only remove orphans your changes created; mention pre-existing dead code instead of deleting it
+- Be consistent with existing code style
+- Write failing tests first, then write code to pass tests
+- Run tests after any code changes
+- Do not remove existing code/comments unless necessary
+- Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
 
 ## 2. Architecture
 
@@ -81,310 +76,312 @@ example/       # multiple modules: a directory, no index.ts barrel
 └── example.module.css
 ```
 
-- 👤 Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
+- Order code top-down by importance: public entry points and core domain logic first, lower-level helpers and utilities last
 
 ### 3.2 Import Rules
 
-- 🤖 Always import from actual files - never barrel files (`import/order`)
-- 🤖 Import order: builtin → external → internal → parent → sibling
-- 🤖 Client cannot import server code (`import/no-restricted-paths`)
-- 👤 No generic names (index.ts, init.ts) - use descriptive names
+- Always import from actual files - never barrel files
+- Import order: builtin → external → internal → parent → sibling
+- Client cannot import server code
+- No generic names (index.ts, init.ts) - use descriptive names
 
 ### 3.3 CSS Modules
 
-- 👤 Use `.module.css` files, not plain CSS
-- 👤 Import as `import styles from "./X.module.css"`
-- 👤 Use `className={styles.ClassName}`
+- Use `.module.css` files, not plain CSS
+- Import as `import styles from "./X.module.css"`
+- Use `className={styles.ClassName}`
 
 ## 4. Naming Conventions
 
-- 🤖 Variables/functions: camelCase (`@typescript-eslint/naming-convention`)
-- 🤖 Components/types/interfaces: PascalCase
-- 🤖 No I prefix for interfaces
-- 👤 Hooks: camelCase with 'use' prefix
-- 👤 Files: Components PascalCase, utilities camelCase
-- 👤 Test files: `*.test.ts` suffix
-- 🤖 Named exports only - no default exports (`import/no-default-export`)
-- 👤 IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
-- 👤 Descriptive names with auxiliary verbs (isLoading, hasError)
+- Variables/functions: camelCase
+- Components/types/interfaces: PascalCase
+- No I prefix for interfaces
+- Hooks: camelCase with 'use' prefix
+- Files: Components PascalCase, utilities camelCase
+- Test files: `*.test.ts` suffix
+- Named exports only - no default exports
+- IMPORTANT: camelCase for constants (not SCREAMING_SNAKE_CASE)
+- Descriptive names with auxiliary verbs (isLoading, hasError)
 
 ## 5. Development Setup
 
 - Node.js 24 LTS via nvm
-- 👤 Inspect @package.json before assuming scripts or package-manager commands
+- Inspect @package.json before assuming scripts or package-manager commands
 
-## 6. Environment Variables
+## 6. Common Standards
 
-- 🤖 No direct process.env or import.meta.env outside config (`no-restricted-syntax`)
-- 👤 Client: `import.meta.env.VITE_*`
-- 👤 Server: `process.env.*`
-- 👤 All variables have fallback defaults
-- 👤 Use .env.example as template
+### 6.1 JavaScript
+
+- Use async/await, not callbacks
+- Use template literals for string interpolation, not concatenation
+- Use `Object.hasOwn()` instead of `hasOwnProperty()`
+- Use `for...of` for array iteration, avoid classical `for` loops
+- Write pure functions - same input returns same output, no side effects
+- Prefer immutable array methods (map, filter, spread) over mutating (push, splice)
+- Use destructuring to extract object/array values
+- Use strict equality `===` and `!==`, never `==` or `!=`
+- Never mutate function parameters
+- Always throw Error objects, not primitives
+- Always reject Promises with Error objects
+- Use rest params `...args` instead of `arguments`
+- Limit nesting depth to 2 levels max
+- Limit cyclomatic complexity - few conditional branches
+- Use early returns (fail fast) instead of nested else
+- Functions should be 100 lines max
+
+### 6.2 TypeScript
+
+- Prefer interfaces over types
+- Avoid enums; use const assertions
+- Never use @ts-ignore
+- No type assertions without runtime validation (use Zod)
+- Return specific types, not generic (string → KnownCallOutcome)
+- Use type guards for narrowing
+- Use React.ComponentProps for extending props
+- Ask user for type information when `any` is unavoidable
+
+### 6.3 Environment Variables
+
+- No direct process.env or import.meta.env outside config
+- Client: `import.meta.env.VITE_*`
+- Server: `process.env.*`
+- All variables have fallback defaults
+- Use .env.example as template
 
 ## 7. Client-Side Standards
 
 ### 7.1 React
 
-- 🤖 Arrow function components only (`react/function-component-definition`)
-- 👤 Use `nullable()` helper for conditional rendering (not &&)
-- 🤖 Props: interfaces, not types
-- 👤 Composition over inheritance
-- 👤 useCallback for handlers passed as props
-- 👤 useMemo for expensive computations
-- 🤖 No inline arrow functions in JSX (`react/jsx-no-bind`)
-- 👤 Components > 200 lines should be split
-- 👤 Use Suspense for data fetching
-- 👤 Use useSuspenseQuery instead of useQuery
-- 🤖 One component per file (`react/no-multi-comp`)
-- 🤖 Never use array index as `key` prop (`react/no-array-index-key`)
-- 🤖 Self-close components with no children (`react/self-closing-comp`)
-- 🤖 Avoid `style` prop, use CSS Modules instead (`react/forbid-component-props`)
-- 👤 Proactively identify reusable component patterns
+- Arrow function components only
+- Use `nullable()` helper for conditional rendering (not &&)
+- Props: interfaces, not types
+- Composition over inheritance
+- useCallback for handlers passed as props
+- useMemo for expensive computations
+- No inline arrow functions in JSX
+- Components > 200 lines should be split
+- Use Suspense for data fetching
+- Use useSuspenseQuery instead of useQuery
+- One component per file
+- Never use array index as `key` prop
+- Self-close components with no children
+- Avoid `style` prop, use CSS Modules instead
+- Proactively identify reusable component patterns
 
-### 7.2 JavaScript
+### 7.2 State Management
 
-- 👤 Use async/await, not callbacks
-- 🤖 Use template literals for string interpolation, not concatenation (`prefer-template`)
-- 🤖 Use `Object.hasOwn()` instead of `hasOwnProperty()` (`prefer-object-has-own`)
-- 👤 Use `for...of` for array iteration, avoid classical `for` loops
-- 👤 Write pure functions - same input returns same output, no side effects
-- 👤 Prefer immutable array methods (map, filter, spread) over mutating (push, splice)
-- 🤖 Use destructuring to extract object/array values (`prefer-destructuring`)
-- 🤖 Use strict equality `===` and `!==`, never `==` or `!=` (`eqeqeq`)
-- 🤖 Never mutate function parameters (`no-param-reassign`)
-- 🤖 Always throw Error objects, not primitives (`no-throw-literal`)
-- 🤖 Always reject Promises with Error objects (`prefer-promise-reject-errors`)
-- 🤖 Use rest params `...args` instead of `arguments` (`prefer-rest-params`)
-- 🤖 Limit nesting depth to 2 levels max (`max-depth`)
-- 🤖 Limit cyclomatic complexity - few conditional branches (`complexity`)
-- 🤖 Use early returns (fail fast) instead of nested else (`no-else-return`)
-- 🤖 Functions should be 100 lines max (`max-lines-per-function`)
+- Don't useEffect to sync state - causes loops
+- Prefer derived state (useMemo) over synced state
+- Map/Set for lookups, Array only when order matters
+- Initialize text states with "", not undefined
+- Keep state in the lowest component that needs it
+- Split state into individual pieces, not entire objects
 
-### 7.3 TypeScript
+### 7.3 React Query
 
-- 🤖 Prefer interfaces over types (`@typescript-eslint/consistent-type-definitions`)
-- 👤 Avoid enums; use const assertions
-- 🤖 Never use @ts-ignore (`@typescript-eslint/ban-ts-comment`)
-- 👤 No type assertions without runtime validation (use Zod)
-- 👤 Return specific types, not generic (string → KnownCallOutcome)
-- 👤 Use type guards for narrowing
-- 👤 Use React.ComponentProps for extending props
-- 👤 Ask user for type information when `any` is unavoidable
+- Handle isLoading, error, data states (use Suspense)
+- Set appropriate staleTime
+- Invalidate queries after mutations
+- Use onError for specific handling
+- DevTools in development only
 
-### 7.4 State Management
+### 7.4 Mantine
 
-- 👤 Don't useEffect to sync state - causes loops
-- 👤 Prefer derived state (useMemo) over synced state
-- 👤 Map/Set for lookups, Array only when order matters
-- 👤 Initialize text states with "", not undefined
-- 👤 Keep state in the lowest component that needs it
-- 👤 Split state into individual pieces, not entire objects
-
-### 7.5 React Query
-
-- 👤 Handle isLoading, error, data states (use Suspense)
-- 👤 Set appropriate staleTime
-- 👤 Invalidate queries after mutations
-- 👤 Use onError for specific handling
-- 👤 DevTools in development only
-
-### 7.6 Mantine
-
-- 👤 Use Mantine components from @mantine/core
-- 👤 Use @mantine/hooks for common hooks
-- 👤 Use @mantine/form with zodResolver
-- 👤 Wrap Mantine components in project-level components for reusability
+- Use Mantine components from @mantine/core
+- Use @mantine/hooks for common hooks
+- Use @mantine/form with zodResolver
+- Wrap Mantine components in project-level components for reusability
 
 ## 8. Server-Side Standards
 
 ### 8.1 NodeJS
 
-- 👤 Use ES6 imports, not CommonJS
-- 🤖 Use fs/promises for file operations (`n/prefer-promises/fs`)
-- 👤 Graceful shutdown with signal handlers
-- 👤 Validate env variables at startup
-- 🤖 Use `node:` protocol prefix for built-in modules (`unicorn/prefer-node-protocol`)
-- 👤 Extend Error class for custom errors with context properties
-- 👤 Await promises before returning for complete stack traces
-- 👤 Subscribe to 'error' events on EventEmitters and streams
+- Use ES6 imports, not CommonJS
+- Use fs/promises for file operations
+- Graceful shutdown with signal handlers
+- Validate env variables at startup
+- Use `node:` protocol prefix for built-in modules
+- Extend Error class for custom errors with context properties
+- Await promises before returning for complete stack traces
+- Subscribe to 'error' events on EventEmitters and streams
 
 ### 8.2 Express
 
-- 👤 Use helmet for security headers
-- 👤 Use compression middleware
-- 👤 Middleware pattern for request handling
+- Use helmet for security headers
+- Use compression middleware
+- Middleware pattern for request handling
 
 ### 8.3 Database (Prisma/Kysely)
 
-- 👤 Prisma: migrations and type generation ONLY
-- 👤 Kysely: ALL application queries
-- 👤 Never use Prisma Client in application code
-- 👤 Use explicit junction tables
-- 👤 Use `/// @kyselyType()` in schema.prisma for typed Json fields (never edit kysely.ts directly)
+- Prisma: migrations and type generation ONLY
+- Kysely: ALL application queries
+- Never use Prisma Client in application code
+- Use explicit junction tables
+- Use `/// @kyselyType()` in schema.prisma for typed Json fields (never edit kysely.ts directly)
 
 ### 8.4 File Operations
 
-- 👤 Use `node:fs/promises` for files < 100MB
-- 👤 Use streams for files > 100MB
-- 👤 Use `pipeline()` for stream chaining
-- 👤 Use `import.meta.dirname` for module-relative paths
-- 👤 Handle error codes: ENOENT, EACCES, etc.
-- 👤 Always close file handles in finally blocks
+- Use `node:fs/promises` for files < 100MB
+- Use streams for files > 100MB
+- Use `pipeline()` for stream chaining
+- Use `import.meta.dirname` for module-relative paths
+- Handle error codes: ENOENT, EACCES, etc.
+- Always close file handles in finally blocks
 
 ## 9. API Standards
 
 ### 9.1 oRPC / tRPC
 
-- 👤 Descriptive procedure names
-- 👤 Always use Zod schemas for input
-- 👤 Use tRPC error codes (NOT_FOUND, UNAUTHORIZED)
-- 👤 Export router type for client
+- Descriptive procedure names
+- Always use Zod schemas for input
+- Use tRPC error codes (NOT_FOUND, UNAUTHORIZED)
+- Export router type for client
 
 ### 9.2 Zod
 
-- 👤 Use .merge(), .partial(), .pick(), .omit()
-- 👤 Use z.infer<> for types
-- 👤 Add custom error messages
-- 👤 Use .transform() for normalization
-- 👤 Use .refine() for complex validation
+- Use .merge(), .partial(), .pick(), .omit()
+- Use z.infer<> for types
+- Add custom error messages
+- Use .transform() for normalization
+- Use .refine() for complex validation
 
 ## 10. Testing
 
 ### 10.1 Quality Standards
 
-- 👤 No duplicate tests - each verifies unique behavior
-- 👤 Test distinct code paths, not variations
-- 👤 Iterate after tests passed to minimize the number of tests and duplications
+- No duplicate tests - each verifies unique behavior
+- Test distinct code paths, not variations
+- Iterate after tests passed to minimize the number of tests and duplications
 
 ### 10.2 Vitest
 
-- 👤 Co-located with source (\*.test.ts)
-- 👤 For: functions, services, utilities in isolation
+- Co-located with source (\*.test.ts)
+- For: functions, services, utilities in isolation
 
 ### 10.3 MSW
 
-- 👤 Use for HTTP mocking in tests
+- Use for HTTP mocking in tests
 
 ### 10.4 Playwright-BDD
 
-- 👤 Features in features/ directory
-- 👤 All helpers must be pure functions
-- 👤 Use data-testid for stable selectors
-- 👤 ES module imports require .js extensions
-- 👤 Uses Playwright under the hood, use Playwright MCP for UI tests
-- 👤 IMPORTANT: Use browser_snapshot before ANY UI work
-- 👤 Never assume element types/labels without verification
-- 👤 Workflow: start dev server → browser_navigate → browser_snapshot → verify → interact
+- Features in features/ directory
+- All helpers must be pure functions
+- Use data-testid for stable selectors
+- ES module imports require .js extensions
+- Uses Playwright under the hood, use Playwright MCP for UI tests
+- IMPORTANT: Use browser_snapshot before ANY UI work
+- Never assume element types/labels without verification
+- Workflow: start dev server → browser_navigate → browser_snapshot → verify → interact
 
 ## 11. Documentation
 
 ### 11.1 JSDoc
 
-- 👤 Every exported interface/type must have JSDoc
-- 👤 File-level JSDoc for config modules
-- 👤 Use @example where usage isn't obvious
-- 👤 Use @see <link> to add links to documentation
-- 👤 Focus on "why" and "how to use", not "what"
-- 👤 No useless descriptions repeating function name
-- 👤 Skip JSDoc only if no params AND obvious from name
-- 👤 Use @deprecated <reason> to mark deprecated code
-- 👤 All modules must have top level JSDoc with description and usage examples
+- Every exported interface/type must have JSDoc
+- File-level JSDoc for config modules
+- Use @example where usage isn't obvious
+- Use @see <link> to add links to documentation
+- Focus on "why" and "how to use", not "what"
+- No useless descriptions repeating function name
+- Skip JSDoc only if no params AND obvious from name
+- Use @deprecated <reason> to mark deprecated code
+- All modules must have top level JSDoc with description and usage examples
 
 ### 11.2 Code comments
 
-- 👤 Avoid obvious comments, only when necessary
-- 👤 Avoid link to exact lines of code
-- 👤 Focus on "why" and "how to use", not "what"
-- 👤 Avoid duplicates comments — it means code must be refactored
-- 👤 Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
-- 👤 Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
-- 👤 Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
-- 👤 Remove the TODO and its `@see` line when the linked issue closes
-- 👤 Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Avoid obvious comments, only when necessary
+- Avoid link to exact lines of code
+- Focus on "why" and "how to use", not "what"
+- Avoid duplicates comments — it means code must be refactored
+- Use only `TODO` (planned improvement) or `FIXME` (known defect) for deferred work — no XXX/HACK/NOTE markers
+- Format: `// TODO: <description>` / `// FIXME: <description>` — uppercase keyword, colon + single space
+- Link every TODO/FIXME with `// @see <issue-url>` on the line immediately below — full issue URL, not a bare `#123` in the description
+- Remove the TODO and its `@see` line when the linked issue closes
+- Use `Skill(autopilot:todo-cleanup)` to create, link, and clean up TODO issues. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 11.3 docs/ structure
 
-- 👤 Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
+- Organize `docs/` as numbered chapters in reading order (`NN-topic.md`, plus `appendix-X-topic.md` for non-sequential references), matching the README Documentation order
 
 ## 12. Performance
 
-- 👤 O(1) lookups: Use Object/Map, not Array.find()
-- 👤 Avoid map/reduce/for combinations
-- 👤 Pre-compute lookups, not in render
-- 👤 Memoize data transformations creating objects/arrays
-- 👤 Use React.memo with displayName for stable-prop components
-- 👤 Use factory functions for handlers with parameters
-- 👤 Profile with React DevTools before adding useMemo/useCallback
+- O(1) lookups: Use Object/Map, not Array.find()
+- Avoid map/reduce/for combinations
+- Pre-compute lookups, not in render
+- Memoize data transformations creating objects/arrays
+- Use React.memo with displayName for stable-prop components
+- Use factory functions for handlers with parameters
+- Profile with React DevTools before adding useMemo/useCallback
 
 ## 13. Security
 
-- 👤 Validate all external input before processing
-- 👤 Never trust user data in object operations
-- 👤 Use crypto.timingSafeEqual() for secret comparison
-- 👤 Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
-- 👤 Use exact versions in package.json (no ^ or ~)
-- 👤 Never enable debug inspector in production
-- 👤 Never pass untrusted data to Object.assign()
-- 👤 Use Object.create(null) for user-provided keys
-- 👤 Use lockfile-based installs in CI/CD (`pnpm install --frozen-lockfile` or `npm ci`)
-- 👤 Run the matching audit command before deploying (`pnpm audit` or `npm audit`)
-- 🤖 Never use eval() or Function() constructor (`no-eval`)
-- 👤 Avoid dynamic require()/import() with user-controlled paths
-- 👤 Use textContent for DOM text insertion, not innerHTML (XSS risk)
+- Validate all external input before processing
+- Never trust user data in object operations
+- Use crypto.timingSafeEqual() for secret comparison
+- Never log or expose secrets, tokens, or PII (logs, error messages, API responses)
+- Use exact versions in package.json (no ^ or ~)
+- Never enable debug inspector in production
+- Never pass untrusted data to Object.assign()
+- Use Object.create(null) for user-provided keys
+- Use lockfile-based installs in CI/CD (`pnpm install --frozen-lockfile` or `npm ci`)
+- Run the matching audit command before deploying (`pnpm audit` or `npm audit`)
+- Never use eval() or Function() constructor
+- Avoid dynamic require()/import() with user-controlled paths
+- Use textContent for DOM text insertion, not innerHTML (XSS risk)
 
 ## 14. Anti-Patterns
 
-- 🤖 No CommonJS require() - use ES6 imports
-- 👤 No callback-based APIs - use Promise-based
-- 🤖 No sync file operations in servers (`n/no-sync`)
-- 👤 No direct process.exit() - use graceful shutdown
-- 👤 No TailwindCSS/CSS-in-JS - use CSS Modules
-- 👤 No barrel files (index.ts re-exports)
-- 👤 No unused exports - delete immediately
-- 👤 No commented-out code - delete it (recover from version control if needed)
-- 👤 No empty catch blocks - never swallow errors; rethrow or handle with context
-- 👤 No wrapper functions without added logic
-- 👤 No Array.find() for lookups - use Map/Object
-- 👤 No useEffect for state sync
-- 👤 No inline functions in loops
-- 👤 No incomplete configurations
-- 👤 No raw `git commit` — use `Skill(autopilot:commits-create)`
-- 👤 No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
-- 👤 No raw `gh pr create` — use `Skill(autopilot:pr-create)`
-- 👤 No raw `gh issue create` — use `Skill(autopilot:issue-create)`
-- 👤 No ad-hoc planning — use `Skill(autopilot:plan)`
+- No CommonJS require() - use ES6 imports
+- No callback-based APIs - use Promise-based
+- No sync file operations in servers
+- No direct process.exit() - use graceful shutdown
+- No TailwindCSS/CSS-in-JS - use CSS Modules
+- No barrel files (index.ts re-exports)
+- No unused exports - delete immediately
+- No commented-out code - delete it (recover from version control if needed)
+- No empty catch blocks - never swallow errors; rethrow or handle with context
+- No wrapper functions without added logic
+- No Array.find() for lookups - use Map/Object
+- No useEffect for state sync
+- No inline functions in loops
+- No incomplete configurations
+- No raw `git commit` — use `Skill(autopilot:commits-create)`
+- No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
+- No raw `gh pr create` — use `Skill(autopilot:pr-create)`
+- No raw `gh issue create` — use `Skill(autopilot:issue-create)`
+- No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
-- 👤 **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
-- 👤 Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- 👤 The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
-- 👤 Never bypass validation hooks with `--no-verify` — fix the violation instead
+- **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
+- Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
+- The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
 
 ### 16.1 Claude Code
 
-- 👤 Use TodoWrite to track complex tasks
-- 👤 Mark todos as completed immediately
-- 👤 Parallel tool execution when possible
-- 👤 Gather context before editing
-- 👤 Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
-- 👤 Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- 👤 **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- 👤 **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- Use TodoWrite to track complex tasks
+- Mark todos as completed immediately
+- Parallel tool execution when possible
+- Gather context before editing
+- Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
+- Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
+- **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
+- **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 
 Prefer the project-registered MCP servers declared in the repo's own `.mcp.json`. The repository README and `docs/` are the authoritative list of which servers are registered and when to reach for each — consult them before hand-rolling work a registered server handles.
 
-- 👤 **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
-- 👤 **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
-- 👤 **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
-- 👤 **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
+- **Documentation servers** (context7, Ref, Exa) — look up docs for any technology, framework, or API (global/user servers, not project-registered)
+- **Playwright MCP server** — persistent, exploratory UI verification with `browser_snapshot`; prefer the token-efficient `@playwright/cli` CLI for high-throughput agent runs
+- **Chrome DevTools MCP server** — performance traces, network inspection, console debugging
+- **Repomix MCP server** — pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
 
 ## 17. Code Review
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -20,12 +20,10 @@ Before making any changes:
 3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
 4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
 5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. Use the Repomix MCP server to pack the codebase into one digest and grep/read it for codebase-wide analysis instead of loading every file
-7. When `graphify-out/graph.json` exists, use the committed knowledge graph before broad source browsing:
-   - For codebase questions, run `graphify query "<question>"` first. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts.
-   - Use `graphify-out/wiki/index.md` for broad navigation when it exists.
-   - Read `graphify-out/GRAPH_REPORT.md` only for broad architecture review or when targeted queries do not surface enough context.
-   - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+6. Acquire codebase context from the first source that works, falling through to the next on any failure:
+   - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+   - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
+   - **Default tools** — with neither available, search and read the repository files directly.
 
 ## 1. Core Principles
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -44,7 +44,7 @@ Before making any changes:
 - Write failing tests first, then write code to pass tests
 - Run tests after any code changes
 - Do not remove existing code/comments unless necessary
-- Write plan before changes, not report after — draft it via `Skill(autopilot:plan)` (if the autopilot plugin is not installed, follow CONTRIBUTING.md)
+- Write plan before changes, not report after
 
 ## 2. Architecture
 
@@ -348,17 +348,12 @@ example/       # multiple modules: a directory, no index.ts barrel
 - No useEffect for state sync
 - No inline functions in loops
 - No incomplete configurations
-- No raw `git commit` — use `Skill(autopilot:commits-create)`
-- No raw `git checkout -b` / `git branch` — use `Skill(autopilot:branch-create)`
-- No raw `gh pr create` — use `Skill(autopilot:pr-create)`
-- No raw `gh issue create` — use `Skill(autopilot:issue-create)`
-- No ad-hoc planning — use `Skill(autopilot:plan)`
 
 ## 15. Git Workflow
 
 - **MANDATORY**: `CONTRIBUTING.md` in the repository root is the binding standard for every branch, commit, PR, and issue operation — read the governing section before acting; never restate or improvise its rules
 - Governing sections: "Branches" for branch names, "Commits" for commit messages, "PR Title" and "Special PR Prefixes" for PR titles, "PR Description" and "Magic Words" for PR bodies and issue linking, "How to Contribute" for issues
-- The `Skill(autopilot:*)` commands in §16.1 implement these conventions — invoking the skill satisfies this section
+- **MANDATORY**: With the autopilot plugin installed, perform these operations only through its skills — `Skill(autopilot:branch-create)` for branches, `Skill(autopilot:commits-create)` for commits, `Skill(autopilot:pr-create)` for pull requests, `Skill(autopilot:issue-create)` for issues, `Skill(autopilot:plan)` for implementation plans — never their raw `git`/`gh`/web-UI equivalents and never ad-hoc planning; invoking the skill satisfies this section. Without the plugin, follow CONTRIBUTING.md directly
 - Never bypass validation hooks with `--no-verify` — fix the violation instead
 
 ## 16. AI Assistant Workflow
@@ -371,11 +366,6 @@ example/       # multiple modules: a directory, no index.ts barrel
 - Gather context before editing
 - Use sub-agents for search-heavy or parallelizable investigation to keep the main context focused
 - Use `gh` CLI for GitHub issues, PRs, comments, and Actions info
-- **MANDATORY**: Commit only via `Skill(autopilot:commits-create)` — no raw `git commit`, no `git commit -m`, no `--amend`, no exceptions. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create branches only via `Skill(autopilot:branch-create)` — no raw `git checkout -b`, `git branch`, or `git switch -c`. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create PRs only via `Skill(autopilot:pr-create)` — no raw `gh pr create` or web-UI PR creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Create issues only via `Skill(autopilot:issue-create)` — no raw `gh issue create` or web-UI issue creation. If the autopilot plugin is not installed, follow CONTRIBUTING.md
-- **MANDATORY**: Plan only via `Skill(autopilot:plan)` — no ad-hoc implementation planning. If the autopilot plugin is not installed, follow CONTRIBUTING.md
 
 ### 16.2 MCP Servers
 

--- a/rules/NodeJS+React.md
+++ b/rules/NodeJS+React.md
@@ -16,13 +16,14 @@ To change it, open a pull request against the source file above.
 Before making any changes:
 
 1. Read the root `README.md` — its Documentation section lists every doc in reading order, as a Markdown table (or an equivalent linked list), each with a link and a description
-2. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
-3. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
-4. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
-5. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
-6. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
-7. Inspect `package.json` before assuming scripts or package-manager commands
-8. Acquire codebase context from the first source that works, falling through to the next on any failure:
+2. When an `llms.txt` exists at the repository root, use it as the curated documentation index — follow its links before crawling docs manually
+3. Read the root `CONTRIBUTING.md` — the binding conventions for every branch, commit, PR, and issue operation
+4. When a `principles/` folder exists, read its `README.md` and the principles relevant to the task — they are the long-lived values that standards and reviews appeal to; follow `rfc/` and `docs/` over them for concrete rules
+5. When an `rfc/` folder exists, treat its Accepted RFCs as binding versioned standards — follow them over `docs/` and this file when they conflict; see `rfc/README.md` for the convention
+6. Inspect all file names under `docs/` and subfolders in the current repository — some files may be missing from the README — read those relevant to the current task, and treat `docs/` as the source of truth for project-specific conventions, following those documents over this file when they conflict
+7. When a `design.md` exists at the repository root, read it before any UI or visual work — it is the binding design and brand spec (tokens, typography, layout conventions); follow it over generic styling defaults
+8. Inspect `package.json` before assuming scripts or package-manager commands
+9. Acquire codebase context from the first source that works, falling through to the next on any failure:
    - **Graphify** — fires when `graphify-out/graph.json` exists and the `graphify` CLI resolves on PATH. Run `graphify query "<question>"` first; use `graphify path "<A>" "<B>"` for relationships, `graphify explain "<concept>"` for focused concepts, and `graphify-out/wiki/index.md` for broad navigation. After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
    - **Repomix** — fires when the Repomix MCP server is connected. Attach the committed `.repomix/pack.xml` when it exists, otherwise pack the codebase; grep/read the digest for codebase-wide analysis instead of loading every file.
    - **Default tools** — with neither available, search and read the repository files directly.


### PR DESCRIPTION
Deep cleanup and generalization of the four synced stack rule sets in [rules/](https://github.com/awinogradov/code-assistants/blob/main/rules) that land in consumer repositories as their agent rules file. The files lose the unmaintained rule-marker system and all duplicated guidance, gain an ordered context-acquisition checklist, and read the same for any coding agent — Claude Code, Codex, Kimi, Cursor.

- Mandatory Context is now a 9-step checklist — README, `llms.txt`, [CONTRIBUTING.md](https://github.com/awinogradov/code-assistants/blob/main/CONTRIBUTING.md), `principles/`, `rfc/`, `docs/`, `design.md`, `package.json`, then a graphify → Repomix → default-tools source chain with a recognition condition per tier — plus a monorepo note applying the steps per workspace member (`apps/*`, `packages/*`)
- Removed the 🤖/👤 marker legend and the per-bullet ESLint rule-name citations; every rule stands on its content
- Consolidated the branch/commit/PR/issue/plan mandates into one audience-neutral Git Workflow block pointing at CONTRIBUTING.md; deleted the duplicate copies in Anti-Patterns and the former Claude Code subsection
- Regrouped general rules under Common Standards in all four files (JavaScript, TypeScript, Environment Variables, File Operations); the server-side section keeps only genuine server concerns
- Deduplicated every bullet stated twice — anti-pattern restatements of other sections, TODO rules restating the CONTRIBUTING "TODO Comments" section, planning bullets restating "Planning"
- Fixed invalid guidance: `bun ci` does not exist — replaced with `bun install --frozen-lockfile`; dropped the hardcoded script lists advertising `bun run lint:fix`
- Net −209 lines across the four files; one bullet deleted outright — `No incomplete configurations` carried no actionable instruction — every other removal has an equivalent statement elsewhere

---

**Release notes:**

- Reworked the synced stack rule sets: ordered Mandatory Context checklist (llms.txt, design.md, package.json, graphify/Repomix source chain) with monorepo member scoping
- Removed the rule-marker system and linter citations; rules are now tool-agnostic for any coding agent
- Fixed invalid `bun ci` guidance to `bun install --frozen-lockfile`