### PR TITLE
Publish Autopilot as a versioned npm package

### DIFF
--- a/.github/actions/release-action/README.md
+++ b/.github/actions/release-action/README.md
@@ -78,25 +78,25 @@ jobs:
 
 ## Inputs
 
-| Input                  | Required | Default               | Description                                                                                                                               |
-| ---------------------- | -------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `mode`                 | yes      | —                     | `create` or `publish`.                                                                                                                    |
-| `bot_token`            | yes      | —                     | PAT or App installation token with `contents: write` + `pull-requests: write`. See [Permissions](#permissions).                           |
-| `bot_username`         | no       | `github-actions[bot]` | Git author/committer login for release commits, tags, and PRs. Pass `${{ vars.BOT_USERNAME }}`.                                           |
-| `npm_token`            | no       | —                     | NPM token. Required for `publish` with `lib-nodejs` or `lib-bun` release types.                                                           |
-| `anthropic_api_key`    | no       | —                     | Anthropic API key. When set, generates human-readable release-note summaries.                                                             |
-| `anthropic_base_url`   | no       | —                     | Custom Anthropic API base URL for a gateway/proxy/compatible endpoint (full URL with scheme). Unset uses the default `api.anthropic.com`. |
-| `anthropic_auth_token` | no       | —                     | Bearer token for a custom Anthropic host (`Authorization: Bearer`). Alternative to `anthropic_api_key` — set one, not both.               |
-| `model`                | no       | `claude-sonnet-4-6`   | Anthropic model for AI-generated release notes. Overrides the built-in default; leave unset to use it.                                    |
-| `name`                 | no       | —                     | Service or library name for PR titles (e.g. `Dialog Manager` → `Release Dialog Manager 1.2.0`).                                           |
-| `branch`               | no       | `release-{version}`   | Release branch template. `{version}` is substituted. `create` mode only.                                                                  |
-| `linear_api_key`       | no       | —                     | Linear API key for ticket integration.                                                                                                    |
-| `linear_keys`          | no       | —                     | Comma-separated Linear key prefixes (e.g. `TEAM,PROJ`).                                                                                   |
-| `jira_base_url`        | no       | —                     | Jira instance base URL (used with `jira_email` + `jira_api_token`).                                                                       |
-| `jira_email`           | no       | —                     | Jira authentication email.                                                                                                                |
-| `jira_api_token`       | no       | —                     | Jira API token.                                                                                                                           |
-| `jira_keys`            | no       | —                     | Comma-separated Jira key prefixes.                                                                                                        |
-| `slack_token`          | no       | —                     | Slack bot token. Required to post release notifications.                                                                                  |
+| Input                  | Required | Default               | Description                                                                                                                                                                                                         |
+| ---------------------- | -------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mode`                 | yes      | —                     | `create` or `publish`.                                                                                                                                                                                              |
+| `bot_token`            | yes      | —                     | PAT or App installation token with `contents: write` + `pull-requests: write`. See [Permissions](#permissions).                                                                                                     |
+| `bot_username`         | no       | `github-actions[bot]` | Git author/committer login for release commits, tags, and PRs. Pass `${{ vars.BOT_USERNAME }}`.                                                                                                                     |
+| `npm_token`            | no       | —                     | NPM token for the npm-publishing release types (`lib-nodejs`, `lib-bun`, non-private `claude-plugin` members). Optional when npm trusted publishing (OIDC) is configured and the workflow grants `id-token: write`. |
+| `anthropic_api_key`    | no       | —                     | Anthropic API key. When set, generates human-readable release-note summaries.                                                                                                                                       |
+| `anthropic_base_url`   | no       | —                     | Custom Anthropic API base URL for a gateway/proxy/compatible endpoint (full URL with scheme). Unset uses the default `api.anthropic.com`.                                                                           |
+| `anthropic_auth_token` | no       | —                     | Bearer token for a custom Anthropic host (`Authorization: Bearer`). Alternative to `anthropic_api_key` — set one, not both.                                                                                         |
+| `model`                | no       | `claude-sonnet-4-6`   | Anthropic model for AI-generated release notes. Overrides the built-in default; leave unset to use it.                                                                                                              |
+| `name`                 | no       | —                     | Service or library name for PR titles (e.g. `Dialog Manager` → `Release Dialog Manager 1.2.0`).                                                                                                                     |
+| `branch`               | no       | `release-{version}`   | Release branch template. `{version}` is substituted. `create` mode only.                                                                                                                                            |
+| `linear_api_key`       | no       | —                     | Linear API key for ticket integration.                                                                                                                                                                              |
+| `linear_keys`          | no       | —                     | Comma-separated Linear key prefixes (e.g. `TEAM,PROJ`).                                                                                                                                                             |
+| `jira_base_url`        | no       | —                     | Jira instance base URL (used with `jira_email` + `jira_api_token`).                                                                                                                                                 |
+| `jira_email`           | no       | —                     | Jira authentication email.                                                                                                                                                                                          |
+| `jira_api_token`       | no       | —                     | Jira API token.                                                                                                                                                                                                     |
+| `jira_keys`            | no       | —                     | Comma-separated Jira key prefixes.                                                                                                                                                                                  |
+| `slack_token`          | no       | —                     | Slack bot token. Required to post release notifications.                                                                                                                                                            |
 
 ## Custom Anthropic host
 
@@ -133,7 +133,9 @@ Release behavior is driven by the top-level `release` field in the consumer's `p
 | `service-nodejs` | `package.json`   | No          | Yes            | No                       |
 | `service-python` | `pyproject.toml` | No          | Yes            | No                       |
 | `github-action`  | `package.json`   | No          | Yes            | Yes                      |
-| `claude-plugin`  | `plugin.json`    | No          | Yes            | No                       |
+| `claude-plugin`  | `plugin.json`    | Opt-in      | Yes            | No                       |
+
+A `claude-plugin` monorepo member publishes to npm when its `package.json` is **not** `private`; private plugin members keep the historical skip. npm auth prefers trusted publishing (OIDC) — grant `id-token: write` to the publish workflow — with `npm_token` as the fallback.
 
 Minimal `package.json`:
 

--- a/.github/actions/release-action/action.yml
+++ b/.github/actions/release-action/action.yml
@@ -19,8 +19,11 @@ inputs:
     required: false
   npm_token:
     description: |
-      NPM token for publishing packages.
-      Required for publish mode with lib-nodejs or lib-bun release types.
+      NPM token for publishing packages. Used in publish mode by the
+      npm-publishing release types: lib-nodejs, lib-bun, and non-private
+      claude-plugin monorepo members. Optional when npm trusted publishing
+      (OIDC) is configured for the package and the workflow grants
+      `id-token: write`; required otherwise.
     required: false
   anthropic_api_key:
     description: |

--- a/.github/actions/release-action/src/monorepo/discoverMembers.test.ts
+++ b/.github/actions/release-action/src/monorepo/discoverMembers.test.ts
@@ -80,6 +80,30 @@ describe("discoverMembers", () => {
     });
   });
 
+  test("reads isPrivate from the member manifest", async () => {
+    await withTempDir(async (dir) => {
+      await writePkg(dir, {
+        name: "monorepo",
+        release: { members: ["packages/open", "packages/closed"] },
+      });
+      await mkdir(join(dir, "packages", "open"), { recursive: true });
+      await mkdir(join(dir, "packages", "closed"), { recursive: true });
+      await writePkg(join(dir, "packages", "open"), {
+        name: "@scope/open",
+        release: { type: "claude-plugin" },
+      });
+      await writePkg(join(dir, "packages", "closed"), {
+        name: "@scope/closed",
+        private: true,
+        release: { type: "claude-plugin" },
+      });
+
+      const result = await discoverMembers(dir);
+      expect(result.members.find((m) => m.name === "open")?.isPrivate).toBe(false);
+      expect(result.members.find((m) => m.name === "closed")?.isPrivate).toBe(true);
+    });
+  });
+
   test("expands workspaces globs and skips members without a release field", async () => {
     await withTempDir(async (dir) => {
       await writePkg(dir, {

--- a/.github/actions/release-action/src/monorepo/discoverMembers.ts
+++ b/.github/actions/release-action/src/monorepo/discoverMembers.ts
@@ -29,6 +29,11 @@ export interface Member {
   relPath: string;
   /** Release type declared on the member's `package.json`. */
   releaseType: ReleaseType;
+  /**
+   * Whether the member's `package.json` declares `"private": true`. A private
+   * `claude-plugin` member keeps the historical no-npm-publish behavior.
+   */
+  isPrivate: boolean;
   /** Optional Slack channel declared on the member's `package.json`. */
   slack?: string;
 }
@@ -127,6 +132,7 @@ async function buildMember(memberPath: string, cwd: string): Promise<Member | un
     path: absPath,
     relPath: relative(cwd, absPath),
     releaseType: config.type,
+    isPrivate: pkgRecord.private === true,
   };
   if (config.slack !== undefined) {
     member.slack = config.slack;

--- a/.github/actions/release-action/src/monorepo/runPublish.test.ts
+++ b/.github/actions/release-action/src/monorepo/runPublish.test.ts
@@ -28,6 +28,17 @@ async function setupMonorepo(dir: string): Promise<void> {
     name: "@scope/act",
     release: { type: "github-action" },
   });
+  await mkdir(join(dir, "packages", "plugin"), { recursive: true });
+  await mkdir(join(dir, "packages", "vendored"), { recursive: true });
+  await writeJson(join(dir, "packages", "plugin", "package.json"), {
+    name: "@scope/plugin",
+    release: { type: "claude-plugin" },
+  });
+  await writeJson(join(dir, "packages", "vendored", "package.json"), {
+    name: "@scope/vendored",
+    private: true,
+    release: { type: "claude-plugin" },
+  });
 }
 
 describe("resolvePublishPlan", () => {
@@ -56,6 +67,29 @@ describe("resolvePublishPlan", () => {
       expect(plan.member.name).toBe("act");
       expect(plan.versionTag).toBe("act@v2.5.1");
       expect(plan.majorTag).toBe("act@v2");
+      expect(plan.publishToNpm).toBe(false);
+    }));
+
+  test("publishes a non-private claude-plugin member to npm", () =>
+    withTempDir(async (dir) => {
+      await setupMonorepo(dir);
+      const plan = await resolvePublishPlan({
+        cwd: dir,
+        changedFiles: ["packages/plugin/.release_notes/3.0.0.md"],
+      });
+      expect(plan.member.name).toBe("plugin");
+      expect(plan.publishToNpm).toBe(true);
+      expect(plan.majorTag).toBeUndefined();
+    }));
+
+  test("keeps a private claude-plugin member off npm", () =>
+    withTempDir(async (dir) => {
+      await setupMonorepo(dir);
+      const plan = await resolvePublishPlan({
+        cwd: dir,
+        changedFiles: ["packages/vendored/.release_notes/3.0.0.md"],
+      });
+      expect(plan.member.name).toBe("vendored");
       expect(plan.publishToNpm).toBe(false);
     }));
 

--- a/.github/actions/release-action/src/monorepo/runPublish.ts
+++ b/.github/actions/release-action/src/monorepo/runPublish.ts
@@ -35,7 +35,10 @@ export interface PublishPlan {
   versionTag: string;
   /** `<name>@v<MAJOR>` floating tag, only set for `github-action` members. */
   majorTag?: string;
-  /** Whether the member opts into NPM publish (`lib-nodejs` / `lib-bun`). */
+  /**
+   * Whether the member opts into NPM publish: `lib-nodejs` / `lib-bun` always,
+   * and `claude-plugin` when its `package.json` is not `private`.
+   */
   publishToNpm: boolean;
   /** Slack channel from the member's `release.slack`, if any. */
   slackChannel?: string;
@@ -157,7 +160,10 @@ export async function resolvePublishPlan(options: ResolveMemberOptions): Promise
   }
 
   const { member, version } = resolved;
-  const publishToNpm = member.releaseType === "lib-nodejs" || member.releaseType === "lib-bun";
+  const publishToNpm =
+    member.releaseType === "lib-nodejs" ||
+    member.releaseType === "lib-bun" ||
+    (member.releaseType === "claude-plugin" && !member.isPrivate);
   const plan: PublishPlan = {
     member,
     version,

--- a/.github/actions/release-action/src/run.test.ts
+++ b/.github/actions/release-action/src/run.test.ts
@@ -7,7 +7,7 @@
  */
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 
-import { resolveBranchTemplate } from "./run.ts";
+import { resolveBranchTemplate, resolveNpmAuthMode } from "./run.ts";
 
 const originalBranch = process.env.INPUT_BRANCH;
 
@@ -78,5 +78,41 @@ describe("resolveBranchTemplate", () => {
     expect(template).toBe("release-{member}");
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain("::warning::");
+  });
+});
+
+describe("resolveNpmAuthMode", () => {
+  test("prefers the token when NPM_TOKEN is set", () => {
+    const mode = resolveNpmAuthMode({
+      npmToken: "npm_secret",
+      idTokenRequestUrl: undefined,
+      npmVersion: "10.0.0",
+    });
+    expect(mode).toBe("token");
+  });
+
+  test("selects OIDC when id-token is granted and npm supports trusted publishing", () => {
+    const mode = resolveNpmAuthMode({
+      npmToken: "",
+      idTokenRequestUrl: "https://token.actions.example",
+      npmVersion: "11.5.1",
+    });
+    expect(mode).toBe("oidc");
+  });
+
+  test("fails fast without a token when id-token was not granted", () => {
+    expect(() =>
+      resolveNpmAuthMode({ npmToken: "", idTokenRequestUrl: undefined, npmVersion: "11.6.0" }),
+    ).toThrow(/npm_token input, or configure npm trusted publishing/);
+  });
+
+  test("fails fast when the npm CLI predates trusted publishing", () => {
+    expect(() =>
+      resolveNpmAuthMode({
+        npmToken: "",
+        idTokenRequestUrl: "https://token.actions.example",
+        npmVersion: "11.4.2",
+      }),
+    ).toThrow(/requires >= 11\.5\.1/);
   });
 });

--- a/.github/actions/release-action/src/run.ts
+++ b/.github/actions/release-action/src/run.ts
@@ -16,6 +16,7 @@
 import { appendFile } from "node:fs/promises";
 
 import { $ } from "bun";
+import semver from "semver";
 
 import { discoverMembers } from "./monorepo/discoverMembers.ts";
 import { memberMajorTag, memberVersionTag } from "./monorepo/memberTags.ts";
@@ -173,6 +174,36 @@ async function runMonorepoCreate(cwd: string): Promise<void> {
   await writeGithubOutput(`released=${releasedNames.join(",")}`);
 }
 
+/** How the npm publish step authenticates against the registry. */
+export type NpmAuthMode = "token" | "oidc";
+
+/**
+ * Decide how `npm publish` authenticates, failing fast before any release side
+ * effect. A configured `NPM_TOKEN` wins. Without it the runner must support
+ * npm trusted publishing: the workflow granted `id-token: write` (visible as
+ * `ACTIONS_ID_TOKEN_REQUEST_URL`) and the npm CLI is >= 11.5.1 — otherwise an
+ * old npm would surface a confusing `ENEEDAUTH` mid-release instead of this
+ * error naming both auth paths.
+ */
+export function resolveNpmAuthMode(options: {
+  npmToken: string;
+  idTokenRequestUrl: string | undefined;
+  npmVersion: string;
+}): NpmAuthMode {
+  if (options.npmToken) return "token";
+  if (!options.idTokenRequestUrl) {
+    throw new Error(
+      "npm publish needs auth: set the npm_token input, or configure npm trusted publishing for the package and grant `id-token: write` to the publish workflow.",
+    );
+  }
+  if (!semver.gte(options.npmVersion, "11.5.1")) {
+    throw new Error(
+      `npm ${options.npmVersion} cannot use trusted publishing (requires >= 11.5.1): set the npm_token input or update the npm CLI on the runner.`,
+    );
+  }
+  return "oidc";
+}
+
 async function runMonorepoPublish(cwd: string): Promise<void> {
   const discovery = await discoverMembers(cwd);
   if (discovery.mode !== "monorepo") {
@@ -185,11 +216,23 @@ async function runMonorepoPublish(cwd: string): Promise<void> {
 
   if (plan.publishToNpm) {
     const npmToken = process.env.NPM_TOKEN ?? "";
+    let authMode: NpmAuthMode = "token";
     if (!npmToken) {
-      throw new Error("NPM_TOKEN required to publish lib-nodejs/lib-bun member");
+      const npmVersion = (await $`npm --version`.quiet()).stdout.toString().trim();
+      authMode = resolveNpmAuthMode({
+        npmToken,
+        idTokenRequestUrl: process.env.ACTIONS_ID_TOKEN_REQUEST_URL,
+        npmVersion,
+      });
     }
     await $`bun install`.cwd(plan.member.path).quiet();
-    await $`npm config set //registry.npmjs.org/:_authToken ${npmToken}`.quiet();
+    if (authMode === "token") {
+      await $`npm config set //registry.npmjs.org/:_authToken ${npmToken}`.quiet();
+    } else {
+      console.log(
+        "NPM_TOKEN unset — publishing via npm trusted publishing (OIDC); the registry generates provenance.",
+      );
+    }
     await $`npm publish`.cwd(plan.member.path);
   }
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,6 +8,17 @@
 #     `pull-requests: write`, used to read PR files and publish the release.
 #   - `BOT_USERNAME` (variable, optional): git author login for release tags and the
 #     GitHub Release. Defaults to `github-actions[bot]` when unset.
+#
+# npm publishing (lib-nodejs/lib-bun members and non-private claude-plugin
+# members) authenticates via npm trusted publishing (OIDC) — hence
+# `id-token: write` below — falling back to the `NPM_TOKEN` secret when the
+# release-action receives an `npm_token` input. One-time bootstrap for a new
+# package: create the npm scope/org, publish the first version with a granular
+# `NPM_TOKEN`, configure the trusted publisher for this workflow on npmjs.com,
+# then drop the token. The `id-token: write` grant is safe on this
+# pull_request_target workflow: the job checks out `github.sha` only (no
+# PR-controlled code runs), and the grant is inert in repositories where no
+# registry-side trusted publisher names this workflow.
 
 name: Release publish
 
@@ -23,6 +34,7 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     ".github/actions/agents-rules-sync": {
       "name": "@code-assistants/agents-rules-sync-action",
-      "version": "2.1.1",
+      "version": "3.0.0",
       "dependencies": {
         "@actions/core": "3.0.1",
         "@code-assistants/actions-core": "workspace:*",
@@ -36,7 +36,7 @@
     },
     ".github/actions/agents-skills-sync": {
       "name": "@code-assistants/agents-skills-sync-action",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@actions/core": "3.0.1",
         "@code-assistants/actions-core": "workspace:*",
@@ -65,7 +65,7 @@
     },
     ".github/actions/code-review-action": {
       "name": "@code-assistants/code-review-action",
-      "version": "5.1.0",
+      "version": "8.1.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.202",
         "@anthropic-ai/sdk": "0.110.0",
@@ -82,7 +82,7 @@
     },
     ".github/actions/code-review-cost-monitor": {
       "name": "@code-assistants/code-review-cost-monitor-action",
-      "version": "0.2.2",
+      "version": "1.1.0",
       "dependencies": {
         "@actions/core": "3.0.1",
         "@code-assistants/actions-core": "workspace:*",
@@ -96,7 +96,7 @@
     },
     ".github/actions/files-sync": {
       "name": "@code-assistants/files-sync-action",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@actions/core": "3.0.1",
         "@code-assistants/actions-core": "workspace:*",
@@ -174,8 +174,8 @@
       },
     },
     "claude-plugins/autopilot": {
-      "name": "autopilot",
-      "version": "4.2.2",
+      "name": "@code-assistants/autopilot",
+      "version": "7.1.2",
     },
     "packages/actions-core": {
       "name": "@code-assistants/actions-core",
@@ -233,6 +233,8 @@
     "@code-assistants/agents-skills-sync-action": ["@code-assistants/agents-skills-sync-action@workspace:.github/actions/agents-skills-sync"],
 
     "@code-assistants/auto-label-action": ["@code-assistants/auto-label-action@workspace:.github/actions/auto-label"],
+
+    "@code-assistants/autopilot": ["@code-assistants/autopilot@workspace:claude-plugins/autopilot"],
 
     "@code-assistants/code-review-action": ["@code-assistants/code-review-action@workspace:.github/actions/code-review-action"],
 
@@ -387,8 +389,6 @@
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
-
-    "autopilot": ["autopilot@workspace:claude-plugins/autopilot"],
 
     "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
 

--- a/claude-plugins/autopilot/.claude-plugin/marketplace.json
+++ b/claude-plugins/autopilot/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "code-assistants-autopilot",
+  "description": "Single-plugin marketplace shipped inside the @code-assistants/autopilot npm package, so the installed package directory can be added to Claude Code from its local path",
+  "owner": {
+    "name": "Tony Vi"
+  },
+  "plugins": [
+    {
+      "name": "autopilot",
+      "source": "./",
+      "description": "Autopilot: plan, implement, commit, PR, and monitor — skills and agents for AI-assisted development workflows"
+    }
+  ]
+}

--- a/claude-plugins/autopilot/LICENSE.md
+++ b/claude-plugins/autopilot/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2026 Tony Vi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/claude-plugins/autopilot/README.md
+++ b/claude-plugins/autopilot/README.md
@@ -38,6 +38,29 @@ Then install the plugin. Choose the scope that fits your workflow:
 /plugin install autopilot@code-assistants --scope local
 ```
 
+### From npm (version-pinned)
+
+The full plugin — `skills/`, `agents/`, `lib/`, `.claude-plugin/plugin.json`, and `.mcp.json` — ships as the public npm package `@code-assistants/autopilot`, so a consuming repository pins one immutable version in `package.json` and its lockfile records the resolved artifact with registry integrity. Per this repo's conventions, pin the exact version (no `^` or `~`):
+
+```bash
+npm install --save-exact @code-assistants/autopilot
+# or
+bun add --exact @code-assistants/autopilot
+```
+
+Dependabot and Renovate then propose upgrades through their normal dependency path — no more tracking a plugin version and a source commit SHA separately.
+
+The installed package directory is itself a single-plugin Claude Code marketplace (it ships its own `.claude-plugin/marketplace.json`), so register it from the local path — no writes to Claude's internal plugin cache:
+
+```bash
+/plugin marketplace add ./node_modules/@code-assistants/autopilot
+/plugin install autopilot@code-assistants-autopilot
+```
+
+Verified end-to-end with Claude Code 2.1.226 against the 7.1.2 artifact (`marketplace add` → `install` → plugin enabled); the pack-and-install contract is enforced continuously by [`lib/packContract.test.ts`](./lib/packContract.test.ts).
+
+npm is the dependency-managed distribution. The alternatives stay supported and unchanged: the GitHub marketplace above, [`agents-skills-sync`](../../.github/actions/agents-skills-sync/README.md) for file-sync consumers, and portable-skills copying per [RFC-0002](../../rfc/0002-portable-skills-layout.md).
+
 ### Local development
 
 ```bash

--- a/claude-plugins/autopilot/lib/packContract.test.ts
+++ b/claude-plugins/autopilot/lib/packContract.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Pack-contract and clean-install tests for the `@code-assistants/autopilot`
+ * npm artifact. The pack contract rejects both a missing runtime surface and
+ * unapproved content sneaking into the tarball; the clean install proves a
+ * consumer project receives the plugin manifest, marketplace manifest, skills,
+ * agents, and helper modules at the released version.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { $ } from "bun";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const memberDir = join(import.meta.dirname, "..");
+
+/** Paths every published artifact must carry (representative runtime surface). */
+const requiredPaths = [
+  "package.json",
+  "README.md",
+  "MIGRATING.md",
+  "CHANGELOG.md",
+  "LICENSE.md",
+  ".mcp.json",
+  ".claude-plugin/plugin.json",
+  ".claude-plugin/marketplace.json",
+  "skills/plan/SKILL.md",
+  "agents/expert-review.md",
+  "lib/git/branchDigest.ts",
+];
+
+/** First path segments allowed in the tarball (npm auto-packs the last two). */
+const allowedTopLevel = new Set([
+  "skills",
+  "agents",
+  "lib",
+  ".claude-plugin",
+  ".mcp.json",
+  "MIGRATING.md",
+  "CHANGELOG.md",
+  "LICENSE.md",
+  "package.json",
+  "README.md",
+]);
+
+interface PackReport {
+  filename: string;
+  version: string;
+  files: { path: string }[];
+}
+
+describe("npm artifact contract", () => {
+  let packDir: string;
+  let packedFiles: string[] = [];
+  let tarballPath = "";
+  let memberVersion = "";
+
+  beforeAll(async () => {
+    packDir = await mkdtemp(join(tmpdir(), "autopilot-pack-"));
+    memberVersion = (await Bun.file(join(memberDir, "version")).text()).trim();
+    const result = await $`npm pack --json --pack-destination ${packDir}`.cwd(memberDir).quiet();
+    const [report] = JSON.parse(result.stdout.toString()) as PackReport[];
+    if (!report) throw new Error("npm pack --json returned no report");
+    packedFiles = report.files.map((f) => f.path);
+    tarballPath = join(packDir, report.filename);
+  }, 120000);
+
+  afterAll(async () => {
+    await rm(packDir, { recursive: true, force: true });
+  });
+
+  test("ships the full runtime surface", () => {
+    const missing = requiredPaths.filter((p) => !packedFiles.includes(p));
+    expect(missing).toEqual([]);
+  });
+
+  test("ships nothing outside the approved surface", () => {
+    const unexpected = packedFiles.filter((p) => {
+      const [top] = p.split("/");
+      return top !== undefined && !allowedTopLevel.has(top);
+    });
+    expect(unexpected).toEqual([]);
+  });
+
+  test("keeps lib tests out of the artifact", () => {
+    const tests = packedFiles.filter((p) => p.startsWith("lib/") && p.endsWith(".test.ts"));
+    expect(tests).toEqual([]);
+  });
+
+  test(
+    "installs cleanly into an empty project at the released version",
+    async () => {
+      const projectDir = await mkdtemp(join(tmpdir(), "autopilot-install-"));
+      try {
+        await Bun.write(
+          join(projectDir, "package.json"),
+          `${JSON.stringify({ name: "consumer", private: true }, null, 2)}\n`,
+        );
+        await $`npm install ${tarballPath} --no-audit --no-fund --ignore-scripts`
+          .cwd(projectDir)
+          .quiet();
+
+        const installedDir = join(projectDir, "node_modules", "@code-assistants", "autopilot");
+        const plugin = (await Bun.file(join(installedDir, ".claude-plugin", "plugin.json")).json()) as {
+          version: string;
+        };
+        expect(plugin.version).toBe(memberVersion);
+
+        for (const required of requiredPaths) {
+          expect(await Bun.file(join(installedDir, required)).exists()).toBe(true);
+        }
+      } finally {
+        await rm(projectDir, { recursive: true, force: true });
+      }
+    },
+    120000,
+  );
+});

--- a/claude-plugins/autopilot/package.json
+++ b/claude-plugins/autopilot/package.json
@@ -1,9 +1,23 @@
 {
-  "name": "autopilot",
+  "name": "@code-assistants/autopilot",
   "description": "Autopilot: plan, implement, commit, PR, and monitor — skills and agents for AI-assisted development workflows",
-  "private": true,
   "type": "module",
   "license": "MIT",
+  "repository": "https://github.com/awinogradov/code-assistants",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "skills",
+    "agents",
+    "lib",
+    "!lib/**/*.test.ts",
+    ".claude-plugin",
+    ".mcp.json",
+    "MIGRATING.md",
+    "CHANGELOG.md",
+    "LICENSE.md"
+  ],
   "release": {
     "type": "claude-plugin"
   },

--- a/docs/06-release-field.md
+++ b/docs/06-release-field.md
@@ -67,9 +67,11 @@ At the **root** of a monorepo, `release.members` declares the workspace paths to
 | `service-nodejs` | `package.json`   | No          | Yes            | No                       | Internal Node services         |
 | `service-python` | `pyproject.toml` | No          | Yes            | No                       | Internal Python services       |
 | `github-action`  | `package.json`   | No          | Yes            | Yes                      | Composite or TypeScript Action |
-| `claude-plugin`  | `plugin.json`    | No          | Yes            | No                       | Claude Code plugins            |
+| `claude-plugin`  | `plugin.json`    | Opt-in      | Yes            | No                       | Claude Code plugins            |
 
 Any other value is treated as unrecognized and fails the action.
+
+**`claude-plugin` npm opt-in.** A `claude-plugin` monorepo member publishes to npm exactly when its `package.json` does **not** declare `"private": true` — dropping `private` (plus normal npm publication metadata: a scoped `name`, `files`, `publishConfig.access`) is the opt-in, so existing private plugins keep the historical no-npm behavior. npm auth prefers trusted publishing (OIDC): the publish workflow grants `id-token: write` and the npm CLI must be ≥ 11.5.1; the `npm_token` input is the fallback. A brand-new package needs a one-time token-based bootstrap publish before the registry-side trusted publisher can be configured.
 
 ## Consumers
 
@@ -127,13 +129,31 @@ The reference implementation is `packages/actions-core/src/releaseField.ts` (`re
 {
   "name": "autopilot",
   "version": "0.4.0",
+  "private": true,
   "release": {
     "type": "claude-plugin"
   }
 }
 ```
 
-Version source switches to `plugin.json`; npm publish is skipped; GitHub Release is created.
+Version source switches to `plugin.json`; npm publish is skipped (`private` member); GitHub Release is created.
+
+### Claude plugin published to npm
+
+```json
+{
+  "name": "@code-assistants/autopilot",
+  "version": "0.4.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "release": {
+    "type": "claude-plugin"
+  }
+}
+```
+
+Same as above, but the member is not `private`, so the publish step also runs `npm publish` — see the [`claude-plugin` npm opt-in](#recognized-type-values) note for auth and bootstrap.
 
 ### Monorepo root
 

--- a/scripts/validate-plugins.ts
+++ b/scripts/validate-plugins.ts
@@ -34,6 +34,7 @@ function classify(path: string): Target | null {
 async function discoverAll(): Promise<Target[]> {
   const patterns = [
     ".claude-plugin/marketplace.json",
+    "claude-plugins/*/.claude-plugin/marketplace.json",
     "claude-plugins/*/.claude-plugin/plugin.json",
     "claude-plugins/*/skills/*/SKILL.md",
     "claude-plugins/*/agents/*.md",
@@ -41,7 +42,9 @@ async function discoverAll(): Promise<Target[]> {
   const out: Target[] = [];
   for (const pattern of patterns) {
     const glob = new Glob(pattern);
-    for await (const path of glob.scan(".")) {
+    // dot: true — without it the scan silently skips the `.claude-plugin/`
+    // manifests, leaving them validated only in `--files` (lint-staged) mode.
+    for await (const path of glob.scan({ cwd: ".", dot: true })) {
       const t = classify(path);
       if (t) out.push(t);
     }
@@ -137,10 +140,42 @@ async function validateRulesSectionSync(): Promise<string | null> {
   return null;
 }
 
+/**
+ * Verify each claude-plugins/* member keeps its npm, Claude-plugin, and release
+ * version manifests in agreement (`package.json`, `.claude-plugin/plugin.json`,
+ * and the `version` file), and still declares `release.type` so the release
+ * pipeline keeps discovering it.
+ */
+async function validatePluginVersionSync(): Promise<string | null> {
+  for await (const pluginPath of new Glob("claude-plugins/*/.claude-plugin/plugin.json").scan({
+    cwd: ".",
+    dot: true,
+  })) {
+    const memberDir = pluginPath.slice(0, -"/.claude-plugin/plugin.json".length);
+    const pkgFile = Bun.file(`${memberDir}/package.json`);
+    if (!(await pkgFile.exists())) {
+      return `${memberDir}: missing package.json (required for the npm/release version invariant)`;
+    }
+    const pkg = (await pkgFile.json()) as { version?: string; release?: { type?: string } };
+    const plugin = (await Bun.file(pluginPath).json()) as { version?: string };
+    const versionFile = Bun.file(`${memberDir}/version`);
+    const fileVersion = (await versionFile.exists()) ? (await versionFile.text()).trim() : null;
+
+    if (typeof pkg.release?.type !== "string") {
+      return `${memberDir}/package.json: missing release.type — the member would silently drop out of the release pipeline`;
+    }
+    if (pkg.version !== plugin.version || plugin.version !== fileVersion) {
+      return `${memberDir}: version drift — package.json ${pkg.version ?? "missing"}, plugin.json ${plugin.version ?? "missing"}, version file ${fileVersion ?? "missing"}`;
+    }
+  }
+  return null;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   let targets: Target[] = [];
   let checkRules = true;
+  let checkVersions = true;
 
   const filesIdx = args.indexOf("--files");
   if (filesIdx !== -1) {
@@ -150,11 +185,12 @@ async function main() {
       if (t) targets.push(t);
     }
     checkRules = paths.some((p) => /^rules\/[^/]+\.md$/.test(p));
+    checkVersions = paths.some((p) => p.startsWith("claude-plugins/"));
   } else {
     targets = await discoverAll();
   }
 
-  if (targets.length === 0 && !checkRules) {
+  if (targets.length === 0 && !checkRules && !checkVersions) {
     console.log("validate-plugins: no plugin files to check");
     return;
   }
@@ -180,11 +216,23 @@ async function main() {
     }
   }
 
+  if (checkVersions) {
+    const err = await validatePluginVersionSync();
+    if (err) {
+      failed += 1;
+      console.error(`✖ claude-plugins/* versions\n    ${err}`);
+    } else {
+      console.log("✔ claude-plugins/* version manifests in agreement");
+    }
+  }
+
   if (failed > 0) {
     console.error(`\nvalidate-plugins: ${failed} file(s) failed validation`);
     process.exit(1);
   }
-  console.log(`\nvalidate-plugins: ${targets.length + (checkRules ? 1 : 0)} check(s) OK`);
+  console.log(
+    `\nvalidate-plugins: ${targets.length + (checkRules ? 1 : 0) + (checkVersions ? 1 : 0)} check(s) OK`,
+  );
 }
 
 main().catch((e) => {


### PR DESCRIPTION
Consumers can now pin the full Autopilot plugin — skills, agents, helper modules, plugin manifest, and MCP manifest — as the public npm package `@code-assistants/autopilot`, with the exact version in `package.json` and the lockfile carrying registry integrity, instead of tracking a plugin version plus a source commit SHA.

- Renamed [claude-plugins/autopilot/package.json](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/package.json) to `@code-assistants/autopilot`, dropped `private`, and added a `files` allowlist for the runtime surface (lib tests excluded); the artifact ships the portable skills layout verbatim per [RFC-0002](https://github.com/awinogradov/code-assistants/blob/main/rfc/0002-portable-skills-layout.md)
- The package bundles a single-plugin `.claude-plugin/marketplace.json`, making `/plugin marketplace add ./node_modules/@code-assistants/autopilot` a supported local install path with no writes to Claude's plugin cache — verified end-to-end with Claude Code 2.1.226
- [release-action](https://github.com/awinogradov/code-assistants/blob/main/.github/actions/release-action/README.md) now npm-publishes non-private `claude-plugin` monorepo members, preferring npm trusted publishing (OIDC) with `NPM_TOKEN` as fallback and failing fast (before any tag or GitHub Release) when neither is available
- [release-publish.yml](https://github.com/awinogradov/code-assistants/blob/main/.github/workflows/release-publish.yml) grants `id-token: write` and documents the one-time bootstrap: first publish via a granular token, then configure the registry-side trusted publisher
- `bun run validate` now fails on version drift between a plugin member's `package.json`, `plugin.json`, and `version` file, or on a missing `release.type`, and discovers the `.claude-plugin` manifests it previously skipped in full-scan mode
- A new pack-contract and clean-install test (`claude-plugins/autopilot/lib/packContract.test.ts`) polices the artifact surface, rejects unapproved content, and asserts the installed plugin version matches the release version file

---

**Release notes:**

- Autopilot now ships as the public npm package `@code-assistants/autopilot` — pin the exact version in `package.json` and lockfiles record registry integrity
- The npm package doubles as a local Claude Code marketplace, so the packaged plugin installs from `node_modules` without touching Claude's plugin cache
- release-action publishes non-private `claude-plugin` monorepo members to npm, preferring OIDC trusted publishing over long-lived tokens
- Repository validation now fails on version drift across a plugin's npm, Claude-plugin, and release manifests

---

**Issues:**

Closes #630
