### PR TITLE
Store the autopilot run plan on its source Linear ticket before implementation

### DIFF
--- a/.github/actions/code-review-action/src/linearPlanContract.test.ts
+++ b/.github/actions/code-review-action/src/linearPlanContract.test.ts
@@ -3,7 +3,7 @@
  * Linear issue's description, and `linear-run`, which executes a valid stored plan
  * verbatim or falls back to a run-local fresh plan when the artifact is unusable.
  *
- * Five properties are load-bearing, and each fails silently without a guard:
+ * Seven properties are load-bearing, and each fails silently without a guard:
  *
  * 1. The stored-plan section names `linear-run` reads match the ones `linear-plan` writes.
  *    This is the real rot: the two files have no import between them, so renaming a
@@ -23,6 +23,13 @@
  *    line; the `--experts-review` flag lives in those two skills and nowhere else, so
  *    the `run` family cannot quietly grow the skip — and a skipped store must stay
  *    visible, so `linear-plan` pins the `Score: skipped` stored-header variant.
+ * 7. `run` stores its finalized plan on the source Linear issue — for `linear-issue`
+ *    inputs only — by reference to `linear-plan`'s store, inside Phase 4 and before
+ *    implementation, and a failed write never blocks delivery. The reference link is
+ *    the sole guard for preserving the prior ticket description: `run` carries no
+ *    second emission template, so the write contract stays single-source in the
+ *    producer, and the reader keeps ignoring the `Stored by` attribution — the one
+ *    field the two producers differ on.
  *
  * The section names are extracted from the producer's own text rather than hardcoded,
  * so the guard tracks the source instead of a copy of it.
@@ -300,13 +307,72 @@ describe("linear plan contract", () => {
     }
   });
 
-  test("ordinary plan and run know nothing of the stored plan", () => {
+  test("ordinary plan and run-primed know nothing of the stored plan", () => {
     for (const [name, source] of [
       ["plan", plan],
-      ["run", run],
       ["run-primed", runPrimed],
     ] as const) {
       expect(`${name}: ${source.includes("## Implementation plan")}`).toBe(`${name}: false`);
     }
+  });
+
+  /**
+   * Issue #618: a `linear-issue` input to `run` persists the finalized plan onto the
+   * source ticket before implementation. The subsection below is extracted from `run`'s
+   * own text; an empty extraction fails the presence assertions rather than passing
+   * vacuously. Preservation of the prior ticket description is guarded solely by the
+   * reference link into `linear-plan`'s write contract — asserting it again against
+   * `run` would recreate the duplicated template these tests exist to prevent.
+   */
+  const runStore = run.split("### Persist the plan to Linear")[1]?.split("\n## ")[0] ?? "";
+
+  test("run gates the Linear store to linear-issue inputs", () => {
+    expect(runStore).toContain("`linear-issue`");
+  });
+
+  test("run stores inside Phase 4, after the blocks and before implementation", () => {
+    const storeIndex = run.indexOf("### Persist the plan to Linear");
+    const phase4Index = run.indexOf("## Phase 4");
+    const phase5Index = run.indexOf("## Phase 5");
+    expect(storeIndex).toBeGreaterThan(-1);
+    expect(phase4Index).toBeGreaterThan(-1);
+    expect(phase5Index).toBeGreaterThan(-1);
+    expect(storeIndex).toBeGreaterThan(phase4Index);
+    expect(storeIndex).toBeLessThan(phase5Index);
+  });
+
+  test("the store never gates delivery", () => {
+    expect(runStore).toContain("never gates delivery");
+    expect(runStore).toContain("the run continues");
+    // Phase 5's precondition must accept a loudly reported failure, not require the store.
+    expect(run).toContain("or its failure loudly reported");
+  });
+
+  test("run reuses linear-plan's store by reference, with no second template", () => {
+    expect(runStore).toContain("../linear-plan/SKILL.md#the-write");
+    expect(runStore).toContain("../linear-plan/SKILL.md#the-emission-template");
+    // run's delta prose names only the `Stored by` and `Score:` fields, so the
+    // template's other header tokens appearing anywhere in run means a copied template.
+    expect(run).not.toContain("Format: v1");
+    expect(run).not.toContain("· Base:");
+  });
+
+  test("run attributes its store and never claims the producer's identity", () => {
+    expect(runStore).toContain("`Stored by`");
+    expect(runStore).toContain("`/autopilot:run`");
+    expect(runStore).not.toContain("Stored by /autopilot:linear-plan");
+  });
+
+  test("run's store never records a skipped review", () => {
+    expect(runStore).toContain("never the literal `skipped`");
+  });
+
+  test("the reader ignores the attribution the two producers differ on", () => {
+    expect(linearRun).not.toContain("Stored by");
+  });
+
+  test("run never dispatches the producer or the reader", () => {
+    expect(run).not.toContain("Skill(autopilot:linear-plan)");
+    expect(run).not.toContain("Skill(autopilot:linear-run)");
   });
 });

--- a/claude-plugins/autopilot/README.md
+++ b/claude-plugins/autopilot/README.md
@@ -198,12 +198,13 @@ Perform deep analysis and create a validated implementation plan. Detects tech s
 
 ### `/autopilot:run`
 
-Plan and implement without a plan-approval pause, then select one of two terminal paths. A task whose verified plan explicitly requires no repository edits reports `Outcome: no_repository_change`; a repository change is committed, opened as a PR, and monitored for review approval. Uses the [codebase context snapshot](#codebase-context-snapshot). See [how the plan and run skills work](../../docs/05-plan-run-skills.md#how-run-differs-automated-post-implementation) for the terminal-path contract.
+Plan and implement without a plan-approval pause, then select one of two terminal paths. A task whose verified plan explicitly requires no repository edits reports `Outcome: no_repository_change`; a repository change is committed, opened as a PR, and monitored for review approval. A Linear-issue input additionally gets the finalized plan stored on its ticket before implementation — the same stored format `/autopilot:linear-plan` writes; see [the linear-plan skill](../../docs/16-linear-plan-skill.md). Uses the [codebase context snapshot](#codebase-context-snapshot). See [how the plan and run skills work](../../docs/05-plan-run-skills.md#how-run-differs-automated-post-implementation) for the terminal-path contract.
 
 ```bash
 /autopilot:run #42                                                      # From GitHub issue
 /autopilot:run 123                                                      # From GitHub issue number
 /autopilot:run https://github.com/org/repo/issues/789                   # From GitHub URL
+/autopilot:run ENG-123                                                  # From Linear issue (plan stored on the ticket)
 /autopilot:run "add user authentication"                                # From description
 /autopilot:run #42 I think we should start with the auth module         # Issue + additional context
 ```

--- a/claude-plugins/autopilot/skills/run/SKILL.md
+++ b/claude-plugins/autopilot/skills/run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run
-description: Plan and implement, then either report verified no repository change or deliver a PR
+description: Plan and implement, then either report verified no repository change or deliver a PR; a Linear-issue input also gets the finalized plan stored on its ticket before implementation
 argument-hint: "<task, GitHub/Linear issue (123, #123, ENG-123, or URL), or code-scanning alert (alert#N or URL)>"
 allowed-tools:
   - TaskCreate
@@ -23,6 +23,8 @@ allowed-tools:
   - Bash(command -v entire)
   - Bash(entire *)
   - MCP(repomix:*)
+  - MCP(linear:*)
+  - ToolSearch
   - AskUserQuestion
   - Skill(autopilot:gather-context)
   - Skill(autopilot:preflight-check)
@@ -209,9 +211,23 @@ PR: <pr-url>
 Status: <approved/merged>
 ```
 
+### Persist the plan to Linear
+
+Runs only when the detected input type is `linear-issue` (the type named by [input-detection.md](../plan/references/input-detection.md)'s detection table); every other input type skips this subsection and keeps its current behavior. It executes once both blocks above are embedded and before any step of [Phase 5](#phase-5-implement-and-proceed) runs, so the source ticket carries the finalized plan before implementation starts. This is chain work between tasks 5 and 6 — the task table stays as it is.
+
+The store is [`linear-plan`](../linear-plan/SKILL.md)'s, executed by reference rather than restated: fill [the emission template](../linear-plan/SKILL.md#the-emission-template) from the finalized plan file under [the stored plan format](../linear-plan/SKILL.md#the-stored-plan-format) and [Linear-safe markdown](../linear-plan/SKILL.md#linear-safe-markdown) rules, then perform [the write](../linear-plan/SKILL.md#the-write)'s read, anchor, preserved-prefix, write, and recovery steps. Resolve `get_issue` and `save_issue` per [`linear-mcp-access.md`](../shared-rules/references/linear-mcp-access.md). Three deltas, and only these:
+
+- The header's `Stored by` field reads `/autopilot:run`, so the ticket records which skill wrote the plan.
+- The header's `Score:` field carries this run's panel verdicts — the review is always-on for the `run` family, so it is never the literal `skipped`.
+- The write's title-refresh and board-transition steps do not run: this same session immediately executes the ticket, so the planned-and-ready hand-off signal belongs to the deliberate `linear-plan` path, and [`branch-create`](../branch-create/SKILL.md) moves the ticket to "In Progress" moments later via `--start`.
+
+When the plan is a no-repository-change candidate with no `## Pre-Implementation` section, the stored `### Pre-Implementation` states in one line that no branch is created because the plan requires no repository change.
+
+Re-running against the same ticket replaces the stored plan and never stacks a second wrapper — that idempotence is the write's anchor rule, inherited by reference. A failed, refused, or unavailable write — the preserved-prefix abort and an unresolvable Linear MCP included — is reported loudly with the full plan text emitted into the transcript, so the store is recoverable by hand; then the run continues. The store is an audit write and never gates delivery. No `Skill(...)` dispatch is involved: the update happens in place, in this session.
+
 ## Phase 5: Implement and proceed
 
-Once the plan file carries the applicable blocks, proceed straight through with no approval gate:
+Once the plan file carries the applicable blocks — and, for a `linear-issue` input, the plan is stored on the ticket or its failure loudly reported — proceed straight through with no approval gate:
 
 1. For a repository-delivery plan, create the branch per the **Mechanics** paragraph beside the matching block in [branch-blocks.md](../plan/references/branch-blocks.md), using the run variant where one is noted. The plan file's `## Pre-Implementation` states the outcome; that paragraph carries the invocation. For a no-repository-change candidate, defer this step.
 2. Implement every step in the plan, verifying each as you go.

--- a/docs/05-plan-run-skills.md
+++ b/docs/05-plan-run-skills.md
@@ -267,6 +267,8 @@ Sub-agents isolate work from the parent's context. Each returns a single schema-
 
 `run` shares Phases 0–3 and the pipeline with `plan`, but never stops for plan approval — invoking `/autopilot:run` is itself the authorization, so there is **no plan-approval gate**; run implements the moment the plan file is written. It then **replaces** the plan's `## Post-Implementation` section with a body for the selected terminal path and drives the decision from its own Phase 4 — the checks, steps, flags, and recovery rules stay in the skill, not in the plan file.
 
+**A Linear-issue input adds one pre-implementation step.** Once both blocks are embedded and before implementation starts, run stores the finalized plan on the source ticket, executing [`linear-plan`'s store contract](./16-linear-plan-skill.md#the-stored-plan-format) by reference — same format, same anchored idempotent write, prior description preserved — with the `Stored by` field naming `/autopilot:run`, no title refresh, and no "AI Ready" transition, since this same session immediately executes the ticket. The store is an audit write, never a gate: a failed write is loudly reported with the plan recoverable from the transcript, and the run continues. Every other input type skips the step.
+
 ```text
                     ┌───────────────────────────┐
                     │ Plan implemented and     │
@@ -297,7 +299,7 @@ Sub-agents isolate work from the parent's context. Each returns a single schema-
 - **Monitor** — `Skill(autopilot:pr-monitor)` polls CI and review status; on changes-requested it runs `pr-resolve` (auto "Address all") and loops until approval.
 - Direct `gh pr create` / `git commit` are forbidden in autopilot mode — everything routes through the sub-skills so format stays correct.
 
-There are two variants of this flow, each replacing a different half of it. [`/autopilot:run-primed`](./15-run-primed-skill.md) keeps every phase above and replaces only the context gather, reading a SHA-validated [explore brief](./14-explore-skill.md) instead of re-mapping the repository. [`/autopilot:linear-run`](./17-linear-run-skill.md) keeps terminal selection and replaces the draft-and-review half, executing a plan that [`/autopilot:linear-plan`](./16-linear-plan-skill.md) stored on a Linear issue earlier — possibly in another session, for another person to read first. Both variants inherit the same no-change checks and repository-delivery chain instead of copying them.
+There are two variants of this flow, each replacing a different half of it. [`/autopilot:run-primed`](./15-run-primed-skill.md) keeps every phase above and replaces only the context gather, reading a SHA-validated [explore brief](./14-explore-skill.md) instead of re-mapping the repository. [`/autopilot:linear-run`](./17-linear-run-skill.md) keeps terminal selection and replaces the draft-and-review half, executing a plan that [`/autopilot:linear-plan`](./16-linear-plan-skill.md) stored on a Linear issue earlier — possibly in another session, for another person to read first. Both variants inherit the same no-change checks and repository-delivery chain instead of copying them. The paths differ in who reads the plan before it runs: `run` on a Linear input stores the plan and executes it in the same breath, while `linear-plan` → `linear-run` puts a teammate between store and execution — pick the pair when the plan should be read on the ticket first.
 
 ## Where to look in the code
 

--- a/docs/16-linear-plan-skill.md
+++ b/docs/16-linear-plan-skill.md
@@ -65,11 +65,12 @@ Section names are the plan file's own, demoted from `##` to `###`, so mapping a 
 
 All five are written, because a human reading the ticket should see the whole plan. The two marked caller-owned are written but not for the reader to consume: a branch step and a post-implementation chain have to be produced in the checkout doing the work, not replayed from a description. Marking them is what lets the guard prove the reader ignores them.
 
-The three metadata fields each earn their place:
+The four metadata fields each earn their place:
 
 - **`Format: v1`** is what keeps "stored under an older template" separable from "corrupt". Without it, the first template revision would make every previously stored plan indistinguishable from a mangled description, and the reader would tell users to discard valid stored work.
 - **`Score:`** records what the plan actually achieved, so a later reader can weigh it.
 - **`Base:`** records the tree the plan was drafted against. It is information, not a gate — see [why drift does not block](./17-linear-run-skill.md#drift-is-reported-not-enforced).
+- **`Stored by`** names the producer. This chapter's deliberate path writes `/autopilot:linear-plan`; [`/autopilot:run` on a Linear-issue input](./05-plan-run-skills.md#how-run-differs-automated-post-implementation) writes the same format with `/autopilot:run` — same anchored write and preservation, but its `Score:` is never `skipped` (the run family's review is always-on), and it performs no title refresh and no "AI Ready" transition, because the same session immediately executes the ticket. The reader validates none of this field, so both producers' plans are equally executable.
 
 The annotated list above is the contract; what the store actually writes is a literal **emission template** the skill carries beside it — the exact stored block with `<angle-bracket>` placeholders for the score (or the literal `skipped`), the base SHA, and each section body. Only placeholders are filled; every other byte — anchor, header line, headings, order, blank-line layout — is emitted verbatim, and the `<- required` / `<- caller-owned` annotations never reach a ticket. That removes the failure mode where each store re-derives the markdown from prose and submits a structurally different description that the reader then rejects as unusable. The first-store `+++ Original task +++` cut is a literal emission form too — the same collapsible shape as `linear-create`'s original-prompt preamble, with the prior description inserted byte-identical and treated as opaque rather than rewritten into the canonical forms below.
 

--- a/docs/17-linear-run-skill.md
+++ b/docs/17-linear-run-skill.md
@@ -81,6 +81,8 @@ The same five verdicts remain, but they select a mode rather than deciding admis
 
 Every fresh-plan verdict is reported before the run continues. **The skill never invokes `linear-plan` and never overwrites the issue description.** The new plan is a run-local harness artifact, so an unusable stored plan stays visible while no longer blocking implementation.
 
+Validation reads no producer attribution: the header field naming which skill stored the plan is ignored, so a plan [`/autopilot:run` stored on its own Linear input](./05-plan-run-skills.md#how-run-differs-automated-post-implementation) validates as `stored plan` exactly like one from `linear-plan` — including on a ticket whose work has since been delivered. The `Base:` drift report below is what surfaces that plan's age; nothing marks it executed.
+
 ## Drift is reported, not enforced
 
 In stored-plan mode, the artifact records the tree it was drafted against in `Base:`. This skill compares that against the checkout's `origin/main`, reports any difference, and **proceeds**. Fresh-plan mode drafts against current context and needs no stored-artifact drift report.


### PR DESCRIPTION
A Linear-backed `/autopilot:run` now persists its finalized plan onto the source Linear issue before implementation starts, so the ticket stays the durable audit artifact while the same session continues through branch, commit, PR, and monitoring — no hand-off to another skill and no re-planning.

- [`run/SKILL.md`](https://github.com/awinogradov/code-assistants/blob/issue-618-run-stores-linear-plan/claude-plugins/autopilot/skills/run/SKILL.md) gains a "Persist the plan to Linear" step at the end of Phase 4, gated to `linear-issue` inputs, executing [`linear-plan`](https://github.com/awinogradov/code-assistants/blob/issue-618-run-stores-linear-plan/claude-plugins/autopilot/skills/linear-plan/SKILL.md)'s stored-format, emission-template, and anchored-write contract by reference, with the `Stored by` field reading `/autopilot:run`, no title refresh, and no "AI Ready" transition
- Re-running against the same ticket replaces the stored plan idempotently, and the prior description stays preserved byte-identical through the referenced write contract
- A failed, refused, or unavailable write is reported loudly with the plan recoverable from the transcript, and the run continues — the store never gates delivery
- [`linearPlanContract.test.ts`](https://github.com/awinogradov/code-assistants/blob/issue-618-run-stores-linear-plan/.github/actions/code-review-action/src/linearPlanContract.test.ts) pins the gating, the store-before-implementation ordering, single-source reuse (no second emission template in `run`), the attribution delta, and that the reader keeps ignoring attribution
- Docs chapters [05](https://github.com/awinogradov/code-assistants/blob/issue-618-run-stores-linear-plan/docs/05-plan-run-skills.md), [16](https://github.com/awinogradov/code-assistants/blob/issue-618-run-stores-linear-plan/docs/16-linear-plan-skill.md), and [17](https://github.com/awinogradov/code-assistants/blob/issue-618-run-stores-linear-plan/docs/17-linear-run-skill.md) and the plugin README document the second producer

---

**Release notes:**

- `/autopilot:run` with a Linear-issue input now stores the finalized plan on the source ticket before implementation, in the same stored format `/autopilot:linear-plan` writes

---

**Issues:**

Closes #618