### PR TITLE
SECURITY: Patch js-yaml denial-of-service advisories in the pdf renderer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,25 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+
+  - package-ecosystem: "npm"
+    # The pdf-create renderer is the repository's only npm-managed manifest: a
+    # self-contained Node sub-project carrying its own package-lock.json,
+    # negated out of the Bun workspace. Nothing else here is npm — the root
+    # resolves through bun.lock, which would need `package-ecosystem: "bun"`
+    # (version updates only; Bun has no Dependabot security-update support),
+    # not this entry.
+    directory: "/claude-plugins/autopilot/skills/pdf-create/renderer"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"
+      timezone: "Asia/Dubai"
+    # One consolidated group -> a single weekly PR, as above.
+    groups:
+      pdf-create-renderer:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/claude-plugins/autopilot/skills/pdf-create/renderer/package-lock.json
+++ b/claude-plugins/autopilot/skills/pdf-create/renderer/package-lock.json
@@ -966,9 +966,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
Three open Dependabot alerts — two high, one medium — all point at js-yaml 3.14.2, pulled in transitively by gray-matter in the bundled pdf-create renderer. Its [lockfile](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/pdf-create/renderer/package-lock.json) now resolves 3.15.2, and [dependabot.yml](https://github.com/awinogradov/code-assistants/blob/main/.github/dependabot.yml) gains npm version-update coverage so that manifest stops drifting back.

- Lockfile only: 3.15.2 sits inside gray-matter's existing `^3.13.1` range, so [package.json](https://github.com/awinogradov/code-assistants/blob/main/claude-plugins/autopilot/skills/pdf-create/renderer/package.json) needs no edit
- All three advisories are quadratic-CPU denial of service in merge-key and `!!omap` resolution, first patched in 3.15.1
- Typed `fix(autopilot):` so the patch actually ships — consumers install the renderer from its lockfile on demand
- The npm entry targets only the renderer, the repository's one npm-managed manifest
- Root excluded: it resolves through [bun.lock](https://github.com/awinogradov/code-assistants/blob/main/bun.lock), which needs the separate `bun` ecosystem, and that has no Dependabot security-update support
- Verified by the renderer's 26 tests and by `npm ci` reporting 0 vulnerabilities

---

**Release notes:**

- Patched js-yaml to 3.15.2 in the bundled pdf-create renderer, clearing three denial-of-service advisories
- Dependabot now opens weekly version-update pull requests for the pdf-create renderer lockfile

---

**Alert:**

https://github.com/awinogradov/code-assistants/security/dependabot/8
https://github.com/awinogradov/code-assistants/security/dependabot/9
https://github.com/awinogradov/code-assistants/security/dependabot/10

https://claude.ai/code/session_01QYRewdHRi1XWbpAwFtuLQa
