### PR TITLE
TRIVIAL: Correct npm auth note in 7.2.0 release notes

### DIFF
--- a/claude-plugins/autopilot/.release_notes/7.2.0.md
+++ b/claude-plugins/autopilot/.release_notes/7.2.0.md
@@ -28,9 +28,9 @@ The existing GitHub-direct and `/plugin marketplace add` installation paths rema
 
 ## ⚙️ Configuration Required
 
-### OIDC Trusted Publishing (recommended) or npm Token
+### npm Token Required for Publishing
 
-The release pipeline publishes to npm using OIDC trusted publishing where available, falling back to a long-lived npm token. If your environment or fork needs to publish releases, configure OIDC trust between your CI provider and npm, or set an `NPM_TOKEN` secret. No change is needed for teams that only consume the package.
+The stock release-publish workflow authenticates to npm with an `NPM_TOKEN` repository secret — its `pull_request_target` trigger cannot obtain GitHub OIDC tokens, so trusted publishing does not engage there. If your environment or fork publishes releases, set `NPM_TOKEN`; the underlying release-action still supports OIDC trusted publishing when invoked from a workflow trigger that can mint OIDC tokens. No change is needed for teams that only consume the package.
 
 ## ⚠️ Breaking Changes
 


### PR DESCRIPTION
Corrects the npm auth section of the shipped 7.2.0 release notes: the stock release-publish workflow authenticates with `NPM_TOKEN` (its `pull_request_target` trigger cannot obtain GitHub OIDC tokens — see [community discussion #137761](https://github.com/orgs/community/discussions/137761)), not OIDC trusted publishing as originally written.

Merging this PR also re-fires the release-publish workflow for autopilot 7.2.0 — it touches `claude-plugins/autopilot/.release_notes/7.2.0.md`, which is how the publish workflow resolves the member and version. The original publish ([run 33078980085](https://github.com/awinogradov/code-assistants/actions/runs/33078980085)) failed before any side effects because the token pass-through was missing; with #635 merged and `NPM_TOKEN` configured, this merge should complete the npm publish, the `autopilot@v7.2.0` tag, and the GitHub Release.
