### PR TITLE
HOTFIX: Correct the branch-recovery rebase command that dropped commits

### DIFF
--- a/.github/actions/code-review-action/src/gitHistoryPolicy.test.ts
+++ b/.github/actions/code-review-action/src/gitHistoryPolicy.test.ts
@@ -106,6 +106,30 @@ describe("canonical forbidden-command regex", () => {
   });
 });
 
+// `--onto <merge-commit>` replays the range <merge-commit>..<branch>, so every
+// commit the branch made before the merge is an ancestor of the exclusion point
+// and is silently dropped: `A, B, M(merge), C` recovers as `C` alone. Both
+// encodings prescribed that form until a downstream review caught it. The
+// positive half of each case is what stops this guard passing vacuously once the
+// section is renamed or moved.
+describe("the recovery recipe keeps the branch's own commits", () => {
+  const recipe = "`git rebase <base-tip> <branch>`";
+  const destructive = "rebase --onto";
+
+  test.each([
+    ["the canonical block", blockPath],
+    ["CONTRIBUTING.md", contributingPath],
+  ])("%s prescribes the plain rebase and no --onto form", async (name, path) => {
+    const content = await readFile(path, "utf8");
+    expect(`${name} prescribes the recipe: ${content.includes(recipe)}`).toBe(
+      `${name} prescribes the recipe: true`,
+    );
+    expect(`${name} mentions --onto: ${content.includes(destructive)}`).toBe(
+      `${name} mentions --onto: false`,
+    );
+  });
+});
+
 describe("prohibition wording survives every restatement", () => {
   test("the block states it as a heading", () => {
     expect(prohibition).toBeDefined();

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,7 +331,7 @@ Never use bare `git push --force` or `git push -f` — without the lease, the pu
 
 **A stale check is not a reason to touch history.** If a check failed against a stale or superseded event rather than against the code, say so on the pull request. Do not merge or rebase unrelated base-branch changes into the branch just to trigger a fresh event: the task did not require those changes, and the resulting diff no longer describes what the pull request does.
 
-If a merge commit already landed on the branch, remove it instead of building on it — `git rebase --onto <base-tip> <merge-commit> <branch>` replays only the branch's own commits — then republish with `git push --force-with-lease`.
+If a merge commit already landed on the branch, remove it instead of building on it — `git rebase <base-tip> <branch>` replays the branch's own commits and drops the merge — then republish with `git push --force-with-lease`.
 
 > [!IMPORTANT]
 > Enforced in CI by the `contributing-check` action, which fails a pull request whose commits merge the base branch. Merge commits inherited from base history are not flagged.

--- a/claude-plugins/autopilot/skills/shared-rules/references/git-history-policy.md
+++ b/claude-plugins/autopilot/skills/shared-rules/references/git-history-policy.md
@@ -32,7 +32,7 @@ A push rejected as non-fast-forward is the same kind of condition. Report it; ne
 
 If a merge commit already exists on the branch, remove it rather than layering more history on top:
 
-- `git rebase --onto <base-tip> <merge-commit> <branch>` replays only the branch's own commits onto the current base tip; or
+- `git rebase <base-tip> <branch>` replays the branch's own commits onto the current base tip and drops the merge; or
 - reset to the fork point and cherry-pick the branch's commits back.
 
 Either way the branch is republished with `git push --force-with-lease`, and only when the branch is agent-owned.


### PR DESCRIPTION
The documented recovery for a branch that already carries a base-branch merge prescribed `git rebase --onto <base-tip> <merge-commit> <branch>` and claimed it replays only the branch's own commits. It does the opposite: `--onto` replays the range `<merge-commit>..<branch>`, so every commit made before the merge is an ancestor of the exclusion point and is silently dropped — a branch of `A, B, M(merge), C` recovers as `C` alone. Removing `--onto <merge-commit>` is the whole fix, and the surviving `git rebase <base-tip> <branch>` still names the branch explicitly, so it carries no new checkout precondition.

- Corrected the recipe in [CONTRIBUTING.md](https://github.com/awinogradov/code-assistants/blob/main/CONTRIBUTING.md#updating-pull-request-branches), which [contributing-sync](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/contributing-sync/action.yml) mirrors verbatim into downstream repositories
- Corrected the same recipe in [git-history-policy.md](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/shared-rules/references/git-history-policy.md), the canonical block autopilot skills load before rewriting history
- Added a case to [gitHistoryPolicy.test.ts](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/code-review-action/src/gitHistoryPolicy.test.ts) asserting both files carry the plain form and no `--onto` form; its positive half is what stops it passing vacuously if the section is renamed or moved
- Verified in scratch repositories on a branch of `A, B, M(merge main), C`: the `--onto` form yields `C` alone, while both `git rebase <base-tip>` and `git rebase <base-tip> <branch>` yield `A, B, C` with the merge dropped. The new guard case was also confirmed red when either old sentence is restored, then green again
- Reported by `fortune-reviewer[bot]` on the downstream sync pull request https://github.com/wefortis/fortune-os/pull/758#discussion_r3778825659
- `.repomix/pack.xml` still carries the old sentence twice; it is generated and refreshed by CI after merge, so it is deliberately not hand-edited here

---

**Release notes:**

- Corrected the documented recovery for a pull-request branch that already carries a base-branch merge: `git rebase <base-tip> <branch>` replaces the previous `--onto` form, which silently discarded every commit made before the merge
